### PR TITLE
Fix WorkOS migration: handle duplicate team names

### DIFF
--- a/services/hasura/migrations/1709836800000_add_workos_user_id_and_team_name_unique/up.sql
+++ b/services/hasura/migrations/1709836800000_add_workos_user_id_and_team_name_unique/up.sql
@@ -1,5 +1,28 @@
 ALTER TABLE auth.accounts ADD COLUMN IF NOT EXISTS workos_user_id text;
-ALTER TABLE auth.accounts ADD CONSTRAINT accounts_workos_user_id_unique UNIQUE (workos_user_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'accounts_workos_user_id_unique') THEN
+    ALTER TABLE auth.accounts ADD CONSTRAINT accounts_workos_user_id_unique UNIQUE (workos_user_id);
+  END IF;
+END $$;
+
+-- Deduplicate team names before adding unique constraint:
+-- append user_id suffix to duplicates, keeping the oldest row unchanged
+UPDATE public.teams t
+SET name = t.name || '-' || LEFT(t.user_id::text, 8)
+WHERE t.id IN (
+  SELECT id FROM (
+    SELECT id, ROW_NUMBER() OVER (PARTITION BY name ORDER BY created_at ASC) AS rn
+    FROM public.teams
+  ) sub WHERE sub.rn > 1
+);
 
 ALTER TABLE public.teams DROP CONSTRAINT IF EXISTS teams_user_id_name_key;
-ALTER TABLE public.teams ADD CONSTRAINT teams_name_unique UNIQUE (name);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'teams_name_unique') THEN
+    ALTER TABLE public.teams ADD CONSTRAINT teams_name_unique UNIQUE (name);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- The `1709836800000_add_workos_user_id_and_team_name_unique` migration fails on the dev cluster because duplicate "Default team" entries exist in the `teams` table
- This blocks the `workos_user_id` column from being added to `auth_accounts`, which breaks WorkOS login (`field 'workos_user_id' not found`)
- Fix: deduplicate team names by appending user_id suffix before adding the unique constraint
- Make constraints idempotent with `IF NOT EXISTS` checks for safe re-runs

## Test plan
- [ ] Migration applies successfully on dev cluster
- [ ] `workos_user_id` column exists on `auth.accounts`
- [ ] WorkOS login flow completes (`/auth/signin` → WorkOS → `/auth/callback` → session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)