### PR TITLE
Fix dev environment startup and k8s Nginx compatibility

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,9 +2,23 @@ version: '3.8'
 
 networks:
   synmetrix_default:
-    external: true
 
 services:
+  postgres:
+    image: postgres:${POSTGRES_VERSION}
+    container_name: synmetrix-postgres
+    restart: always
+    ports:
+      - 5432:5432
+    volumes:
+      - pgstorage-data:/var/lib/postgresql/data
+      - ./etc/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+    env_file:
+      - .env
+      - .dev.env
+    networks:
+      - synmetrix_default
+
   redis:
     image: redis:7.0.0
     restart: always
@@ -89,7 +103,8 @@ services:
       - ./services/hasura/metadata:/hasura/metadata
       - ./services/hasura/config.yaml:/hasura/config.yaml
     depends_on:
-      - hasura
+      hasura:
+        condition: service_healthy
     networks:
       - synmetrix_default
 
@@ -109,6 +124,7 @@ services:
       ENABLE_TELEMETRY: "false"
       CONSOLE_MODE: server
     depends_on:
+      - postgres
       - redis
     networks:
       - synmetrix_default
@@ -124,6 +140,9 @@ services:
     env_file:
       - .env
       - .dev.env
+    depends_on:
+      hasura_cli:
+        condition: service_healthy
     networks:
       - synmetrix_default
 
@@ -166,7 +185,7 @@ services:
         ENABLE_MINIO_PROXY: 'true'
         HASURA_GRAPHQL_ENDPOINT: /v1/graphql
         HASURA_WS_ENDPOINT: /v1/graphql
-        GRAPHQL_PLUS_SERVER_URL: 
+        GRAPHQL_PLUS_SERVER_URL:
         CUBEJS_MYSQL_API_URL: localhost:13306
         CUBEJS_PG_API_URL: localhost:15432
         CUBEJS_REST_API_URL: /api/v1/load
@@ -175,6 +194,11 @@ services:
     ports:
       - 80:8888
       - 9055:9055
+    environment:
+      NGINX_RESOLVER: "127.0.0.11"
+      ACTIONS_UPSTREAM: "actions:3000"
+      HASURA_UPSTREAM: "hasura:8080"
+      CUBEJS_UPSTREAM: "cubejs:4000"
     depends_on:
       - hasura
       - hasura_plus

--- a/etc/init-db.sql
+++ b/etc/init-db.sql
@@ -1,0 +1,4 @@
+-- Required extensions and schemas for hasura-backend-plus
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE SCHEMA IF NOT EXISTS auth;

--- a/scripts/containers/hasura-cli/start.sh
+++ b/scripts/containers/hasura-cli/start.sh
@@ -7,4 +7,9 @@ cd /hasura || {
 
 socat TCP-LISTEN:8080,fork TCP:hasura:8080 &
 
+echo "Applying migrations..."
+hasura-cli migrate apply --database-name default --endpoint http://hasura:8080 --admin-secret "$HASURA_GRAPHQL_ADMIN_SECRET" 2>&1
+echo "Applying metadata..."
+hasura-cli metadata apply --endpoint http://hasura:8080 --admin-secret "$HASURA_GRAPHQL_ADMIN_SECRET" 2>&1
+
 hasura-cli console --log-level DEBUG --address 0.0.0.0 --no-browser || exit 1

--- a/services/client/nginx/default.conf.template
+++ b/services/client/nginx/default.conf.template
@@ -1,8 +1,14 @@
+resolver $NGINX_RESOLVER valid=30s;
+
 server {
   listen 80;
 
+  set $upstream_actions $ACTIONS_UPSTREAM;
+  set $upstream_hasura $HASURA_UPSTREAM;
+  set $upstream_cubejs $CUBEJS_UPSTREAM;
+
   location ~ ^/auth {
-    proxy_pass http://synmetrix-actions:3000;
+    proxy_pass http://$upstream_actions;
   }
 
   location / {
@@ -24,7 +30,7 @@ server {
   }
 
   location ~ ^/v1 {
-    proxy_pass http://synmetrix-hasura:8080;
+    proxy_pass http://$upstream_hasura;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
@@ -32,14 +38,14 @@ server {
   }
 
   location ~ ^/v2 {
-    proxy_pass http://synmetrix-hasura:8080;
+    proxy_pass http://$upstream_hasura;
   }
 
   location ~ ^/console {
-    proxy_pass http://synmetrix-hasura:8080;
+    proxy_pass http://$upstream_hasura;
   }
 
   location ~ ^/api/v1 {
-   proxy_pass http://synmetrix-cubejs:4000;
+   proxy_pass http://$upstream_cubejs;
   }
 }


### PR DESCRIPTION
## Summary

- **Add Postgres to docker-compose.dev.yml** — was a standalone container, not reproducible from scratch
- **Add `etc/init-db.sql`** — creates `auth` schema + `citext`/`pgcrypto` extensions on fresh DB init (required by hasura-backend-plus)
- **Fix hasura_cli `start.sh`** — applies migrations + metadata before starting console (hasura_plus depends on Hasura-created functions)
- **Fix startup dependency chain**: `postgres` → `hasura` (healthy) → `hasura_cli` (healthy) → `hasura_plus`
- **Make Nginx upstreams configurable** via env vars (`ACTIONS_UPSTREAM`, `HASURA_UPSTREAM`, `CUBEJS_UPSTREAM`) for k8s compatibility — Docker Compose uses bare service names, k8s uses `synmetrix-*` prefixed service names

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml down -v && docker compose -f docker-compose.dev.yml up -d` — all services start from scratch
- [ ] hasura_plus comes up healthy without manual intervention
- [ ] Client Nginx starts without DNS resolution errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)