### PR TITLE
Fix sliding auth session cookie refresh

### DIFF
--- a/services/actions/src/auth/callback.js
+++ b/services/actions/src/auth/callback.js
@@ -2,6 +2,7 @@ import * as jose from "jose";
 
 import { workos } from "../utils/workos.js";
 import { createSession } from "../utils/session.js";
+import { getSessionCookieOptions } from "../utils/sessionCookie.js";
 import { provisionUser } from "./provision.js";
 import generateUserAccessToken from "../utils/jwt.js";
 import logger from "../utils/logger.js";
@@ -98,14 +99,7 @@ export default async function callbackHandler(req, res) {
     const appUrl = process.env.APP_FRONTEND_URL || process.env.APP_URL || "http://localhost:8000";
 
     // Set session cookie
-    const isSecure = appUrl.startsWith("https://") || process.env.NODE_ENV === "production";
-    res.cookie("session", sessionId, {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: "lax",
-      maxAge: 86400000, // 24 hours in ms
-      path: "/",
-    });
+    res.cookie("session", sessionId, getSessionCookieOptions(req));
     let redirectTo = `${appUrl}/explore`;
     if (state) {
       try {

--- a/services/actions/src/auth/token.js
+++ b/services/actions/src/auth/token.js
@@ -2,6 +2,7 @@ import * as jose from "jose";
 
 import { workos } from "../utils/workos.js";
 import { getSession, updateSession, extendSession } from "../utils/session.js";
+import { getSessionCookieOptions } from "../utils/sessionCookie.js";
 import generateUserAccessToken from "../utils/jwt.js";
 import logger from "../utils/logger.js";
 
@@ -33,6 +34,7 @@ export default async function tokenHandler(req, res) {
     const session = await getSession(sessionId);
 
     if (!session) {
+      res.clearCookie("session", { path: "/" });
       return res.status(401).json({
         error: true,
         code: "unauthorized",
@@ -44,6 +46,9 @@ export default async function tokenHandler(req, res) {
     extendSession(sessionId).catch((err) =>
       logger.error("[Token] Failed to extend session TTL:", err)
     );
+
+    // Keep the browser cookie sliding in lockstep with the Redis session TTL.
+    res.cookie("session", sessionId, getSessionCookieOptions(req));
 
     // Check if WorkOS access token needs refresh
     if (

--- a/services/actions/src/utils/sessionCookie.js
+++ b/services/actions/src/utils/sessionCookie.js
@@ -1,0 +1,30 @@
+const SESSION_COOKIE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function isHttpsRequest(req) {
+  if (req.secure) return true;
+
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  if (typeof forwardedProto === "string") {
+    return forwardedProto.split(",")[0].trim() === "https";
+  }
+
+  return false;
+}
+
+export function getSessionCookieOptions(req) {
+  const appUrl = process.env.APP_FRONTEND_URL || process.env.APP_URL || "";
+  const secure =
+    process.env.SESSION_COOKIE_SECURE === "true" ||
+    isHttpsRequest(req) ||
+    appUrl.startsWith("https://");
+
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: "lax",
+    maxAge: SESSION_COOKIE_MAX_AGE_MS,
+    path: "/",
+  };
+}
+
+export { SESSION_COOKIE_MAX_AGE_MS };


### PR DESCRIPTION
## Summary
- keep the browser session cookie sliding in sync with the Redis session TTL
- centralize session cookie option calculation so callback and token refresh use the same policy
- derive the cookie secure flag from the actual request/proxy/frontend URL instead of a bare NODE_ENV check

## Verification
- node --check services/actions/src/auth/callback.js
- node --check services/actions/src/auth/token.js
- node --check services/actions/src/utils/sessionCookie.js

## Notes
- This is the backend half of the session-drop investigation.
- Companion frontend PR: smartdataHQ/client-v2#9