### PR TITLE
005: Search, datasource count for list_all_teams

### DIFF
--- a/services/actions/src/rpc/listAllTeams.js
+++ b/services/actions/src/rpc/listAllTeams.js
@@ -3,8 +3,8 @@ import { fetchGraphQL } from "../utils/graphql.js";
 import { isPortalAdmin } from "../utils/portalAdmin.js";
 
 const teamsQuery = `
-  query ListAllTeams($limit: Int, $offset: Int) {
-    teams(limit: $limit, offset: $offset, order_by: { created_at: desc }) {
+  query ListAllTeams($limit: Int, $offset: Int, $where: teams_bool_exp) {
+    teams(limit: $limit, offset: $offset, where: $where, order_by: { created_at: desc }) {
       id
       name
       settings
@@ -14,8 +14,13 @@ const teamsQuery = `
           count
         }
       }
+      datasources_aggregate {
+        aggregate {
+          count
+        }
+      }
     }
-    teams_aggregate {
+    teams_aggregate(where: $where) {
       aggregate {
         count
       }
@@ -32,15 +37,20 @@ export default async (session, input) => {
       return { teams: [], total: 0 };
     }
 
-    const { limit = 50, offset = 0 } = input || {};
+    const { limit = 50, offset = 0, search } = input || {};
 
-    const res = await fetchGraphQL(teamsQuery, { limit, offset });
+    const where = search
+      ? { name: { _ilike: `%${search}%` } }
+      : {};
+
+    const res = await fetchGraphQL(teamsQuery, { limit, offset, where });
 
     const teams = (res?.data?.teams || []).map((t) => ({
       id: t.id,
       name: t.name,
       settings: t.settings,
       member_count: t.members_aggregate?.aggregate?.count || 0,
+      datasource_count: t.datasources_aggregate?.aggregate?.count || 0,
       created_at: t.created_at,
     }));
 

--- a/services/hasura/metadata/actions.graphql
+++ b/services/hasura/metadata/actions.graphql
@@ -274,6 +274,7 @@ type Mutation {
   list_all_teams(
     limit: Int
     offset: Int
+    search: String
   ): ListAllTeamsOutput
 }
 
@@ -313,6 +314,7 @@ type TeamInfo {
   name: String!
   settings: jsonb
   member_count: Int!
+  datasource_count: Int!
   created_at: String!
 }
 


### PR DESCRIPTION
## Summary
- Add `search` parameter to `list_all_teams` action for name filtering (case-insensitive `_ilike`)
- Add `datasource_count` to `TeamInfo` output type
- Backend queries `datasources_aggregate` alongside `members_aggregate`

## Test plan
- [ ] Call `list_all_teams` with `search: "test"` — should filter teams by name
- [ ] Call without search — should return all teams as before
- [ ] Verify `datasource_count` is returned for each team

🤖 Generated with [Claude Code](https://claude.com/claude-code)