### PR TITLE
Fix team_role type in provision mutation

### DIFF
--- a/services/actions/src/auth/provision.js
+++ b/services/actions/src/auth/provision.js
@@ -160,7 +160,7 @@ async function createMember(userId, teamId) {
 
 async function createMemberRole(memberId, teamRole) {
   const mutation = `
-    mutation CreateMemberRole($member_id: uuid!, $team_role: String!) {
+    mutation CreateMemberRole($member_id: uuid!, $team_role: team_roles_enum!) {
       insert_member_roles_one(object: { member_id: $member_id, team_role: $team_role }) {
         id
       }


### PR DESCRIPTION
## Summary
- Fix GraphQL mutation type for `team_role` parameter from `String!` to `team_roles_enum!` in `provision.js`
- Matches the Hasura schema enum type, preventing type mismatch errors during user provisioning

## Test plan
- [ ] Verify new user sign-up via WorkOS creates team membership correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)