### PR TITLE
006: Model authoring improvements with single-pass smart generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,8 @@ These are the target patterns for adapting Synmetrix and client-v2:
 - PostgreSQL via Hasura (versions, dataschemas, team settings), ClickHouse (profiling target — read-only) (004-dynamic-model-creation)
 - JavaScript (ES modules), Node.js 18+ + Cube.js v1.6.x (CubeJS), Express 4.x (Actions), Hasura v2 (GraphQL), React 18 + Vite + Ant Design 5 (client-v2), URQL (GraphQL client), Zustand (state) (005-simple-access-controls)
 - PostgreSQL (via Hasura), Redis (sessions), CubeStore (query cache) (005-simple-access-controls)
+- TypeScript (client-v2, React 18 + Vite 4), JavaScript ES modules (CubeJS service, Node.js 18+) + Monaco Editor (existing), `yaml` ^2.3.4 (existing in CubeJS, add to client-v2), `@cubejs-backend/schema-compiler` ^1.6.19 (existing in CubeJS), Ant Design 5 (existing in client-v2), URQL (existing GraphQL client) (006-model-authoring)
+- N/A (schema spec is static; cube registry is in-memory from FetchMeta) (006-model-authoring)
 
 ## Recent Changes
 - 001-dev-environment: Added TypeScript (ES2022, Node16 modules) — matches + oclif (CLI framework), zx (shell execution)

--- a/services/actions/src/auth/callback.js
+++ b/services/actions/src/auth/callback.js
@@ -2,6 +2,7 @@ import * as jose from "jose";
 
 import { workos } from "../utils/workos.js";
 import { createSession } from "../utils/session.js";
+import { getSessionCookieOptions } from "../utils/sessionCookie.js";
 import { provisionUser } from "./provision.js";
 import generateUserAccessToken from "../utils/jwt.js";
 import logger from "../utils/logger.js";
@@ -98,14 +99,7 @@ export default async function callbackHandler(req, res) {
     const appUrl = process.env.APP_FRONTEND_URL || process.env.APP_URL || "http://localhost:8000";
 
     // Set session cookie
-    const isSecure = appUrl.startsWith("https://") || process.env.NODE_ENV === "production";
-    res.cookie("session", sessionId, {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: "lax",
-      maxAge: 86400000, // 24 hours in ms
-      path: "/",
-    });
+    res.cookie("session", sessionId, getSessionCookieOptions(req));
     let redirectTo = `${appUrl}/explore`;
     if (state) {
       try {

--- a/services/actions/src/auth/token.js
+++ b/services/actions/src/auth/token.js
@@ -2,6 +2,7 @@ import * as jose from "jose";
 
 import { workos } from "../utils/workos.js";
 import { getSession, updateSession, extendSession } from "../utils/session.js";
+import { getSessionCookieOptions } from "../utils/sessionCookie.js";
 import generateUserAccessToken from "../utils/jwt.js";
 import logger from "../utils/logger.js";
 
@@ -33,6 +34,7 @@ export default async function tokenHandler(req, res) {
     const session = await getSession(sessionId);
 
     if (!session) {
+      res.clearCookie("session", { path: "/" });
       return res.status(401).json({
         error: true,
         code: "unauthorized",
@@ -44,6 +46,9 @@ export default async function tokenHandler(req, res) {
     extendSession(sessionId).catch((err) =>
       logger.error("[Token] Failed to extend session TTL:", err)
     );
+
+    // Keep the browser cookie sliding in lockstep with the Redis session TTL.
+    res.cookie("session", sessionId, getSessionCookieOptions(req));
 
     // Check if WorkOS access token needs refresh
     if (

--- a/services/actions/src/rpc/smartGenSchemas.js
+++ b/services/actions/src/rpc/smartGenSchemas.js
@@ -10,6 +10,8 @@ export default async (session, input, headers) => {
     array_join_columns: arrayJoinColumns,
     max_map_keys: maxMapKeys,
     merge_strategy: mergeStrategy,
+    profile_data: profileData,
+    dry_run: dryRun,
   } = input || {};
 
   const userId = session?.["x-hasura-user-id"];
@@ -28,6 +30,8 @@ export default async (session, input, headers) => {
       arrayJoinColumns,
       maxMapKeys,
       mergeStrategy,
+      profileData,
+      dryRun,
     });
 
     return result;

--- a/services/actions/src/utils/sessionCookie.js
+++ b/services/actions/src/utils/sessionCookie.js
@@ -1,0 +1,30 @@
+const SESSION_COOKIE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+function isHttpsRequest(req) {
+  if (req.secure) return true;
+
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  if (typeof forwardedProto === "string") {
+    return forwardedProto.split(",")[0].trim() === "https";
+  }
+
+  return false;
+}
+
+export function getSessionCookieOptions(req) {
+  const appUrl = process.env.APP_FRONTEND_URL || process.env.APP_URL || "";
+  const secure =
+    process.env.SESSION_COOKIE_SECURE === "true" ||
+    isHttpsRequest(req) ||
+    appUrl.startsWith("https://");
+
+  return {
+    httpOnly: true,
+    secure,
+    sameSite: "lax",
+    maxAge: SESSION_COOKIE_MAX_AGE_MS,
+    path: "/",
+  };
+}
+
+export { SESSION_COOKIE_MAX_AGE_MS };

--- a/services/cubejs/src/routes/index.js
+++ b/services/cubejs/src/routes/index.js
@@ -11,6 +11,8 @@ import profileTable from "./profileTable.js";
 import runSql from "./runSql.js";
 import smartGenerate from "./smartGenerate.js";
 import testConnection from "./testConnection.js";
+import validate from "./validate.js";
+import version from "./version.js";
 
 const router = express.Router();
 
@@ -71,6 +73,18 @@ export default ({ basePath, cubejs }) => {
     `${basePath}/v1/smart-generate`,
     checkAuthMiddleware,
     async (req, res) => smartGenerate(req, res, cubejs)
+  );
+
+  router.post(
+    `${basePath}/v1/validate`,
+    checkAuthMiddleware,
+    async (req, res) => validate(req, res)
+  );
+
+  router.get(
+    `${basePath}/v1/version`,
+    checkAuthMiddleware,
+    (req, res) => version(req, res)
   );
 
   return router;

--- a/services/cubejs/src/routes/index.js
+++ b/services/cubejs/src/routes/index.js
@@ -81,11 +81,8 @@ export default ({ basePath, cubejs }) => {
     async (req, res) => validate(req, res)
   );
 
-  router.get(
-    `${basePath}/v1/version`,
-    checkAuthMiddleware,
-    (req, res) => version(req, res)
-  );
+  // Version endpoint is public — returns only the schema-compiler version string
+  router.get(`${basePath}/v1/version`, (req, res) => version(req, res));
 
   return router;
 };

--- a/services/cubejs/src/routes/profileTable.js
+++ b/services/cubejs/src/routes/profileTable.js
@@ -4,6 +4,7 @@ import { findDataSchemas } from '../utils/dataSourceHelpers.js';
 import { profileTable } from '../utils/smart-generation/profiler.js';
 import { detectPrimaryKeys } from '../utils/smart-generation/primaryKeyDetector.js';
 import { createProgressEmitter } from '../utils/smart-generation/progressEmitter.js';
+import { serializeProfile } from '../utils/smart-generation/profileSerializer.js';
 import { ColumnType } from '../utils/smart-generation/typeParser.js';
 
 /**
@@ -145,6 +146,10 @@ export default async (req, res, cubejs) => {
       });
     }
 
+    // Serialize the full profile data so the frontend can pass it back to
+    // smart_gen_dataschemas — avoids re-profiling ClickHouse a second time.
+    const rawProfile = serializeProfile(profiledTable, primaryKeys);
+
     const payload = {
       code: 'ok',
       database: schema,
@@ -157,6 +162,7 @@ export default async (req, res, cubejs) => {
       primary_keys: primaryKeys,
       existing_model: existingModel,
       array_candidates: arrayCandidates,
+      raw_profile: rawProfile,
     };
 
     emitter.complete(payload);

--- a/services/cubejs/src/routes/smartGenerate.js
+++ b/services/cubejs/src/routes/smartGenerate.js
@@ -9,6 +9,8 @@ import { buildCubes } from '../utils/smart-generation/cubeBuilder.js';
 import { generateJs, generateFileName } from '../utils/smart-generation/yamlGenerator.js';
 import { createProgressEmitter } from '../utils/smart-generation/progressEmitter.js';
 import { mergeModels } from '../utils/smart-generation/merger.js';
+import { deserializeProfile } from '../utils/smart-generation/profileSerializer.js';
+import { diffModels } from '../utils/smart-generation/diffModels.js';
 
 export default async (req, res, cubejs) => {
   const { securityContext } = req;
@@ -19,11 +21,17 @@ export default async (req, res, cubejs) => {
     arrayJoinColumns: rawArrayJoinColumns,
     maxMapKeys: rawMaxMapKeys,
     mergeStrategy = 'auto',
+    profileData: rawProfileData,
+    dryRun: rawDryRun,
   } = req.body;
 
   // Hasura sends {} instead of null for optional fields — normalize
   const arrayJoinColumns = Array.isArray(rawArrayJoinColumns) ? rawArrayJoinColumns : [];
   const maxMapKeys = typeof rawMaxMapKeys === 'number' ? rawMaxMapKeys : 500;
+  const profileData = (rawProfileData && typeof rawProfileData === 'object' && rawProfileData.profiledTable)
+    ? rawProfileData
+    : null;
+  const dryRun = rawDryRun === true;
 
   if (!table || !schema || !branchId) {
     return res.status(400).json({
@@ -39,23 +47,33 @@ export default async (req, res, cubejs) => {
     const partition = securityContext.userScope?.dataSource?.partition || null;
     const internalTables = securityContext.userScope?.dataSource?.internalTables || [];
 
-    driver = await cubejs.options.driverFactory({ securityContext });
-
     const emitter = createProgressEmitter(res, req.headers.accept);
 
-    // Step 1: Profile the table
-    emitter.emit('profile', 'Profiling table...', 0.05);
-    const profiledTable = await profileTable(driver, schema, table, {
-      partition,
-      internalTables,
-      emitter,
-    });
+    let profiledTable;
+    let primaryKeys;
 
-    // Step 2: Detect primary keys
-    emitter.emit('primary_keys', 'Detecting primary keys...', 0.5);
-    const primaryKeys = await detectPrimaryKeys(driver, schema, table);
+    if (profileData) {
+      // Use cached profile data from the profile_table step — no ClickHouse queries
+      emitter.emit('building', 'Using cached profile...', 0.5);
+      const deserialized = deserializeProfile(profileData);
+      profiledTable = deserialized.profiledTable;
+      primaryKeys = deserialized.primaryKeys;
+    } else {
+      // Legacy path: profile from scratch (two ClickHouse round-trips)
+      driver = await cubejs.options.driverFactory({ securityContext });
 
-    // Step 3: Build cubes
+      emitter.emit('profile', 'Profiling table...', 0.05);
+      profiledTable = await profileTable(driver, schema, table, {
+        partition,
+        internalTables,
+        emitter,
+      });
+
+      emitter.emit('primary_keys', 'Detecting primary keys...', 0.5);
+      primaryKeys = await detectPrimaryKeys(driver, schema, table);
+    }
+
+    // Build cubes
     emitter.emit('building', 'Building cube definitions...', 0.6);
     const cubeResult = buildCubes(profiledTable, {
       partition,
@@ -65,26 +83,51 @@ export default async (req, res, cubejs) => {
       primaryKeys,
     });
 
-    // Step 4: Generate JS model (JS is a superset of YAML — supports
-    // FILTER_PARAMS callbacks, asyncModule, COMPILE_CONTEXT, extends)
+    // Generate JS model
     emitter.emit('generating', 'Generating JS model...', 0.7);
     const yamlContent = generateJs(cubeResult.cubes);
     const fileName = generateFileName(table, true);
 
-    // Step 5: Fetch existing schemas
+    // Fetch existing schemas
     emitter.emit('versioning', 'Checking existing schemas...', 0.75);
     const existingSchemas = await findDataSchemas({ branchId, authToken });
 
-    // Step 6: Apply merge strategy
+    // Apply merge strategy
     emitter.emit('merging', 'Applying merge strategy...', 0.78);
     const existingFileIndex = existingSchemas.findIndex(
       (f) => f.name === fileName
     );
 
+    const existingCode = existingFileIndex >= 0
+      ? existingSchemas[existingFileIndex].code
+      : null;
+
     let finalYaml = yamlContent;
-    if (existingFileIndex >= 0) {
-      const existingFile = existingSchemas[existingFileIndex];
-      finalYaml = mergeModels(existingFile.code, yamlContent, mergeStrategy);
+    if (existingCode) {
+      finalYaml = mergeModels(existingCode, yamlContent, mergeStrategy);
+    }
+
+    // Compute change preview
+    const changePreview = diffModels(existingCode, yamlContent, mergeStrategy);
+
+    // Dry-run: return preview without saving
+    if (dryRun) {
+      const { summary } = cubeResult;
+      const payload = {
+        code: 'ok',
+        message: changePreview.summary,
+        version_id: null,
+        file_name: fileName,
+        changed: existingCode !== finalYaml,
+        change_preview: changePreview,
+        model_summary: {
+          dimensions_count: summary.dimensions_count,
+          measures_count: summary.measures_count,
+          cubes_count: summary.cubes_count,
+        },
+      };
+      emitter.complete(payload);
+      return;
     }
 
     let files;
@@ -101,14 +144,12 @@ export default async (req, res, cubejs) => {
       ];
     }
 
-    // Step 7: Compute checksum of ALL files
+    // Compute checksum of ALL files
     emitter.emit('versioning', 'Computing checksum...', 0.8);
     const commitChecksum = createMd5Hex(
       files.reduce((acc, f) => acc + f.code, '')
     );
 
-    // Step 8: Check if anything changed
-    // Find the latest version checksum from existing schemas
     const existingChecksum = createMd5Hex(
       existingSchemas.reduce((acc, f) => acc + f.code, '')
     );
@@ -120,6 +161,7 @@ export default async (req, res, cubejs) => {
         version_id: null,
         file_name: fileName,
         changed: false,
+        change_preview: changePreview,
         profile_summary: {
           row_count: profiledTable.row_count,
           columns_profiled: cubeResult.summary.columns_profiled,
@@ -138,7 +180,7 @@ export default async (req, res, cubejs) => {
       return;
     }
 
-    // Step 9: Create new version
+    // Create new version
     emitter.emit('versioning', 'Creating new version...', 0.85);
 
     const dataSourceId = securityContext.userScope?.dataSource?.dataSourceId;
@@ -159,7 +201,7 @@ export default async (req, res, cubejs) => {
       },
     });
 
-    // Step 10: Purge compiler cache
+    // Purge compiler cache
     if (cubejs.compilerCache) {
       cubejs.compilerCache.purgeStale();
     }
@@ -171,6 +213,7 @@ export default async (req, res, cubejs) => {
       version_id: result?.id || null,
       file_name: fileName,
       changed: true,
+      change_preview: changePreview,
       profile_summary: {
         row_count: profiledTable.row_count,
         columns_profiled: summary.columns_profiled,

--- a/services/cubejs/src/routes/smartGenerate.js
+++ b/services/cubejs/src/routes/smartGenerate.js
@@ -16,10 +16,14 @@ export default async (req, res, cubejs) => {
     table,
     schema,
     branchId,
-    arrayJoinColumns = [],
-    maxMapKeys = 500,
+    arrayJoinColumns: rawArrayJoinColumns,
+    maxMapKeys: rawMaxMapKeys,
     mergeStrategy = 'auto',
   } = req.body;
+
+  // Hasura sends {} instead of null for optional fields — normalize
+  const arrayJoinColumns = Array.isArray(rawArrayJoinColumns) ? rawArrayJoinColumns : [];
+  const maxMapKeys = typeof rawMaxMapKeys === 'number' ? rawMaxMapKeys : 500;
 
   if (!table || !schema || !branchId) {
     return res.status(400).json({

--- a/services/cubejs/src/routes/validate.js
+++ b/services/cubejs/src/routes/validate.js
@@ -1,0 +1,125 @@
+import { prepareCompiler } from "@cubejs-backend/schema-compiler";
+
+/**
+ * In-memory schema file repository that satisfies the SchemaFileRepository
+ * interface from @cubejs-backend/shared. Each file has { fileName, content }.
+ */
+class InMemorySchemaFileRepository {
+  constructor(files) {
+    this.files = files;
+  }
+
+  localPath() {
+    return "/";
+  }
+
+  async dataSchemaFiles() {
+    return this.files;
+  }
+}
+
+/**
+ * Map a CompilerErrorInterface to the response format.
+ *
+ * CompilerErrorInterface: { message, plainMessage?, fileName?, lineNumber?, position? }
+ */
+function mapCompilerError(err) {
+  return {
+    severity: "error",
+    message: err.plainMessage || err.message || String(err),
+    fileName: err.fileName || null,
+    startLine: err.lineNumber ? Number(err.lineNumber) : null,
+    startColumn: err.position != null ? Number(err.position) : null,
+    endLine: null,
+    endColumn: null,
+  };
+}
+
+/**
+ * Map a SyntaxErrorInterface to the response format.
+ *
+ * SyntaxErrorInterface: { message, plainMessage?, loc: { start: { line, column }, end?: { line, column } } | null }
+ */
+function mapSyntaxWarning(warn) {
+  const loc = warn.loc || {};
+  const start = loc.start || {};
+  const end = loc.end || {};
+
+  return {
+    severity: "warning",
+    message: warn.plainMessage || warn.message || String(warn),
+    fileName: null,
+    startLine: start.line != null ? Number(start.line) : null,
+    startColumn: start.column != null ? Number(start.column) : null,
+    endLine: end.line != null ? Number(end.line) : null,
+    endColumn: end.column != null ? Number(end.column) : null,
+  };
+}
+
+export default async (req, res) => {
+  const { files } = req.body || {};
+
+  if (!Array.isArray(files) || files.length === 0) {
+    return res.status(400).json({
+      code: "validate_missing_files",
+      message: "The files parameter is required and must be a non-empty array of { fileName, content }.",
+    });
+  }
+
+  try {
+    const repo = new InMemorySchemaFileRepository(files);
+    const { compiler } = prepareCompiler(repo, {
+      allowNodeRequire: false,
+      standalone: true,
+    });
+
+    let compileError = null;
+    try {
+      await compiler.compile();
+    } catch (err) {
+      // compile() throws a CompileError when there are validation errors.
+      // The errors are already collected in compiler.errorsReport — we just
+      // need to suppress the throw and read them below.
+      compileError = err;
+    }
+
+    const errorsReport = compiler.errorsReport;
+    const rawErrors = errorsReport ? errorsReport.getErrors() : [];
+    const rawWarnings = errorsReport ? errorsReport.getWarnings() : [];
+
+    // If compile threw but no structured errors were collected, surface the
+    // thrown error as a single error entry.
+    if (compileError && rawErrors.length === 0) {
+      return res.json({
+        valid: false,
+        errors: [
+          {
+            severity: "error",
+            message: compileError.message || String(compileError),
+            fileName: null,
+            startLine: null,
+            startColumn: null,
+            endLine: null,
+            endColumn: null,
+          },
+        ],
+        warnings: rawWarnings.map(mapSyntaxWarning),
+      });
+    }
+
+    const errors = rawErrors.map(mapCompilerError);
+    const warnings = rawWarnings.map(mapSyntaxWarning);
+
+    return res.json({
+      valid: errors.length === 0,
+      errors,
+      warnings,
+    });
+  } catch (err) {
+    console.error("Validation endpoint error:", err);
+    return res.status(500).json({
+      code: "validate_error",
+      message: err.message || String(err),
+    });
+  }
+};

--- a/services/cubejs/src/routes/version.js
+++ b/services/cubejs/src/routes/version.js
@@ -1,0 +1,9 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("@cubejs-backend/schema-compiler/package.json");
+const SCHEMA_COMPILER_VERSION = pkg.version;
+
+export default (req, res) => {
+  res.json({ version: SCHEMA_COMPILER_VERSION });
+};

--- a/services/cubejs/src/utils/smart-generation/diffModels.js
+++ b/services/cubejs/src/utils/smart-generation/diffModels.js
@@ -1,0 +1,345 @@
+/**
+ * Diff Models — computes a structured diff between existing and newly generated
+ * Cube.js YAML models, reporting what would change during a merge operation.
+ *
+ * Used to preview changes before applying a smart model regeneration.
+ */
+
+import YAML from 'yaml';
+import { hasUserContent } from './merger.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isAutoField(field) {
+  return field?.meta?.auto_generated === true;
+}
+
+function isAutoCube(cube) {
+  return cube?.meta?.auto_generated === true;
+}
+
+function fieldsByName(fields) {
+  const map = new Map();
+  if (!Array.isArray(fields)) return map;
+  for (const f of fields) {
+    if (f?.name) map.set(f.name, f);
+  }
+  return map;
+}
+
+/**
+ * Check whether a smart-generated existing doc should be replaced or merged
+ * under the "auto" strategy (mirrors merger.js autoStrategy logic).
+ */
+function autoWouldReplace(existingDoc) {
+  const cubes = existingDoc?.cubes;
+  if (!Array.isArray(cubes) || cubes.length === 0) return true;
+
+  // If no cube has auto_generated tag, it's standard-generated -> replace
+  const hasAuto = cubes.some((c) => isAutoCube(c));
+  if (!hasAuto) return true;
+
+  // If no cube has user content, safe to replace
+  const hasUser = cubes.some((cube) => {
+    // Check preserve-worthy blocks
+    if (Array.isArray(cube.joins) && cube.joins.length > 0) return true;
+    if (Array.isArray(cube.pre_aggregations) && cube.pre_aggregations.length > 0) return true;
+    if (Array.isArray(cube.segments) && cube.segments.length > 0) return true;
+
+    const allFields = [
+      ...(Array.isArray(cube.dimensions) ? cube.dimensions : []),
+      ...(Array.isArray(cube.measures) ? cube.measures : []),
+    ];
+    for (const field of allFields) {
+      if (!isAutoField(field)) return true;
+      if (field.description) return true;
+    }
+    return false;
+  });
+
+  return !hasUser;
+}
+
+// ---------------------------------------------------------------------------
+// Diff computation for a single field list (dimensions or measures)
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff a single field list between existing and new cubes.
+ *
+ * @param {Array} existingFields
+ * @param {Array} newFields
+ * @param {string} memberType - "dimension" or "measure"
+ * @param {string} cubeName
+ * @param {boolean} isReplace - If true, all existing are removed, all new are added
+ * @returns {{ added, updated, removed, preserved }}
+ */
+function diffFields(existingFields, newFields, memberType, cubeName, isReplace) {
+  const existing = Array.isArray(existingFields) ? existingFields : [];
+  const incoming = Array.isArray(newFields) ? newFields : [];
+
+  const added = [];
+  const updated = [];
+  const removed = [];
+  const preserved = [];
+
+  if (isReplace) {
+    // Replace strategy: everything existing is removed, everything new is added
+    for (const field of existing) {
+      removed.push({ name: field.name, type: field.type, member_type: memberType, cube: cubeName });
+    }
+    for (const field of incoming) {
+      added.push({ name: field.name, type: field.type, member_type: memberType, cube: cubeName });
+    }
+    return { added, updated, removed, preserved };
+  }
+
+  // Merge strategy
+  const newMap = fieldsByName(incoming);
+  const existingMap = fieldsByName(existing);
+  const handledNames = new Set();
+
+  for (const field of existing) {
+    const name = field.name;
+    handledNames.add(name);
+
+    if (!isAutoField(field)) {
+      // User-created field — always preserved
+      preserved.push({ name, member_type: memberType, cube: cubeName, reason: 'user_created' });
+      continue;
+    }
+
+    // Auto-generated field
+    const newField = newMap.get(name);
+
+    if (newField) {
+      // Check for edited description
+      if (field.description && field.description !== (newField.description ?? undefined)) {
+        preserved.push({ name, member_type: memberType, cube: cubeName, reason: 'edited_description' });
+      } else {
+        updated.push({ name: newField.name, type: newField.type, member_type: memberType, cube: cubeName });
+      }
+    } else {
+      // Auto field no longer generated — removed
+      removed.push({ name: field.name, type: field.type, member_type: memberType, cube: cubeName });
+    }
+  }
+
+  // New fields not in existing
+  for (const field of incoming) {
+    if (!handledNames.has(field.name)) {
+      added.push({ name: field.name, type: field.type, member_type: memberType, cube: cubeName });
+    }
+  }
+
+  return { added, updated, removed, preserved };
+}
+
+// ---------------------------------------------------------------------------
+// Preserved blocks detection
+// ---------------------------------------------------------------------------
+
+function getPreservedBlocks(cube, cubeName) {
+  const blocks = [];
+  if (Array.isArray(cube.joins) && cube.joins.length > 0) {
+    blocks.push({ block: 'joins', cube: cubeName });
+  }
+  if (Array.isArray(cube.pre_aggregations) && cube.pre_aggregations.length > 0) {
+    blocks.push({ block: 'pre_aggregations', cube: cubeName });
+  }
+  if (Array.isArray(cube.segments) && cube.segments.length > 0) {
+    blocks.push({ block: 'segments', cube: cubeName });
+  }
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Summary builder
+// ---------------------------------------------------------------------------
+
+function buildSummary(added, updated, removed, preserved, blocksPreserved) {
+  const parts = [];
+
+  if (added.length > 0) {
+    parts.push(`Adding ${added.length} field${added.length !== 1 ? 's' : ''}`);
+  }
+  if (updated.length > 0) {
+    parts.push(`updating ${updated.length}`);
+  }
+  if (removed.length > 0) {
+    parts.push(`removing ${removed.length}`);
+  }
+
+  let summary = parts.length > 0 ? parts.join(', ') + '.' : 'No field changes.';
+
+  const preservedParts = [];
+  if (preserved.length > 0) {
+    preservedParts.push(`${preserved.length} user field${preserved.length !== 1 ? 's' : ''}`);
+  }
+  if (blocksPreserved.length > 0) {
+    const blockNames = [...new Set(blocksPreserved.map((b) => b.block))];
+    preservedParts.push(blockNames.join(', '));
+  }
+
+  if (preservedParts.length > 0) {
+    summary += ` Preserving ${preservedParts.join(' and ')}.`;
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a structured diff between existing YAML model and newly generated YAML.
+ *
+ * @param {string|null} existingYaml - Current YAML model content (null if new)
+ * @param {string} newYaml - Newly generated YAML content
+ * @param {string} [mergeStrategy="auto"] - "auto", "merge", or "replace"
+ * @returns {{ fields_added, fields_updated, fields_removed, fields_preserved, blocks_preserved, summary }}
+ */
+export function diffModels(existingYaml, newYaml, mergeStrategy = 'auto') {
+  const result = {
+    fields_added: [],
+    fields_updated: [],
+    fields_removed: [],
+    fields_preserved: [],
+    blocks_preserved: [],
+    summary: '',
+  };
+
+  // Parse new YAML
+  let newDoc;
+  try {
+    newDoc = YAML.parse(newYaml);
+  } catch {
+    result.summary = 'Cannot parse new YAML.';
+    return result;
+  }
+
+  const newCubes = Array.isArray(newDoc?.cubes) ? newDoc.cubes : [];
+
+  // No existing model — everything is added
+  if (!existingYaml || typeof existingYaml !== 'string' || existingYaml.trim() === '') {
+    for (const cube of newCubes) {
+      const cubeName = cube.name;
+      for (const dim of Array.isArray(cube.dimensions) ? cube.dimensions : []) {
+        result.fields_added.push({ name: dim.name, type: dim.type, member_type: 'dimension', cube: cubeName });
+      }
+      for (const meas of Array.isArray(cube.measures) ? cube.measures : []) {
+        result.fields_added.push({ name: meas.name, type: meas.type, member_type: 'measure', cube: cubeName });
+      }
+    }
+    result.summary = buildSummary(result.fields_added, [], [], [], []);
+    return result;
+  }
+
+  // Parse existing YAML
+  let existingDoc;
+  try {
+    existingDoc = YAML.parse(existingYaml);
+  } catch {
+    // Can't parse existing — treat as empty, everything is added
+    for (const cube of newCubes) {
+      const cubeName = cube.name;
+      for (const dim of Array.isArray(cube.dimensions) ? cube.dimensions : []) {
+        result.fields_added.push({ name: dim.name, type: dim.type, member_type: 'dimension', cube: cubeName });
+      }
+      for (const meas of Array.isArray(cube.measures) ? cube.measures : []) {
+        result.fields_added.push({ name: meas.name, type: meas.type, member_type: 'measure', cube: cubeName });
+      }
+    }
+    result.summary = buildSummary(result.fields_added, [], [], [], []);
+    return result;
+  }
+
+  const existingCubes = Array.isArray(existingDoc?.cubes) ? existingDoc.cubes : [];
+
+  // Determine effective strategy
+  let isReplace = mergeStrategy === 'replace';
+
+  if (mergeStrategy === 'auto') {
+    isReplace = autoWouldReplace(existingDoc);
+  }
+
+  // Build cube lookup maps
+  const existingByName = new Map();
+  for (const cube of existingCubes) {
+    if (cube?.name) existingByName.set(cube.name, cube);
+  }
+
+  const newByName = new Map();
+  for (const cube of newCubes) {
+    if (cube?.name) newByName.set(cube.name, cube);
+  }
+
+  const processedCubes = new Set();
+
+  // Walk existing cubes
+  for (const existingCube of existingCubes) {
+    const cubeName = existingCube.name;
+    processedCubes.add(cubeName);
+
+    const newCube = newByName.get(cubeName);
+
+    if (!newCube) {
+      if (isReplace) {
+        // Entire cube removed under replace
+        for (const dim of Array.isArray(existingCube.dimensions) ? existingCube.dimensions : []) {
+          result.fields_removed.push({ name: dim.name, type: dim.type, member_type: 'dimension', cube: cubeName });
+        }
+        for (const meas of Array.isArray(existingCube.measures) ? existingCube.measures : []) {
+          result.fields_removed.push({ name: meas.name, type: meas.type, member_type: 'measure', cube: cubeName });
+        }
+      } else {
+        // Merge: auto cubes without match are removed; user cubes preserved
+        if (!isAutoCube(existingCube)) {
+          // User cube with no match — preserved entirely (not in new generation scope)
+          // We don't list its fields since it's untouched
+        } else {
+          for (const dim of Array.isArray(existingCube.dimensions) ? existingCube.dimensions : []) {
+            result.fields_removed.push({ name: dim.name, type: dim.type, member_type: 'dimension', cube: cubeName });
+          }
+          for (const meas of Array.isArray(existingCube.measures) ? existingCube.measures : []) {
+            result.fields_removed.push({ name: meas.name, type: meas.type, member_type: 'measure', cube: cubeName });
+          }
+        }
+      }
+      continue;
+    }
+
+    // Cube exists in both — diff fields
+    const dimDiff = diffFields(existingCube.dimensions, newCube.dimensions, 'dimension', cubeName, isReplace);
+    const measDiff = diffFields(existingCube.measures, newCube.measures, 'measure', cubeName, isReplace);
+
+    result.fields_added.push(...dimDiff.added, ...measDiff.added);
+    result.fields_updated.push(...dimDiff.updated, ...measDiff.updated);
+    result.fields_removed.push(...dimDiff.removed, ...measDiff.removed);
+    result.fields_preserved.push(...dimDiff.preserved, ...measDiff.preserved);
+
+    // Preserved blocks (only relevant for merge)
+    if (!isReplace) {
+      result.blocks_preserved.push(...getPreservedBlocks(existingCube, cubeName));
+    }
+  }
+
+  // New cubes not in existing — all fields are added
+  for (const newCube of newCubes) {
+    if (!processedCubes.has(newCube.name)) {
+      const cubeName = newCube.name;
+      for (const dim of Array.isArray(newCube.dimensions) ? newCube.dimensions : []) {
+        result.fields_added.push({ name: dim.name, type: dim.type, member_type: 'dimension', cube: cubeName });
+      }
+      for (const meas of Array.isArray(newCube.measures) ? newCube.measures : []) {
+        result.fields_added.push({ name: meas.name, type: meas.type, member_type: 'measure', cube: cubeName });
+      }
+    }
+  }
+
+  result.summary = buildSummary(result.fields_added, result.fields_updated, result.fields_removed, result.fields_preserved, result.blocks_preserved);
+  return result;
+}

--- a/services/cubejs/src/utils/smart-generation/profileSerializer.js
+++ b/services/cubejs/src/utils/smart-generation/profileSerializer.js
@@ -1,0 +1,95 @@
+/**
+ * Profile Serializer — converts profiler's profiledTable to/from plain JSON
+ * for transport through GraphQL.
+ *
+ * The profiledTable uses Map objects for `columns` and `columnDescriptions`,
+ * which do not survive JSON serialization. These functions handle the conversion.
+ */
+
+/**
+ * Serialize a profiledTable and primaryKeys into a plain JSON-safe object.
+ *
+ * Converts Map fields (`columns`, `columnDescriptions`) to plain objects.
+ *
+ * @param {object} profiledTable - The profiler output with Map fields
+ * @param {string[]} primaryKeys - Detected primary key column names
+ * @returns {object} Plain JSON-safe object
+ */
+export function serializeProfile(profiledTable, primaryKeys) {
+  if (!profiledTable) {
+    return { profiledTable: null, primaryKeys: primaryKeys || [] };
+  }
+
+  const columns = {};
+  if (profiledTable.columns instanceof Map) {
+    for (const [key, value] of profiledTable.columns) {
+      columns[key] = value;
+    }
+  } else if (profiledTable.columns && typeof profiledTable.columns === 'object') {
+    // Already a plain object — pass through
+    Object.assign(columns, profiledTable.columns);
+  }
+
+  const columnDescriptions = {};
+  if (profiledTable.columnDescriptions instanceof Map) {
+    for (const [key, value] of profiledTable.columnDescriptions) {
+      columnDescriptions[key] = value;
+    }
+  } else if (profiledTable.columnDescriptions && typeof profiledTable.columnDescriptions === 'object') {
+    Object.assign(columnDescriptions, profiledTable.columnDescriptions);
+  }
+
+  return {
+    profiledTable: {
+      database: profiledTable.database,
+      table: profiledTable.table,
+      row_count: profiledTable.row_count,
+      sampled: profiledTable.sampled,
+      sample_size: profiledTable.sample_size,
+      columns,
+      columnDescriptions,
+    },
+    primaryKeys: primaryKeys || [],
+  };
+}
+
+/**
+ * Deserialize a plain JSON object back into a profiledTable with Map fields.
+ *
+ * @param {object} serialized - The serialized object from `serializeProfile`
+ * @returns {{ profiledTable: object, primaryKeys: string[] }}
+ */
+export function deserializeProfile(serialized) {
+  if (!serialized || !serialized.profiledTable) {
+    return { profiledTable: null, primaryKeys: serialized?.primaryKeys || [] };
+  }
+
+  const src = serialized.profiledTable;
+
+  const columns = new Map();
+  if (src.columns && typeof src.columns === 'object') {
+    for (const [key, value] of Object.entries(src.columns)) {
+      columns.set(key, value);
+    }
+  }
+
+  const columnDescriptions = new Map();
+  if (src.columnDescriptions && typeof src.columnDescriptions === 'object') {
+    for (const [key, value] of Object.entries(src.columnDescriptions)) {
+      columnDescriptions.set(key, value);
+    }
+  }
+
+  return {
+    profiledTable: {
+      database: src.database,
+      table: src.table,
+      row_count: src.row_count,
+      sampled: src.sampled,
+      sample_size: src.sample_size,
+      columns,
+      columnDescriptions,
+    },
+    primaryKeys: serialized.primaryKeys || [],
+  };
+}

--- a/services/hasura/metadata/actions.graphql
+++ b/services/hasura/metadata/actions.graphql
@@ -109,6 +109,8 @@ type Mutation {
     array_join_columns: [ArrayJoinInput]
     max_map_keys: Int
     merge_strategy: String
+    profile_data: jsonb
+    dry_run: Boolean
   ): SmartGenOutput
 }
 
@@ -230,6 +232,7 @@ type ProfileTableOutput {
   array_candidates: [ArrayCandidateOutput]
   primary_keys: [String]
   existing_model: ExistingModelInfo
+  raw_profile: jsonb
 }
 
 type ExistingModelInfo {
@@ -263,6 +266,7 @@ type SmartGenOutput {
   version_id: uuid
   file_name: String
   changed: Boolean!
+  change_preview: jsonb
 }
 
 type UpdateTeamSettingsOutput {

--- a/specs/006-model-authoring/checklists/requirements.md
+++ b/specs/006-model-authoring/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Model Authoring Improvements
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The brainstorming session prior to spec creation resolved all design questions (format support, validation strategy, metadata source, UI placement, spec coverage depth, schema knowledge location).
+- The design document from the brainstorming session contains the architectural approach (Monaco Language Service) that will inform the implementation plan.

--- a/specs/006-model-authoring/contracts/cubejs-version-endpoint.md
+++ b/specs/006-model-authoring/contracts/cubejs-version-endpoint.md
@@ -1,0 +1,29 @@
+# Contract: GET /api/v1/version
+
+**Service**: CubeJS (port 4000)
+**Auth**: JWT Bearer token (same as all CubeJS routes)
+
+## Request
+
+```
+GET /api/v1/version
+Authorization: Bearer <jwt_token>
+```
+
+## Response (200)
+
+```json
+{
+  "version": "1.6.19"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| version | string | CubeJS schema-compiler package version |
+
+## Notes
+
+- Used by the frontend to compare against the static schema spec version
+- If versions diverge (major/minor), frontend shows a soft warning banner
+- Lightweight endpoint — reads version from package.json at startup, no computation

--- a/specs/006-model-authoring/contracts/validate-endpoint.md
+++ b/specs/006-model-authoring/contracts/validate-endpoint.md
@@ -1,0 +1,120 @@
+# Contract: POST /api/v1/validate
+
+**Service**: CubeJS (port 4000)
+**Auth**: JWT Bearer token (same as all CubeJS routes)
+
+## Request
+
+```
+POST /api/v1/validate
+Content-Type: application/json
+Authorization: Bearer <jwt_token>
+```
+
+### Body
+
+```json
+{
+  "files": [
+    {
+      "fileName": "semantic_events.js",
+      "content": "cube(`semantic_events`, { sql_table: `cst.semantic_events`, ... })"
+    },
+    {
+      "fileName": "orders.yml",
+      "content": "cubes:\n  - name: orders\n    sql_table: public.orders\n    ..."
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| files | FileContent[] | Yes | All dataschema files to validate together |
+| files[].fileName | string | Yes | File name including extension (.yml, .js) |
+| files[].content | string | Yes | Full file content |
+
+## Response
+
+### Success (200)
+
+```json
+{
+  "valid": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+### Validation Errors (200)
+
+```json
+{
+  "valid": false,
+  "errors": [
+    {
+      "severity": "error",
+      "message": "\"measures.revenue.type\" must be one of [count, sum, avg, min, max, number, count_distinct, count_distinct_approx, running_total, string, boolean, time]",
+      "fileName": "orders.yml",
+      "startLine": 15,
+      "startColumn": 12,
+      "endLine": 15,
+      "endColumn": 20
+    },
+    {
+      "severity": "error",
+      "message": "\"joins.unknown_cube\" references a cube that does not exist",
+      "fileName": "semantic_events.js",
+      "startLine": 42,
+      "startColumn": 5,
+      "endLine": 45,
+      "endColumn": 6
+    }
+  ],
+  "warnings": [
+    {
+      "severity": "warning",
+      "message": "\"shown\" is deprecated, use \"public\" instead",
+      "fileName": "orders.yml",
+      "startLine": 8,
+      "startColumn": 5,
+      "endLine": 8,
+      "endColumn": 10
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| valid | boolean | true if no errors (warnings don't affect validity) |
+| errors | ValidationItem[] | Compilation errors |
+| warnings | ValidationItem[] | Deprecation warnings, style issues |
+
+### ValidationItem
+
+| Field | Type | Description |
+|-------|------|-------------|
+| severity | "error" \| "warning" | Severity level |
+| message | string | Human-readable message |
+| fileName | string | File containing the issue |
+| startLine | number | 1-based start line |
+| startColumn | number | 1-based start column |
+| endLine | number \| null | 1-based end line (null if unavailable) |
+| endColumn | number \| null | 1-based end column (null if unavailable) |
+
+### Server Error (500)
+
+```json
+{
+  "code": "validation_failed",
+  "message": "Internal validation error: <details>"
+}
+```
+
+## Notes
+
+- All files are validated together as a unit (cross-file references like joins must resolve)
+- The endpoint uses `prepareCompiler` from `@cubejs-backend/schema-compiler` — it does NOT use the live compiler cache
+- Line/column positions are 1-based to match Monaco editor conventions
+- The `ErrorReporter` from the schema compiler may not always provide end positions — `endLine`/`endColumn` will be null in those cases

--- a/specs/006-model-authoring/data-model.md
+++ b/specs/006-model-authoring/data-model.md
@@ -1,0 +1,151 @@
+# Data Model: Model Authoring Improvements
+
+**Date**: 2026-03-10
+**Feature**: 006-model-authoring
+
+## Entities
+
+### SchemaSpec (static, client-side)
+
+The structured definition of all valid Cube.js model properties. Shipped as a TypeScript file in client-v2.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| version | string | Cube.js version this spec targets (e.g., "1.6.19") |
+| constructs | Map<string, ConstructSpec> | Top-level constructs: cube, view |
+| templateVariables | TemplateVariableSpec[] | CUBE, FILTER_PARAMS, SECURITY_CONTEXT, SQL_UTILS, COMPILE_CONTEXT |
+
+### ConstructSpec
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | "cube" or "view" |
+| properties | Map<string, PropertySpec> | All valid top-level properties |
+| memberTypes | Map<string, MemberTypeSpec> | dimensions, measures, joins, segments, pre_aggregations |
+
+### PropertySpec
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | string | Property name (snake_case for YAML, camelCase for JS) |
+| jsKey | string | camelCase variant |
+| yamlKey | string | snake_case variant |
+| type | "string" \| "boolean" \| "number" \| "enum" \| "object" \| "array" \| "sql" \| "reference" \| "function" | Value type |
+| required | boolean | Whether property is required |
+| values | string[] | Valid values for enum types |
+| description | string | Human-readable description for hover/completion docs |
+| deprecated | boolean | Whether this property is deprecated |
+| deprecatedBy | string | Replacement property name |
+| children | Map<string, PropertySpec> | Nested properties for object types |
+| referenceType | "cube" \| "dimension" \| "measure" \| "segment" \| "pre_aggregation" | For reference-typed properties |
+
+### MemberTypeSpec
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | "dimensions", "measures", "joins", etc. |
+| properties | Map<string, PropertySpec> | Valid properties for this member type |
+| typeValues | string[] | Valid values for the `type` property of this member |
+
+### CubeRegistryEntry (runtime, client-side)
+
+Populated from FetchMeta query. One entry per cube in the current branch.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Cube name |
+| title | string | Display title |
+| type | "cube" \| "view" | Construct type |
+| dimensions | MemberEntry[] | All dimensions |
+| measures | MemberEntry[] | All measures |
+| segments | MemberEntry[] | All segments |
+
+### MemberEntry
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Member name |
+| title | string | Display title |
+| type | string | Member type value (string, number, sum, count, etc.) |
+| primaryKey | boolean | Whether this is a primary key dimension |
+
+### ParsedDocument (transient, client-side)
+
+Format-agnostic representation of a model file, produced by YAML or JS parser.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| format | "yaml" \| "js" | Source format |
+| cubes | ParsedCube[] | Parsed cube definitions |
+| views | ParsedView[] | Parsed view definitions |
+| errors | ParseError[] | Syntax errors found during parsing |
+
+### ParsedCube / ParsedView
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Cube/view name |
+| nameRange | MonacoRange | Source position of the name |
+| properties | ParsedProperty[] | Top-level properties |
+| members | Map<string, ParsedMember[]> | dimensions, measures, joins, etc. |
+
+### ParsedMember
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Member name |
+| range | MonacoRange | Full member source range |
+| nameRange | MonacoRange | Name-only source range |
+| properties | ParsedProperty[] | Member properties with positions |
+
+### ParsedProperty
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | string | Property name |
+| value | any | Parsed value |
+| range | MonacoRange | Full property range |
+| valueRange | MonacoRange | Value-only range |
+
+### ValidationError (backend → frontend)
+
+Returned from the `/api/v1/validate` endpoint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| severity | "error" \| "warning" | Error severity |
+| message | string | Human-readable error message |
+| fileName | string | File containing the error |
+| startLine | number | 1-based start line |
+| startColumn | number | 1-based start column |
+| endLine | number \| null | 1-based end line (null if unavailable) |
+| endColumn | number \| null | 1-based end column (null if unavailable) |
+
+## Relationships
+
+```
+SchemaSpec ──provides property definitions──▶ CompletionProvider
+SchemaSpec ──provides validation rules──▶ DiagnosticProvider (client-side)
+CubeRegistry ──provides cube/member names──▶ CompletionProvider
+CubeRegistry ──populated from──▶ FetchMeta GraphQL query
+ParsedDocument ──provides cursor context──▶ CompletionProvider, HoverProvider
+ParsedDocument ──provides structure for──▶ DiagnosticProvider (client-side)
+ValidationError ──produced by──▶ CubeJS /api/v1/validate endpoint
+ValidationError ──consumed by──▶ DiagnosticProvider (backend results)
+```
+
+## State Transitions
+
+### Cube Registry Lifecycle
+1. **Empty** → **Loading** (on editor mount, FetchMeta query fires)
+2. **Loading** → **Ready** (FetchMeta returns, registry populated)
+3. **Ready** → **Refreshing** (on file save or smart regeneration)
+4. **Refreshing** → **Ready** (FetchMeta returns updated data)
+5. **Loading/Refreshing** → **Error** (FetchMeta fails — autocomplete works without cube refs)
+
+### Validation Lifecycle (per file)
+1. **Clean** → **Validating (client)** (user edits file, debounce timer fires)
+2. **Validating (client)** → **Client errors shown** (parser + schema spec validation complete)
+3. **Client errors shown** → **Validating (backend)** (user saves file)
+4. **Validating (backend)** → **All errors shown** (backend returns, markers merged)
+5. **All errors shown** → **Validating (client)** (user edits again)

--- a/specs/006-model-authoring/plan.md
+++ b/specs/006-model-authoring/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Model Authoring Improvements
+
+**Branch**: `006-model-authoring` | **Date**: 2026-03-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/006-model-authoring/spec.md`
+
+## Summary
+
+Transform the Models IDE Monaco editor from a plain text editor into a Cube.js-aware authoring environment with context-sensitive autocomplete (both YAML and JS), real-time validation (client-side structural + backend semantic), hover documentation, and an editor toolbar regenerate button for smart-generated models. Built as a custom Monaco Language Service backed by a static Cube.js schema spec (v1.6.19) and a runtime cube registry from FetchMeta.
+
+## Technical Context
+
+**Language/Version**: TypeScript (client-v2, React 18 + Vite 4), JavaScript ES modules (CubeJS service, Node.js 18+)
+**Primary Dependencies**: Monaco Editor (existing), `yaml` ^2.3.4 (existing in CubeJS, add to client-v2), `@cubejs-backend/schema-compiler` ^1.6.19 (existing in CubeJS), Ant Design 5 (existing in client-v2), URQL (existing GraphQL client)
+**Storage**: N/A (schema spec is static; cube registry is in-memory from FetchMeta)
+**Testing**: Vitest (client-v2), StepCI (integration tests for new endpoint)
+**Target Platform**: Browser (client-v2), Docker/Node.js (CubeJS service)
+**Project Type**: Web application (frontend language service + backend validation endpoint)
+**Performance Goals**: Autocomplete <100ms, client validation <500ms, backend validation <3s
+**Constraints**: Must work with both YAML and JS model formats; must not break existing editor functionality
+**Scale/Scope**: ~10 new files in client-v2, 2 new route files in CubeJS, 1 schema spec file (~1500 lines)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Service Isolation — PASS
+- New `/api/v1/validate` and `/api/v1/version` endpoints are internal to the CubeJS service
+- Frontend communicates via existing proxy pattern (`/api/v1/*` → CubeJS)
+- No new cross-service contracts; only new CubeJS REST routes
+- client-v2 changes are purely frontend (language service, UI components)
+
+### II. Multi-Tenancy First — PASS
+- Validate endpoint uses `checkAuthMiddleware` (JWT verification)
+- Validation operates on files passed in the request body — no datasource/branch resolution needed
+- Cube registry populated from FetchMeta which already respects the user's security context
+- No changes to `defineUserScope.js` or `buildSecurityContext.js`
+
+### III. Test-Driven Development — REQUIRED
+- Schema spec: unit tests validating every property definition against CubeValidator.js
+- Parsers (YAML + JS): unit tests with fixture model files
+- Completion provider: unit tests with mock Monaco models verifying context → suggestion mapping
+- Diagnostic provider: unit tests verifying marker generation from known errors
+- Validate endpoint: StepCI integration test
+- Merge preservation: integration test (smart regenerate with user content, verify preservation)
+
+### IV. Security by Default — PASS
+- Validate endpoint requires JWT authentication (same middleware as all CubeJS routes)
+- No new secrets or credentials introduced
+- No user input is executed — file content is only compiled/validated, never evaluated as code in a user context
+
+### V. Simplicity / YAGNI — PASS
+- Static schema spec is the simplest approach (vs. LSP server, vs. runtime spec generation)
+- Reuses existing FetchMeta query for cube registry (no new GraphQL queries)
+- Reuses existing `prepareCompiler` API for backend validation (no custom compiler logic)
+- No new databases, caches, or infrastructure
+
+### Post-Phase 1 Re-check — PASS
+- No violations introduced during design phase
+- All new code lives within existing service boundaries
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-model-authoring/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research findings
+├── data-model.md        # Entity definitions
+├── quickstart.md        # Development guide
+├── contracts/
+│   ├── validate-endpoint.md    # POST /api/v1/validate contract
+│   └── cubejs-version-endpoint.md  # GET /api/v1/version contract
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+services/cubejs/src/
+├── routes/
+│   ├── index.js                    # (modify) Register validate + version routes
+│   ├── validate.js                 # (new) POST /api/v1/validate
+│   └── version.js                  # (new) GET /api/v1/version
+└── ...
+
+../client-v2/src/
+├── utils/
+│   └── cubejs-language/            # (new) Language service module
+│       ├── types.ts                # Shared types (ParsedDocument, CursorContext, etc.)
+│       ├── spec.ts                 # Static Cube.js schema spec (~1500 lines)
+│       ├── registry.ts             # Cube registry (wraps FetchMeta)
+│       ├── yamlParser.ts           # YAML → ParsedDocument
+│       ├── jsParser.ts             # JS → ParsedDocument
+│       ├── completionProvider.ts   # Monaco CompletionItemProvider
+│       ├── diagnosticProvider.ts   # Client-side + backend validation → markers
+│       └── hoverProvider.ts        # Monaco HoverProvider
+├── components/
+│   └── CodeEditor/
+│       ├── index.tsx               # (modify) Register providers, add toolbar
+│       └── RegenerateModal.tsx     # (new) Merge strategy modal for smart-generated files
+└── ...
+
+tests/stepci/
+└── validate_flow.yml              # (new) StepCI test for validate endpoint
+```
+
+**Structure Decision**: Web application structure — this feature spans the CubeJS backend service (2 new route files) and the client-v2 frontend (new `cubejs-language` module + editor modifications). Both live in their existing project directories with no new top-level structure.
+
+## Complexity Tracking
+
+| Decision | Complexity | Rejected Simpler Alternative | Justification |
+|----------|------------|------------------------------|---------------|
+| Static schema spec (~1500-line TypeScript file defining all Cube.js properties) | HIGH | **Runtime extraction from CubeValidator.js**: parse validator source at build time to auto-generate the spec. Rejected because CubeValidator internals are not a stable API and would break on Cube.js upgrades. | Static spec is manually maintained but predictable, testable, and decoupled from Cube.js internals. Version mismatch detected at runtime via `/api/v1/version`. |
+| Dual parsers (YAML + JS) with shared CursorContext type | MEDIUM | **Single YAML-only parser**: require all models in YAML. Rejected because existing codebases have JS models and the spec explicitly requires both formats (FR-001). | CursorContext union type keeps downstream consumers (completion, diagnostic, hover providers) format-agnostic. |
+
+### Existing Utilities
+
+The following existing files are referenced by tasks but not created by this feature:
+- `../client-v2/src/utils/provenanceParser.ts` — exports `isSmartGenerated(code)` and `parseProvenance(code)`, used by T023 to detect smart-generated files
+
+### Known Limitations (v1)
+
+| Limitation | Impact | Deferred To |
+|------------|--------|-------------|
+| **Smart-gen writes JS, but merger/reprofile are YAML-only** | Regenerate button restricted to YAML files only (FR-004). JS smart-generated files can't be re-profiled with merge until a JS merge path is built. | Future: JS-aware merger + provenance detection |
+| **Cube registry is save-based, not workspace-aware** | Cross-cube autocomplete uses last-saved FetchMeta state. Unsaved renames/additions not reflected until save. | Future: workspace overlay combining saved meta + parsed dirty buffers |
+| **Existing Console error surface not migrated** | Branch-level compile errors from FetchMeta continue to show in Console component. New inline markers show per-file errors from `/api/v1/validate`. Both coexist — no deduplication or unification in v1. | Future: unify error surfaces, deprecate Console for model files |
+| **JS parser uses regex+brace-matching, not AST** | Adequate for `cube()`/`view()` extraction but cannot handle deeply nested template literals or arbitrary JS. Code outside these blocks is ignored (no false positives). | Future: Babel/Acorn parser if JS model complexity warrants it |
+
+### Prerequisite Bugs
+
+| Bug | Location | Impact | Task |
+|-----|----------|--------|------|
+| Language detection splits on wrong `.` segment | `CodeEditor/index.tsx:128` — `active.split(".")[0]` extracts basename, not extension | Monaco providers keyed on `'yaml'`/`'javascript'` won't attach for files like `semantic_events.js` | T038 |

--- a/specs/006-model-authoring/quickstart.md
+++ b/specs/006-model-authoring/quickstart.md
@@ -1,0 +1,53 @@
+# Quickstart: Model Authoring Improvements
+
+## Prerequisites
+
+- Docker services running (`./cli.sh compose up`)
+- client-v2 dev server (`cd ../client-v2 && yarn dev`)
+- ClickHouse accessible (kubectl port-forward if needed)
+
+## Development Flow
+
+### Backend (CubeJS service)
+
+1. Edit files in `services/cubejs/src/routes/` and `services/cubejs/src/utils/`
+2. Restart CubeJS: `./cli.sh compose restart cubejs`
+3. Test validate endpoint: `curl -X POST http://localhost:4000/api/v1/validate -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"files": [...]}'`
+
+### Frontend (client-v2)
+
+1. Language service code lives in `src/utils/cubejs-language/`
+2. Schema spec lives in `src/utils/cubejs-language/spec.ts`
+3. Monaco providers are registered in `src/components/CodeEditor/`
+4. Hot reload via Vite — changes appear immediately
+
+### Testing
+
+- Schema spec: unit tests in client-v2 (`yarn test`)
+- Parsers: unit tests with fixture files
+- Completion/validation providers: unit tests with mock Monaco models
+- Validate endpoint: StepCI integration test
+- Merge preservation: integration test via smart regeneration with user content
+
+## Key Files to Modify
+
+### CubeJS Service (new)
+- `services/cubejs/src/routes/validate.js` — validation endpoint
+- `services/cubejs/src/routes/version.js` — version endpoint
+
+### CubeJS Service (existing)
+- `services/cubejs/src/routes/index.js` — register new routes
+
+### client-v2 (new)
+- `src/utils/cubejs-language/spec.ts` — Cube.js schema spec
+- `src/utils/cubejs-language/registry.ts` — Cube registry (wraps FetchMeta)
+- `src/utils/cubejs-language/yamlParser.ts` — YAML document parser
+- `src/utils/cubejs-language/jsParser.ts` — JS document parser
+- `src/utils/cubejs-language/types.ts` — Shared types (ParsedDocument, CursorContext, etc.)
+- `src/utils/cubejs-language/completionProvider.ts` — Monaco completion provider
+- `src/utils/cubejs-language/diagnosticProvider.ts` — Client + backend validation
+- `src/utils/cubejs-language/hoverProvider.ts` — Hover documentation provider
+
+### client-v2 (existing)
+- `src/components/CodeEditor/index.tsx` — Register providers, add toolbar button
+- `src/components/SmartGeneration/index.tsx` — Regenerate flow integration

--- a/specs/006-model-authoring/research.md
+++ b/specs/006-model-authoring/research.md
@@ -1,0 +1,121 @@
+# Research: Model Authoring Improvements
+
+**Date**: 2026-03-10
+**Feature**: 006-model-authoring
+
+## 1. Monaco Editor Language Service APIs
+
+### Decision: Register custom providers for both YAML and JavaScript
+
+Monaco supports registering the same provider object for multiple languages via separate `register*` calls. Each returns an `IDisposable`.
+
+### Key APIs
+
+**CompletionItemProvider** — `monaco.languages.registerCompletionItemProvider(langId, provider)`
+- `provideCompletionItems(model, position, context, token)` → `CompletionList`
+- `triggerCharacters`: string[] on the provider object (e.g., `.`, `$`, `:`)
+- CompletionItem properties: `label`, `kind`, `insertText`, `insertTextRules` (set `InsertAsSnippet` for snippet syntax), `documentation` (supports markdown), `sortText`, `detail`, `range`
+- Snippet syntax: `$1`/`$2` tabstops, `${1:default}` placeholders, `${1|a,b,c|}` choice dropdowns, `$0` final position
+
+**Markers API** — `monaco.editor.setModelMarkers(model, owner, markers)`
+- No provider pattern — markers are pushed imperatively
+- `IMarkerData`: `severity`, `message`, `startLineNumber`, `startColumn`, `endLineNumber`, `endColumn`, `source`, `code`
+- Severity levels: `Error` (8), `Warning` (4), `Info` (2), `Hint` (1)
+- Pattern: listen to `editor.onDidChangeModelContent`, debounce, validate, call `setModelMarkers`
+
+**HoverProvider** — `monaco.languages.registerHoverProvider(langId, provider)`
+- `provideHover(model, position, token)` → `Hover`
+- Hover: `{ range, contents: IMarkdownString[] }`
+
+### Alternatives Considered
+- **monaco-languageclient** (LSP over WebSocket): Rejected — too heavy for our needs, adds infrastructure complexity
+- **Custom language ID**: Rejected — registering on existing `yaml`/`javascript` IDs is simpler and avoids breaking syntax highlighting
+
+---
+
+## 2. Cube.js v1.6 Model Specification
+
+### Decision: Build schema spec from CubeValidator.js Joi schema (authoritative source)
+
+The complete spec was extracted from `@cubejs-backend/schema-compiler/dist/src/compiler/CubeValidator.js` (v1.6.19). This is the Joi-based validator that accepts/rejects every property.
+
+### Coverage Summary
+
+| Construct | Properties | Types/Enums |
+|-----------|-----------|-------------|
+| `cube()` top-level | 18 properties | — |
+| `dimensions` | 14 base + case/geo/granularities | type: string, number, boolean, time, geo |
+| `measures` | 15 base + multi-stage | type: count, sum, avg, min, max, number, count_distinct, count_distinct_approx, running_total, string, boolean, time + multi-stage: number_agg, rank |
+| `joins` | 2 (sql, relationship) | relationship: many_to_one, one_to_many, one_to_one (+ aliases) |
+| `segments` | 7 properties | — |
+| `pre_aggregations` | 15 base + type-specific | type: rollup, original_sql, rollup_join, rollup_lambda, auto_rollup |
+| `refresh_key` | 4 forms (every+sql, every+cron, immutable) | — |
+| `view()` | base + cubes/folders arrays | — |
+| Template variables | FILTER_PARAMS, SECURITY_CONTEXT, SQL_UTILS, COMPILE_CONTEXT, CUBE | — |
+| `access_policy` | role, conditions, member_level, row_level | 22 filter operators |
+| `hierarchies` | title, public, levels | — |
+
+### YAML ↔ JS Key Mapping
+YAML uses `snake_case`, JS uses `camelCase`. 40+ property name mappings documented. The schema spec must store both forms and select based on file format.
+
+### Alternatives Considered
+- **Scraping Cube.js docs**: Rejected — docs lag behind code, miss internal properties
+- **Generating spec at build time from CubeValidator.js**: Considered but deferred — would automate spec updates on Cube.js upgrades, but adds build complexity. The static file with a version constant is simpler for now.
+
+---
+
+## 3. CubeJS Backend Validation Endpoint
+
+### Decision: Use `prepareCompiler` from `@cubejs-backend/schema-compiler` for standalone validation
+
+### Available APIs
+
+**`prepareCompiler(repo, options)`** from `@cubejs-backend/schema-compiler`:
+- Input: `SchemaFileRepository` with `dataSchemaFiles()` returning `FileContent[]`
+- Output: `{ compiler, metaTransformer, cubeEvaluator, joinGraph, ... }`
+- `compiler.compile()` triggers full validation
+- `compiler.errorReport.getErrors()` → `CompilerErrorInterface[]` with `message`, `fileName`, `lineNumber`, `position`
+- `compiler.errorReport.getWarnings()` → `SyntaxErrorInterface[]` with `loc: { start: { line, column }, end: { line, column } }`
+
+**ErrorReporter** provides structured errors:
+```typescript
+interface CompilerErrorInterface {
+  message: string;
+  plainMessage?: string;
+  fileName?: string;
+  lineNumber?: string;
+  position?: number;
+}
+
+interface SyntaxErrorInterface {
+  message: string;
+  plainMessage?: string;
+  loc: { start: { line, column }, end?: { line, column } } | null;
+}
+```
+
+**SchemaFileRepository** interface:
+```typescript
+interface FileContent { fileName: string; content: string; readOnly?: boolean; }
+interface SchemaFileRepository {
+  localPath(): string;
+  dataSchemaFiles(includeDependencies?: boolean): Promise<FileContent[]>;
+}
+```
+
+### Validation Stages Available
+1. **Syntax** — YAML/JS parse errors (YamlCompiler, transpilers)
+2. **Schema** — CubeValidator Joi validation (property names, types, required fields)
+3. **Semantic** — CubeToMetaTransformer (cross-cube references, join validation)
+4. **Graph** — JoinGraph (circular dependencies, relationship consistency)
+
+### Endpoint Design
+- Route: `POST /api/v1/validate`
+- Input: `{ files: [{ fileName, content }] }` — all files in the current version
+- Auth: Same `checkAuthMiddleware` as other routes
+- Process: Create in-memory `SchemaFileRepository` → `prepareCompiler()` → `compile()` → collect errors
+- Output: `{ errors: [...], warnings: [...] }` with file/line/column positions
+
+### Alternatives Considered
+- **Using `cubejs.getCompilerApi(context).compileSchema()`**: Rejected — requires full security context setup, caches results, heavier weight. `prepareCompiler` is more direct for validation-only use.
+- **Client-side only validation**: Rejected (per spec) — can't catch semantic errors like invalid join targets or circular dependencies without the compiler.

--- a/specs/006-model-authoring/spec.md
+++ b/specs/006-model-authoring/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: Model Authoring Improvements
+
+**Feature Branch**: `006-model-authoring`
+**Created**: 2026-03-10
+**Status**: Draft
+**Input**: User description: "Model Authoring Improvements"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Autocomplete While Editing Models (Priority: P1)
+
+A data engineer is editing a Cube.js model file (YAML or JS) in the Models IDE. As they type, the editor suggests valid property names, type values, template variables, and cube/member references — similar to an IDE experience for a typed language. They can press Tab to accept suggestions and quickly scaffold new dimensions, measures, joins, and pre-aggregations without referencing documentation.
+
+**Why this priority**: Autocomplete is the highest-leverage improvement. It accelerates every editing session, reduces errors at the point of entry, and makes joins (currently the hardest thing to author) easy by suggesting target cubes and their members.
+
+**Independent Test**: Can be tested by opening any model file in the editor and verifying that context-aware suggestions appear for property names, type enums, cube references, template variables, and join targets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is editing a cube's top-level properties, **When** they trigger autocomplete, **Then** they see valid top-level keys (sql_table, dimensions, measures, joins, etc.) with descriptions.
+2. **Given** a user is inside a `dimensions` block, **When** they trigger autocomplete for a new member, **Then** a skeleton snippet is inserted with tabstops for name, sql, and type.
+3. **Given** a user is typing a `type` value for a measure, **When** they trigger autocomplete, **Then** they see only valid measure types (sum, count, avg, min, max, etc.).
+4. **Given** a user is editing a join's `sql` property, **When** they trigger autocomplete after `${`, **Then** they see CUBE and all other cube names from the current branch, and selecting a cube name followed by `.` shows that cube's dimensions.
+5. **Given** a user is editing a YAML model file, **When** they trigger autocomplete, **Then** suggestions use YAML syntax (not JS).
+6. **Given** a user is editing a JS model file with `${FILTER_PARAMS...}` references, **When** they trigger autocomplete inside a template literal, **Then** they see valid template variables including FILTER_PARAMS, SECURITY_CONTEXT, CUBE, and SQL_UTILS.
+
+---
+
+### User Story 2 - Real-Time Validation with Inline Errors (Priority: P1)
+
+A data engineer saves or edits a model file and sees validation errors inline in the editor (red squiggles under problematic code) with descriptive error messages on hover. Validation catches both structural issues (invalid property names, wrong types, missing required fields) and semantic issues (referencing a nonexistent cube in a join, circular dependencies).
+
+**Why this priority**: Without validation, users only discover errors when queries fail at runtime. Inline errors catch mistakes immediately, reducing the debug cycle from minutes to seconds.
+
+**Independent Test**: Can be tested by introducing known errors into a model file (e.g., invalid type value, reference to nonexistent cube) and verifying that red squiggles appear with helpful error messages.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user types an invalid property name inside a cube definition, **When** the editor re-validates (debounced after typing stops), **Then** a red squiggle appears under the invalid property with a message listing valid alternatives.
+2. **Given** a user sets a dimension type to an invalid value (e.g., "integer"), **When** the editor validates, **Then** a diagnostic appears stating the valid type options.
+3. **Given** a user references a nonexistent cube in a join, **When** the file is saved or validation runs, **Then** a semantic error from the backend appears under the join definition.
+4. **Given** a model has a missing required property (e.g., a measure without a `type`), **When** the editor validates, **Then** a warning appears indicating the missing field.
+5. **Given** the backend validation endpoint returns errors with line/column positions, **When** errors are received, **Then** they appear as Monaco markers at the correct positions in the editor.
+6. **Given** a user fixes a validation error, **When** the editor re-validates, **Then** the corresponding marker is removed.
+
+---
+
+### User Story 3 - Regenerate Smart Model from Editor Toolbar (Priority: P2)
+
+A data engineer is viewing a smart-generated model file in the editor. They click a "Regenerate" button in the editor toolbar to re-profile the source table and update the model. The existing merge strategy options (auto, merge, replace) are presented, and after regeneration, user-added content (joins, pre-aggregations, custom measures, edited descriptions) is preserved according to the chosen strategy.
+
+**Why this priority**: Re-profiling is essential as source data evolves. Placing the action in the editor toolbar (where the user is already working) removes friction. The merge behavior is the key trust factor — users must be confident their manual edits survive.
+
+**Independent Test**: Can be tested by adding custom joins/pre-aggregations to a smart-generated model, regenerating with "merge" strategy, and verifying the custom content is preserved while auto-generated fields are updated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has a smart-generated file open in the editor, **When** they look at the editor toolbar, **Then** a "Regenerate" button is visible.
+2. **Given** a user has a non-smart-generated file open, **When** they look at the editor toolbar, **Then** no "Regenerate" button is shown.
+3. **Given** a user clicks "Regenerate", **When** an existing model exists for that table, **Then** they are presented with merge strategy options (auto, merge, replace) before proceeding.
+4. **Given** a user has added custom joins and pre-aggregations to a smart-generated model, **When** they regenerate with "merge" strategy, **Then** their custom joins and pre-aggregations are preserved in the new version.
+5. **Given** a user has edited the `description` on an auto-generated dimension, **When** they regenerate with "merge" strategy, **Then** the edited description is preserved.
+6. **Given** a user regenerates with "replace" strategy, **When** the new version is created, **Then** all previous content is replaced with the fresh profile output.
+7. **Given** regeneration is in progress, **When** the user views the editor, **Then** a progress indicator is shown and the editor is not editable until complete.
+
+---
+
+### User Story 4 - Full Cube.js Spec Coverage in Completions (Priority: P2)
+
+The autocomplete covers the entire Cube.js model specification — not just basic properties, but advanced features including pre-aggregation configuration (partition granularity, refresh keys, indexes, build ranges), rollup joins/lambdas, context blocks, extends, refresh_key options, SQL_UTILS helpers, and all FILTER_PARAMS/SECURITY_CONTEXT patterns.
+
+**Why this priority**: Power users need the long tail of Cube.js features. Incomplete autocomplete forces them back to documentation, breaking flow.
+
+**Independent Test**: Can be tested by attempting to author each major Cube.js feature (pre-aggregation with partitioning, rollup_join, extends, refresh_key, SECURITY_CONTEXT) and verifying that autocomplete provides correct suggestions for each.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is inside a `pre_aggregations` block, **When** they trigger autocomplete, **Then** they see all valid pre-aggregation properties including type, measures, dimensions, time_dimension, granularity, partition_granularity, refresh_key, indexes, build_range_start, build_range_end.
+2. **Given** a user types `extends` at the cube root, **When** they trigger autocomplete for the value, **Then** they see a list of all other cube names in the branch.
+3. **Given** a user is editing a `refresh_key` block, **When** they trigger autocomplete, **Then** they see valid options (sql, every, incremental, update_window).
+4. **Given** a user types `${SQL_UTILS}` inside a sql property, **When** they trigger autocomplete after the dot, **Then** they see available SQL utility methods.
+
+---
+
+### User Story 5 - Hover Documentation (Priority: P3)
+
+A data engineer hovers over a property name, type value, or template variable in the editor and sees a tooltip with a brief description of what it does, valid values, and usage notes.
+
+**Why this priority**: Hover docs complement autocomplete by providing context without leaving the editor. Lower priority because autocomplete descriptions provide partial coverage.
+
+**Independent Test**: Can be tested by hovering over various Cube.js keywords and verifying that informative tooltips appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user hovers over a property name like `relationship`, **When** the tooltip appears, **Then** it shows a description and valid values (one_to_one, one_to_many, many_to_one).
+2. **Given** a user hovers over `${FILTER_PARAMS}`, **When** the tooltip appears, **Then** it explains FILTER_PARAMS usage with the callback syntax pattern.
+3. **Given** a user hovers over a cube reference in a join sql, **When** the tooltip appears, **Then** it shows the referenced cube's available dimensions and measures.
+
+---
+
+### Edge Cases
+
+- What happens when a model file has syntax errors so severe the parser cannot determine cursor context? Autocomplete degrades gracefully to top-level suggestions; validation shows a parse error.
+- What happens when FetchMeta fails or returns empty? Autocomplete works for schema spec properties but not for cube references; a warning is shown.
+- What happens when the backend validation endpoint is unreachable? Client-side validation still functions; semantic validation is skipped with a status indicator.
+- What happens when a user edits a file that another user has also modified? Version conflict handled by existing checksum mechanism.
+- What happens when a YAML file contains invalid YAML syntax? YAML parser catches it and shows a parse error diagnostic before any schema validation.
+- What happens when a JS model uses non-standard patterns (e.g., helper functions, imports)? Parser marks unparseable sections as unknown; no false errors emitted for code outside `cube()`/`view()` blocks.
+- What happens when a user renames a cube or adds a member in an unsaved file? The cube registry reflects the last saved state; cross-cube references won't include unsaved changes until save. This is a known v1 limitation — a workspace overlay is deferred to a future iteration.
+- What happens when inline Monaco markers show the same errors as the existing Console component? The Console continues to show branch-level compilation errors from FetchMeta. Inline markers show per-file errors from the new validation flow. Both surfaces coexist; the Console is not modified in this iteration.
+
+### Format Scope (v1)
+
+Smart generation currently outputs JS files, but the merge/reprofile pipeline (`merger.js`, `profileTable.js`) operates on YAML structures. Until a JS merge path exists:
+
+- **YAML files**: Full support — autocomplete, validation, hover, regenerate with merge
+- **JS files**: Autocomplete, hover, and backend validation (via `/api/v1/validate`). Client-side structural validation operates on parsed `cube()`/`view()` blocks only. Regenerate button is NOT shown for JS smart-generated files (the `isSmartGenerated` check must also verify the file is YAML)
+- **Future**: JS merge support and JS provenance detection are deferred
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide context-aware autocomplete suggestions in the Monaco editor for both YAML and JS Cube.js model formats.
+- **FR-002**: System MUST validate model files client-side for structural correctness (valid properties, types, required fields) and display errors as Monaco diagnostic markers.
+- **FR-003**: System MUST validate model files server-side via a backend endpoint for semantic correctness (invalid references, circular dependencies, compilation errors) and display results as Monaco diagnostic markers with correct line/column positions.
+- **FR-004**: System MUST include a "Regenerate" button in the editor toolbar that is visible only when editing smart-generated YAML model files (JS smart-generated files are excluded until JS merge support exists).
+- **FR-005**: System MUST present merge strategy options (auto, merge, replace) when regenerating a model that already exists.
+- **FR-006**: The merge strategy MUST preserve user-added content (joins, pre-aggregations, segments, custom measures/dimensions, edited descriptions) when using "merge" or "auto" strategies.
+- **FR-007**: Autocomplete MUST suggest other cube names and their members when editing join targets and sql references.
+- **FR-008**: Autocomplete MUST cover the full Cube.js model specification including pre-aggregations, refresh keys, extends, rollup joins/lambdas, context blocks, FILTER_PARAMS, SECURITY_CONTEXT, and SQL_UTILS.
+- **FR-009**: System MUST provide member scaffolding snippets (dimension, measure, join, segment, pre-aggregation) with tabstops for required fields.
+- **FR-010**: System MUST ship a static Cube.js schema spec versioned to match the backend CubeJS version, with a non-blocking warning banner displayed if the frontend spec version differs from the backend version (major or minor).
+- **FR-011**: System MUST provide hover tooltips for Cube.js property names, type values, and template variables with descriptions and valid values.
+- **FR-012**: Client-side validation MUST run on a debounced timer after edits; backend validation MUST run on file save.
+- **FR-013**: System MUST use the existing FetchMeta query as the source for the cube registry (cube names, dimensions, measures, segments) used by autocomplete. The registry reflects the last saved/compiled state; unsaved edits in dirty buffers are not reflected until save.
+- **FR-015**: System MUST fix the existing language detection bug in CodeEditor (currently splits filename on `.` taking the first segment instead of the extension) as a prerequisite for Monaco language provider registration.
+- **FR-014**: The cube registry MUST refresh after saving a file, after smart regeneration, and on initial editor load.
+
+### Key Entities
+
+- **Schema Spec**: A structured definition of all valid Cube.js model properties, their types, nesting rules, descriptions, and allowed values. Versioned to the CubeJS backend version.
+- **Cube Registry**: A runtime cache of all cubes and their members in the current branch, populated from FetchMeta. Used for cross-cube reference suggestions and validation.
+- **Parsed Document**: A format-agnostic representation of a model file (cubes, members, properties with source positions) produced by either the YAML or JS parser.
+- **Cursor Context**: The semantic location of the cursor within the document tree (e.g., "inside a measure's type property of the events cube"), used to determine what completions to offer.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Autocomplete suggestions appear within 100ms of trigger in both YAML and JS formats.
+- **SC-002**: Client-side validation errors appear within 500ms of the user stopping typing.
+- **SC-003**: Backend validation results appear within 3 seconds of saving a file.
+- **SC-004**: Users can author a complete join between two cubes (including sql reference) using only autocomplete suggestions and tab navigation, without typing cube or member names manually.
+- **SC-005**: Smart model regeneration with "merge" strategy preserves 100% of user-added content (joins, pre-aggregations, segments, custom members, edited descriptions).
+- **SC-006**: The schema spec covers all Cube.js model properties documented in the official Cube.js v1.6 specification.
+- **SC-007**: Zero false-positive validation errors on valid Cube.js model files (no red squiggles on correct code). For JS files, client-side validation only covers parsed `cube()`/`view()` blocks; code outside these blocks is not validated and must not produce false markers.
+
+## Assumptions
+
+- The existing FetchMeta GraphQL query returns sufficient metadata (cube names, member names, member types) for autocomplete purposes.
+- The CubeJS compiler can be invoked programmatically to validate a set of model files and return structured errors with source positions.
+- Monaco editor's language service APIs (CompletionItemProvider, DiagnosticProvider, HoverProvider) support the registration model needed for both YAML and JS simultaneously.
+- The current smart generation merge logic correctly preserves user content — this will be verified through testing rather than reimplemented.
+- Users are comfortable with the existing 5-step smart generation wizard for initial model creation; only the re-profile/regenerate flow is being streamlined.

--- a/specs/006-model-authoring/tasks.md
+++ b/specs/006-model-authoring/tasks.md
@@ -25,10 +25,10 @@
 
 **Purpose**: Create the language service module structure and install dependencies
 
-- [ ] T001 Create the `cubejs-language` directory structure at `../client-v2/src/utils/cubejs-language/`
-- [ ] T002 Add `yaml` ^2.3.4 dependency to `../client-v2/package.json` and install
-- [ ] T003 Create shared types file at `../client-v2/src/utils/cubejs-language/types.ts` defining ParsedDocument, ParsedCube, ParsedView, ParsedMember, ParsedProperty, CursorContext, MonacoRange, CubeRegistryEntry, MemberEntry, ValidationError, and PropertySpec interfaces per data-model.md
-- [ ] T038 [PREREQUISITE] Fix language detection bug in `../client-v2/src/components/CodeEditor/index.tsx` — change `active.split(".")[0]` (line 128) to extract the file extension (last segment after final dot), not the basename. Current code maps `semantic_events.js` → `"semantic_events"` → undefined instead of `"js"` → `"javascript"`. Without this fix, Monaco language providers registered for 'yaml'/'javascript' will not attach. (FR-015)
+- [x] T001 Create the `cubejs-language` directory structure at `../client-v2/src/utils/cubejs-language/`
+- [x] T002 Add `yaml` ^2.3.4 dependency to `../client-v2/package.json` and install
+- [x] T003 Create shared types file at `../client-v2/src/utils/cubejs-language/types.ts` defining ParsedDocument, ParsedCube, ParsedView, ParsedMember, ParsedProperty, CursorContext, MonacoRange, CubeRegistryEntry, MemberEntry, ValidationError, and PropertySpec interfaces per data-model.md
+- [x] T038 [PREREQUISITE] Fix language detection bug in `../client-v2/src/components/CodeEditor/index.tsx` — change `active.split(".")[0]` (line 128) to extract the file extension (last segment after final dot), not the basename. Current code maps `semantic_events.js` → `"semantic_events"` → undefined instead of `"js"` → `"javascript"`. Without this fix, Monaco language providers registered for 'yaml'/'javascript' will not attach. (FR-015)
 
 ---
 
@@ -40,23 +40,23 @@
 
 ### Schema Spec
 
-- [ ] T004 Write failing unit tests for the Cube.js schema spec at `../client-v2/src/utils/cubejs-language/__tests__/spec.test.ts` — verify cube top-level properties, dimension types, measure types, join relationships, pre-aggregation types, refresh_key forms, view properties, and YAML↔JS key mappings all match CubeValidator.js (v1.6.19)
-- [ ] T005 Create the static Cube.js schema spec at `../client-v2/src/utils/cubejs-language/spec.ts` — define all constructs (cube, view), all member types (dimensions, measures, joins, segments, pre_aggregations), all property definitions with types/enums/descriptions/required flags, all template variables (CUBE, FILTER_PARAMS, SECURITY_CONTEXT, SQL_UTILS, COMPILE_CONTEXT), YAML↔JS key mappings, and `CUBEJS_SPEC_VERSION = "1.6.19"` constant. Full coverage per research.md Section 2.
+- [x] T004 Write failing unit tests for the Cube.js schema spec at `../client-v2/src/utils/cubejs-language/__tests__/spec.test.ts` — verify cube top-level properties, dimension types, measure types, join relationships, pre-aggregation types, refresh_key forms, view properties, and YAML↔JS key mappings all match CubeValidator.js (v1.6.19)
+- [x] T005 Create the static Cube.js schema spec at `../client-v2/src/utils/cubejs-language/spec.ts` — define all constructs (cube, view), all member types (dimensions, measures, joins, segments, pre_aggregations), all property definitions with types/enums/descriptions/required flags, all template variables (CUBE, FILTER_PARAMS, SECURITY_CONTEXT, SQL_UTILS, COMPILE_CONTEXT), YAML↔JS key mappings, and `CUBEJS_SPEC_VERSION = "1.6.19"` constant. Full coverage per research.md Section 2.
 
 ### YAML Parser
 
-- [ ] T006 [P] Write failing unit tests for the YAML parser at `../client-v2/src/utils/cubejs-language/__tests__/yamlParser.test.ts` — test parsing cubes/views from YAML, source position tracking for properties and members, getCursorContext at various positions (cube_root, member_list, member_body, property_value, sql), and graceful handling of invalid YAML
-- [ ] T007 [P] Implement the YAML parser at `../client-v2/src/utils/cubejs-language/yamlParser.ts` — use `yaml` package with `keepSourceTokens: true`, parse YAML into ParsedDocument with cubes/views/errors, map YAML structure to normalized model with MonacoRange positions, implement `getCursorContext(position)` returning CursorContext union type
+- [x] T006 [P] Write failing unit tests for the YAML parser at `../client-v2/src/utils/cubejs-language/__tests__/yamlParser.test.ts` — test parsing cubes/views from YAML, source position tracking for properties and members, getCursorContext at various positions (cube_root, member_list, member_body, property_value, sql), and graceful handling of invalid YAML
+- [x] T007 [P] Implement the YAML parser at `../client-v2/src/utils/cubejs-language/yamlParser.ts` — use `yaml` package with `keepSourceTokens: true`, parse YAML into ParsedDocument with cubes/views/errors, map YAML structure to normalized model with MonacoRange positions, implement `getCursorContext(position)` returning CursorContext union type
 
 ### JS Parser
 
-- [ ] T008 [P] Write failing unit tests for the JS parser at `../client-v2/src/utils/cubejs-language/__tests__/jsParser.test.ts` — test parsing `cube()` and `view()` calls, brace-matching for object extraction, property/member position tracking, template literal detection (${CUBE}, ${FILTER_PARAMS...}), getCursorContext at various positions, and graceful handling of unparseable sections
-- [ ] T009 [P] Implement the JS parser at `../client-v2/src/utils/cubejs-language/jsParser.ts` — find `cube(`/`view(` call sites via regex, extract object literals via brace matching, parse properties with position tracking, detect template variable references in sql strings, implement `getCursorContext(position)` matching the same CursorContext type as YAML parser
+- [x] T008 [P] Write failing unit tests for the JS parser at `../client-v2/src/utils/cubejs-language/__tests__/jsParser.test.ts` — test parsing `cube()` and `view()` calls, brace-matching for object extraction, property/member position tracking, template literal detection (${CUBE}, ${FILTER_PARAMS...}), getCursorContext at various positions, and graceful handling of unparseable sections
+- [x] T009 [P] Implement the JS parser at `../client-v2/src/utils/cubejs-language/jsParser.ts` — find `cube(`/`view(` call sites via regex, extract object literals via brace matching, parse properties with position tracking, detect template variable references in sql strings, implement `getCursorContext(position)` matching the same CursorContext type as YAML parser
 
 ### Cube Registry
 
-- [ ] T010 Write failing unit tests for the cube registry at `../client-v2/src/utils/cubejs-language/__tests__/registry.test.ts` — test populating from FetchMeta response, looking up cubes by name, getting members by type, refreshing on demand, and error state handling
-- [ ] T011 Implement the cube registry at `../client-v2/src/utils/cubejs-language/registry.ts` — wraps FetchMeta query result, stores CubeRegistryEntry[] with name/dimensions/measures/segments, provides lookup methods (getCube, getAllCubeNames, getMembersByType), exposes refresh() method, handles loading/ready/error states
+- [x] T010 Write failing unit tests for the cube registry at `../client-v2/src/utils/cubejs-language/__tests__/registry.test.ts` — test populating from FetchMeta response, looking up cubes by name, getting members by type, refreshing on demand, and error state handling
+- [x] T011 Implement the cube registry at `../client-v2/src/utils/cubejs-language/registry.ts` — wraps FetchMeta query result, stores CubeRegistryEntry[] with name/dimensions/measures/segments, provides lookup methods (getCube, getAllCubeNames, getMembersByType), exposes refresh() method, handles loading/ready/error states
 
 **Checkpoint**: Foundation ready — schema spec, both parsers, and cube registry are tested and working. User story implementation can begin.
 
@@ -70,12 +70,12 @@
 
 ### Tests for User Story 1
 
-- [ ] T012 [P] [US1] Write failing unit tests for the completion provider at `../client-v2/src/utils/cubejs-language/__tests__/completionProvider.test.ts` — test suggestions for: cube_root (top-level keys), member_list (skeleton snippets), member_body (valid properties per member type), property_value for type enums (dimension types, measure types, relationship values), sql context (${CUBE}, template variables), join sql (cube names + member references from registry), extends (cube names), drill_members (current cube members), and YAML vs JS format differences
+- [x] T012 [P] [US1] Write failing unit tests for the completion provider at `../client-v2/src/utils/cubejs-language/__tests__/completionProvider.test.ts` — test suggestions for: cube_root (top-level keys), member_list (skeleton snippets), member_body (valid properties per member type), property_value for type enums (dimension types, measure types, relationship values), sql context (${CUBE}, template variables), join sql (cube names + member references from registry), extends (cube names), drill_members (current cube members), and YAML vs JS format differences
 
 ### Implementation for User Story 1
 
-- [ ] T013 [US1] Implement the completion provider at `../client-v2/src/utils/cubejs-language/completionProvider.ts` — register with Monaco for both 'yaml' and 'javascript' languages, set triggerCharacters ['.', '$', ':'], implement provideCompletionItems using getCursorContext → schema spec + cube registry lookup, generate CompletionItems with correct kind/sortText/documentation/range, use InsertAsSnippet for member scaffolding (dimension, measure, join, segment, pre-aggregation snippets with tabstops and choice dropdowns for type enums)
-- [ ] T014 [US1] Integrate the completion provider into the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — import and register the completion provider on editor mount, pass the cube registry instance, dispose on unmount, ensure the registry is populated from FetchMeta on mount
+- [x] T013 [US1] Implement the completion provider at `../client-v2/src/utils/cubejs-language/completionProvider.ts` — register with Monaco for both 'yaml' and 'javascript' languages, set triggerCharacters ['.', '$', ':'], implement provideCompletionItems using getCursorContext → schema spec + cube registry lookup, generate CompletionItems with correct kind/sortText/documentation/range, use InsertAsSnippet for member scaffolding (dimension, measure, join, segment, pre-aggregation snippets with tabstops and choice dropdowns for type enums)
+- [x] T014 [US1] Integrate the completion provider into the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — import and register the completion provider on editor mount, pass the cube registry instance, dispose on unmount, ensure the registry is populated from FetchMeta on mount
 
 **Checkpoint**: Autocomplete works in both YAML and JS. Users can scaffold members, get type suggestions, and reference other cubes in joins.
 
@@ -89,16 +89,16 @@
 
 ### Tests for User Story 2
 
-- [ ] T015 [P] [US2] Write failing unit tests for the diagnostic provider at `../client-v2/src/utils/cubejs-language/__tests__/diagnosticProvider.test.ts` — test client-side validation: invalid property names produce error markers, invalid type values produce error markers, missing required properties produce warning markers, deprecated properties produce warning markers; test backend result mapping: ValidationError[] converted to IMarkerData[] with correct severity/position; test marker lifecycle: markers cleared when errors are fixed, client and backend markers merged correctly
-- [ ] T016 [P] [US2] Write failing StepCI integration test for the validate endpoint at `tests/stepci/validate_flow.yml` (StepCI tests live under `tests/stepci/`, not `tests/workflows/`) — test valid files return `{ valid: true, errors: [], warnings: [] }`, test file with invalid property returns error with fileName/line/column, test file referencing nonexistent cube in join returns semantic error, test request without auth returns 401
+- [x] T015 [P] [US2] Write failing unit tests for the diagnostic provider at `../client-v2/src/utils/cubejs-language/__tests__/diagnosticProvider.test.ts` — test client-side validation: invalid property names produce error markers, invalid type values produce error markers, missing required properties produce warning markers, deprecated properties produce warning markers; test backend result mapping: ValidationError[] converted to IMarkerData[] with correct severity/position; test marker lifecycle: markers cleared when errors are fixed, client and backend markers merged correctly
+- [x] T016 [P] [US2] Write failing StepCI integration test for the validate endpoint at `tests/stepci/validate_flow.yml` (StepCI tests live under `tests/stepci/`, not `tests/workflows/`) — test valid files return `{ valid: true, errors: [], warnings: [] }`, test file with invalid property returns error with fileName/line/column, test file referencing nonexistent cube in join returns semantic error, test request without auth returns 401
 
 ### Implementation for User Story 2
 
-- [ ] T017 [US2] Implement the validate route at `services/cubejs/src/routes/validate.js` — accept POST with `{ files: [{ fileName, content }] }`, create in-memory SchemaFileRepository, call `prepareCompiler(repo)` then `compiler.compile()`, collect errors from `compiler.errorReport.getErrors()` and `.getWarnings()`, map CompilerErrorInterface/SyntaxErrorInterface to response format with severity/message/fileName/startLine/startColumn/endLine/endColumn, return `{ valid, errors, warnings }`
-- [ ] T018 [US2] Implement the version route at `services/cubejs/src/routes/version.js` — read `@cubejs-backend/schema-compiler` package version at startup, return `{ version }` on GET
-- [ ] T019 [US2] Register validate and version routes in `services/cubejs/src/routes/index.js` — add `POST /api/v1/validate` and `GET /api/v1/version` with `checkAuthMiddleware`
-- [ ] T020 [US2] Implement the diagnostic provider at `../client-v2/src/utils/cubejs-language/diagnosticProvider.ts` — client-side: listen to `editor.onDidChangeModelContent`, debounce 300ms, parse document, validate property names/types/required fields against schema spec, call `monaco.editor.setModelMarkers` with owner 'cubejs-client'; backend: on file save, POST all current version files to `/api/v1/validate`, map response errors to IMarkerData, call `setModelMarkers` with owner 'cubejs-backend'; merge: both owners coexist, Monaco shows markers from both
-- [ ] T021 [US2] Integrate the diagnostic provider into the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — initialize diagnostic provider on editor mount, connect to save handler to trigger backend validation and cube registry refresh (FR-014: registry must refresh after saving a file), add version check on mount (GET /api/v1/version, compare with CUBEJS_SPEC_VERSION, show warning banner if mismatch), dispose on unmount
+- [x] T017 [US2] Implement the validate route at `services/cubejs/src/routes/validate.js` — accept POST with `{ files: [{ fileName, content }] }`, create in-memory SchemaFileRepository, call `prepareCompiler(repo)` then `compiler.compile()`, collect errors from `compiler.errorReport.getErrors()` and `.getWarnings()`, map CompilerErrorInterface/SyntaxErrorInterface to response format with severity/message/fileName/startLine/startColumn/endLine/endColumn, return `{ valid, errors, warnings }`
+- [x] T018 [US2] Implement the version route at `services/cubejs/src/routes/version.js` — read `@cubejs-backend/schema-compiler` package version at startup, return `{ version }` on GET
+- [x] T019 [US2] Register validate and version routes in `services/cubejs/src/routes/index.js` — add `POST /api/v1/validate` and `GET /api/v1/version` with `checkAuthMiddleware`
+- [x] T020 [US2] Implement the diagnostic provider at `../client-v2/src/utils/cubejs-language/diagnosticProvider.ts` — client-side: listen to `editor.onDidChangeModelContent`, debounce 300ms, parse document, validate property names/types/required fields against schema spec, call `monaco.editor.setModelMarkers` with owner 'cubejs-client'; backend: on file save, POST all current version files to `/api/v1/validate`, map response errors to IMarkerData, call `setModelMarkers` with owner 'cubejs-backend'; merge: both owners coexist, Monaco shows markers from both
+- [x] T021 [US2] Integrate the diagnostic provider into the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — initialize diagnostic provider on editor mount, connect to save handler to trigger backend validation and cube registry refresh (FR-014: registry must refresh after saving a file), add version check on mount (GET /api/v1/version, compare with CUBEJS_SPEC_VERSION, show warning banner if mismatch), dispose on unmount
 
 **Checkpoint**: Typing errors get instant red squiggles. Saving triggers deep validation. Both YAML and JS files validated correctly.
 
@@ -112,12 +112,12 @@
 
 ### Tests for User Story 3
 
-- [ ] T022 [P] [US3] Write failing integration test for merge preservation at `../client-v2/src/utils/cubejs-language/__tests__/mergePreservation.test.ts` — test that a smart-generated model with user-added joins, pre_aggregations, segments, custom dimensions, and edited descriptions survives regeneration with merge strategy; test that replace strategy replaces everything; test that auto strategy detects user content and selects merge
+- [x] T022 [P] [US3] Write failing integration test for merge preservation at `../client-v2/src/utils/cubejs-language/__tests__/mergePreservation.test.ts` — test that a smart-generated model with user-added joins, pre_aggregations, segments, custom dimensions, and edited descriptions survives regeneration with merge strategy; test that replace strategy replaces everything; test that auto strategy detects user content and selects merge
 
 ### Implementation for User Story 3
 
-- [ ] T023 [US3] Add "Regenerate" toolbar button to the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — detect smart-generated YAML files using `isSmartGenerated()` from `provenanceParser.ts` AND verifying the file extension is `.yml`/`.yaml` (JS smart-generated files are excluded per FR-004 — merger.js and profileTable.js only support YAML), show/hide button conditionally, extract source_table and source_database from provenance metadata
-- [ ] T024 [US3] Implement the regenerate flow UI at `../client-v2/src/components/CodeEditor/RegenerateModal.tsx` — modal with merge strategy radio group (Auto recommended, Merge, Replace), progress indicator during regeneration, call SmartGenDataSchemas mutation with selected strategy, refresh editor content and cube registry on completion, disable editor during regeneration
+- [x] T023 [US3] Add "Regenerate" toolbar button to the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — detect smart-generated YAML files using `isSmartGenerated()` from `provenanceParser.ts` AND verifying the file extension is `.yml`/`.yaml` (JS smart-generated files are excluded per FR-004 — merger.js and profileTable.js only support YAML), show/hide button conditionally, extract source_table and source_database from provenance metadata
+- [x] T024 [US3] Implement the regenerate flow UI at `../client-v2/src/components/CodeEditor/RegenerateModal.tsx` — modal with merge strategy radio group (Auto recommended, Merge, Replace), progress indicator during regeneration, call SmartGenDataSchemas mutation with selected strategy, refresh editor content and cube registry on completion, disable editor during regeneration
 
 **Checkpoint**: Users can regenerate smart models from the toolbar. Merge strategy preserves user content.
 
@@ -131,12 +131,12 @@
 
 ### Tests for User Story 4
 
-- [ ] T025 [P] [US4] Write failing unit tests for advanced completions at `../client-v2/src/utils/cubejs-language/__tests__/advancedCompletions.test.ts` — test: pre_aggregation properties (partition_granularity, refresh_key, indexes, build_range_start/end, rollup_join, rollup_lambda), refresh_key sub-properties (sql, every, incremental, update_window, immutable), view cubes/includes/excludes, access_policy structure, hierarchies, granularities for time dimensions, rolling_window options, multi-stage measure properties, FILTER_PARAMS callback syntax, SECURITY_CONTEXT.key.unsafeValue(), SQL_UTILS methods, COMPILE_CONTEXT
+- [x] T025 [P] [US4] Write failing unit tests for advanced completions at `../client-v2/src/utils/cubejs-language/__tests__/advancedCompletions.test.ts` — test: pre_aggregation properties (partition_granularity, refresh_key, indexes, build_range_start/end, rollup_join, rollup_lambda), refresh_key sub-properties (sql, every, incremental, update_window, immutable), view cubes/includes/excludes, access_policy structure, hierarchies, granularities for time dimensions, rolling_window options, multi-stage measure properties, FILTER_PARAMS callback syntax, SECURITY_CONTEXT.key.unsafeValue(), SQL_UTILS methods, COMPILE_CONTEXT
 
 ### Implementation for User Story 4
 
-- [ ] T026 [US4] Extend the completion provider at `../client-v2/src/utils/cubejs-language/completionProvider.ts` — add context cases for: pre_aggregation member_body (all type-specific properties), refresh_key nested properties, view cubes/includes/excludes, access_policy/member_level/row_level, hierarchies/levels, granularities (standard + custom), rolling_window (fixed vs to_date types), all FILTER_PARAMS/SECURITY_CONTEXT/SQL_UTILS/COMPILE_CONTEXT template completions with proper callback syntax snippets
-- [ ] T027 [US4] Extend client-side validation at `../client-v2/src/utils/cubejs-language/diagnosticProvider.ts` — validate pre-aggregation type-specific required properties (e.g., rollups required for rollup_join), validate refresh_key mutual exclusivity (every+sql vs immutable), validate view cubes array structure, warn on deprecated properties (shown, visible, refresh_range_start/end)
+- [x] T026 [US4] Extend the completion provider at `../client-v2/src/utils/cubejs-language/completionProvider.ts` — add context cases for: pre_aggregation member_body (all type-specific properties), refresh_key nested properties, view cubes/includes/excludes, access_policy/member_level/row_level, hierarchies/levels, granularities (standard + custom), rolling_window (fixed vs to_date types), all FILTER_PARAMS/SECURITY_CONTEXT/SQL_UTILS/COMPILE_CONTEXT template completions with proper callback syntax snippets
+- [x] T027 [US4] Extend client-side validation at `../client-v2/src/utils/cubejs-language/diagnosticProvider.ts` — validate pre-aggregation type-specific required properties (e.g., rollups required for rollup_join), validate refresh_key mutual exclusivity (every+sql vs immutable), validate view cubes array structure, warn on deprecated properties (shown, visible, refresh_range_start/end)
 
 **Checkpoint**: Full Cube.js spec autocomplete — every property in CubeValidator.js has a completion and validation rule.
 
@@ -150,12 +150,12 @@
 
 ### Tests for User Story 5
 
-- [ ] T028 [P] [US5] Write failing unit tests for the hover provider at `../client-v2/src/utils/cubejs-language/__tests__/hoverProvider.test.ts` — test: hovering property names shows description + valid values, hovering type values shows what they mean, hovering template variables shows usage syntax, hovering cube references in join sql shows that cube's members, hovering deprecated properties shows replacement
+- [x] T028 [P] [US5] Write failing unit tests for the hover provider at `../client-v2/src/utils/cubejs-language/__tests__/hoverProvider.test.ts` — test: hovering property names shows description + valid values, hovering type values shows what they mean, hovering template variables shows usage syntax, hovering cube references in join sql shows that cube's members, hovering deprecated properties shows replacement
 
 ### Implementation for User Story 5
 
-- [ ] T029 [US5] Implement the hover provider at `../client-v2/src/utils/cubejs-language/hoverProvider.ts` — register with Monaco for both 'yaml' and 'javascript', use getCursorContext + word detection to find what's under cursor, look up PropertySpec from schema spec for descriptions, look up CubeRegistryEntry for cube references, return Hover with markdown contents (bold name, description, valid values as code block, usage example for template variables)
-- [ ] T030 [US5] Register the hover provider in the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — import and register on editor mount, pass schema spec and cube registry instances, dispose on unmount
+- [x] T029 [US5] Implement the hover provider at `../client-v2/src/utils/cubejs-language/hoverProvider.ts` — register with Monaco for both 'yaml' and 'javascript', use getCursorContext + word detection to find what's under cursor, look up PropertySpec from schema spec for descriptions, look up CubeRegistryEntry for cube references, return Hover with markdown contents (bold name, description, valid values as code block, usage example for template variables)
+- [x] T030 [US5] Register the hover provider in the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — import and register on editor mount, pass schema spec and cube registry instances, dispose on unmount
 
 **Checkpoint**: Hovering any Cube.js keyword shows helpful documentation inline.
 
@@ -165,12 +165,12 @@
 
 **Purpose**: Improvements that affect multiple user stories
 
-- [ ] T031 [P] Run `yarn codegen` in client-v2 if any GraphQL queries were modified
-- [ ] T036 [P] Validate zero false positives: create a test in `../client-v2/src/utils/cubejs-language/__tests__/diagnosticProvider.test.ts` that runs client-side validation against 3+ known-valid Cube.js model files (YAML and JS) and asserts zero error markers are produced (SC-007)
+- [x] T031 [P] Run `yarn codegen` in client-v2 if any GraphQL queries were modified — N/A, no .gql files changed
+- [x] T036 [P] Validate zero false positives: create a test in `../client-v2/src/utils/cubejs-language/__tests__/diagnosticProvider.test.ts` that runs client-side validation against 3+ known-valid Cube.js model files (YAML and JS) and asserts zero error markers are produced (SC-007)
 - [ ] T037 [P] Manual smoke test for SC-004: in the Models IDE, author a complete join between two cubes using only autocomplete suggestions and tab navigation — verify no manual typing of cube or member names is required
-- [ ] T032 [P] Run `yarn lint` in client-v2 and fix any lint errors in new files
-- [ ] T033 Verify all StepCI tests pass (`./cli.sh tests stepci`)
-- [ ] T034 Run full client-v2 test suite (`cd ../client-v2 && yarn test`)
+- [x] T032 [P] Run `yarn lint` in client-v2 and fix any lint errors in new files
+- [ ] T033 Verify all StepCI tests pass (`./cli.sh tests stepci`) — requires Docker services running
+- [x] T034 Run full client-v2 test suite (`cd ../client-v2 && yarn test`) — 58 passed, 1 pre-existing failure (VirtualTable unrelated)
 - [ ] T035 Manual smoke test: open Models IDE, test autocomplete in YAML file, test autocomplete in JS file, test validation errors, test regenerate button, test hover tooltips
 
 ---

--- a/specs/006-model-authoring/tasks.md
+++ b/specs/006-model-authoring/tasks.md
@@ -1,0 +1,282 @@
+# Tasks: Model Authoring Improvements
+
+**Input**: Design documents from `/specs/006-model-authoring/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included per constitution (Principle III: Test-Driven Development is NON-NEGOTIABLE).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend**: `services/cubejs/src/` (CubeJS service)
+- **Frontend**: `../client-v2/src/` (client-v2 app)
+- **Tests**: `tests/` (StepCI integration), `../client-v2/` (Vitest unit)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the language service module structure and install dependencies
+
+- [ ] T001 Create the `cubejs-language` directory structure at `../client-v2/src/utils/cubejs-language/`
+- [ ] T002 Add `yaml` ^2.3.4 dependency to `../client-v2/package.json` and install
+- [ ] T003 Create shared types file at `../client-v2/src/utils/cubejs-language/types.ts` defining ParsedDocument, ParsedCube, ParsedView, ParsedMember, ParsedProperty, CursorContext, MonacoRange, CubeRegistryEntry, MemberEntry, ValidationError, and PropertySpec interfaces per data-model.md
+- [ ] T038 [PREREQUISITE] Fix language detection bug in `../client-v2/src/components/CodeEditor/index.tsx` — change `active.split(".")[0]` (line 128) to extract the file extension (last segment after final dot), not the basename. Current code maps `semantic_events.js` → `"semantic_events"` → undefined instead of `"js"` → `"javascript"`. Without this fix, Monaco language providers registered for 'yaml'/'javascript' will not attach. (FR-015)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Schema spec and parsers that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+### Schema Spec
+
+- [ ] T004 Write failing unit tests for the Cube.js schema spec at `../client-v2/src/utils/cubejs-language/__tests__/spec.test.ts` — verify cube top-level properties, dimension types, measure types, join relationships, pre-aggregation types, refresh_key forms, view properties, and YAML↔JS key mappings all match CubeValidator.js (v1.6.19)
+- [ ] T005 Create the static Cube.js schema spec at `../client-v2/src/utils/cubejs-language/spec.ts` — define all constructs (cube, view), all member types (dimensions, measures, joins, segments, pre_aggregations), all property definitions with types/enums/descriptions/required flags, all template variables (CUBE, FILTER_PARAMS, SECURITY_CONTEXT, SQL_UTILS, COMPILE_CONTEXT), YAML↔JS key mappings, and `CUBEJS_SPEC_VERSION = "1.6.19"` constant. Full coverage per research.md Section 2.
+
+### YAML Parser
+
+- [ ] T006 [P] Write failing unit tests for the YAML parser at `../client-v2/src/utils/cubejs-language/__tests__/yamlParser.test.ts` — test parsing cubes/views from YAML, source position tracking for properties and members, getCursorContext at various positions (cube_root, member_list, member_body, property_value, sql), and graceful handling of invalid YAML
+- [ ] T007 [P] Implement the YAML parser at `../client-v2/src/utils/cubejs-language/yamlParser.ts` — use `yaml` package with `keepSourceTokens: true`, parse YAML into ParsedDocument with cubes/views/errors, map YAML structure to normalized model with MonacoRange positions, implement `getCursorContext(position)` returning CursorContext union type
+
+### JS Parser
+
+- [ ] T008 [P] Write failing unit tests for the JS parser at `../client-v2/src/utils/cubejs-language/__tests__/jsParser.test.ts` — test parsing `cube()` and `view()` calls, brace-matching for object extraction, property/member position tracking, template literal detection (${CUBE}, ${FILTER_PARAMS...}), getCursorContext at various positions, and graceful handling of unparseable sections
+- [ ] T009 [P] Implement the JS parser at `../client-v2/src/utils/cubejs-language/jsParser.ts` — find `cube(`/`view(` call sites via regex, extract object literals via brace matching, parse properties with position tracking, detect template variable references in sql strings, implement `getCursorContext(position)` matching the same CursorContext type as YAML parser
+
+### Cube Registry
+
+- [ ] T010 Write failing unit tests for the cube registry at `../client-v2/src/utils/cubejs-language/__tests__/registry.test.ts` — test populating from FetchMeta response, looking up cubes by name, getting members by type, refreshing on demand, and error state handling
+- [ ] T011 Implement the cube registry at `../client-v2/src/utils/cubejs-language/registry.ts` — wraps FetchMeta query result, stores CubeRegistryEntry[] with name/dimensions/measures/segments, provides lookup methods (getCube, getAllCubeNames, getMembersByType), exposes refresh() method, handles loading/ready/error states
+
+**Checkpoint**: Foundation ready — schema spec, both parsers, and cube registry are tested and working. User story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Autocomplete While Editing Models (Priority: P1) MVP
+
+**Goal**: Context-aware autocomplete in Monaco for both YAML and JS Cube.js model formats
+
+**Independent Test**: Open any model file, trigger autocomplete at various positions, verify correct context-sensitive suggestions appear
+
+### Tests for User Story 1
+
+- [ ] T012 [P] [US1] Write failing unit tests for the completion provider at `../client-v2/src/utils/cubejs-language/__tests__/completionProvider.test.ts` — test suggestions for: cube_root (top-level keys), member_list (skeleton snippets), member_body (valid properties per member type), property_value for type enums (dimension types, measure types, relationship values), sql context (${CUBE}, template variables), join sql (cube names + member references from registry), extends (cube names), drill_members (current cube members), and YAML vs JS format differences
+
+### Implementation for User Story 1
+
+- [ ] T013 [US1] Implement the completion provider at `../client-v2/src/utils/cubejs-language/completionProvider.ts` — register with Monaco for both 'yaml' and 'javascript' languages, set triggerCharacters ['.', '$', ':'], implement provideCompletionItems using getCursorContext → schema spec + cube registry lookup, generate CompletionItems with correct kind/sortText/documentation/range, use InsertAsSnippet for member scaffolding (dimension, measure, join, segment, pre-aggregation snippets with tabstops and choice dropdowns for type enums)
+- [ ] T014 [US1] Integrate the completion provider into the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — import and register the completion provider on editor mount, pass the cube registry instance, dispose on unmount, ensure the registry is populated from FetchMeta on mount
+
+**Checkpoint**: Autocomplete works in both YAML and JS. Users can scaffold members, get type suggestions, and reference other cubes in joins.
+
+---
+
+## Phase 4: User Story 2 — Real-Time Validation with Inline Errors (Priority: P1)
+
+**Goal**: Client-side structural validation (instant) and backend semantic validation (on save) with Monaco markers
+
+**Independent Test**: Introduce known errors (invalid property, wrong type value, nonexistent cube reference), verify red squiggles appear at correct positions
+
+### Tests for User Story 2
+
+- [ ] T015 [P] [US2] Write failing unit tests for the diagnostic provider at `../client-v2/src/utils/cubejs-language/__tests__/diagnosticProvider.test.ts` — test client-side validation: invalid property names produce error markers, invalid type values produce error markers, missing required properties produce warning markers, deprecated properties produce warning markers; test backend result mapping: ValidationError[] converted to IMarkerData[] with correct severity/position; test marker lifecycle: markers cleared when errors are fixed, client and backend markers merged correctly
+- [ ] T016 [P] [US2] Write failing StepCI integration test for the validate endpoint at `tests/stepci/validate_flow.yml` (StepCI tests live under `tests/stepci/`, not `tests/workflows/`) — test valid files return `{ valid: true, errors: [], warnings: [] }`, test file with invalid property returns error with fileName/line/column, test file referencing nonexistent cube in join returns semantic error, test request without auth returns 401
+
+### Implementation for User Story 2
+
+- [ ] T017 [US2] Implement the validate route at `services/cubejs/src/routes/validate.js` — accept POST with `{ files: [{ fileName, content }] }`, create in-memory SchemaFileRepository, call `prepareCompiler(repo)` then `compiler.compile()`, collect errors from `compiler.errorReport.getErrors()` and `.getWarnings()`, map CompilerErrorInterface/SyntaxErrorInterface to response format with severity/message/fileName/startLine/startColumn/endLine/endColumn, return `{ valid, errors, warnings }`
+- [ ] T018 [US2] Implement the version route at `services/cubejs/src/routes/version.js` — read `@cubejs-backend/schema-compiler` package version at startup, return `{ version }` on GET
+- [ ] T019 [US2] Register validate and version routes in `services/cubejs/src/routes/index.js` — add `POST /api/v1/validate` and `GET /api/v1/version` with `checkAuthMiddleware`
+- [ ] T020 [US2] Implement the diagnostic provider at `../client-v2/src/utils/cubejs-language/diagnosticProvider.ts` — client-side: listen to `editor.onDidChangeModelContent`, debounce 300ms, parse document, validate property names/types/required fields against schema spec, call `monaco.editor.setModelMarkers` with owner 'cubejs-client'; backend: on file save, POST all current version files to `/api/v1/validate`, map response errors to IMarkerData, call `setModelMarkers` with owner 'cubejs-backend'; merge: both owners coexist, Monaco shows markers from both
+- [ ] T021 [US2] Integrate the diagnostic provider into the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — initialize diagnostic provider on editor mount, connect to save handler to trigger backend validation and cube registry refresh (FR-014: registry must refresh after saving a file), add version check on mount (GET /api/v1/version, compare with CUBEJS_SPEC_VERSION, show warning banner if mismatch), dispose on unmount
+
+**Checkpoint**: Typing errors get instant red squiggles. Saving triggers deep validation. Both YAML and JS files validated correctly.
+
+---
+
+## Phase 5: User Story 3 — Regenerate Smart Model from Editor Toolbar (Priority: P2)
+
+**Goal**: "Regenerate" button in editor toolbar for smart-generated files, with merge strategy selection and verified user-content preservation
+
+**Independent Test**: Add custom joins to a smart-generated model, click Regenerate with merge strategy, verify joins are preserved
+
+### Tests for User Story 3
+
+- [ ] T022 [P] [US3] Write failing integration test for merge preservation at `../client-v2/src/utils/cubejs-language/__tests__/mergePreservation.test.ts` — test that a smart-generated model with user-added joins, pre_aggregations, segments, custom dimensions, and edited descriptions survives regeneration with merge strategy; test that replace strategy replaces everything; test that auto strategy detects user content and selects merge
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Add "Regenerate" toolbar button to the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — detect smart-generated YAML files using `isSmartGenerated()` from `provenanceParser.ts` AND verifying the file extension is `.yml`/`.yaml` (JS smart-generated files are excluded per FR-004 — merger.js and profileTable.js only support YAML), show/hide button conditionally, extract source_table and source_database from provenance metadata
+- [ ] T024 [US3] Implement the regenerate flow UI at `../client-v2/src/components/CodeEditor/RegenerateModal.tsx` — modal with merge strategy radio group (Auto recommended, Merge, Replace), progress indicator during regeneration, call SmartGenDataSchemas mutation with selected strategy, refresh editor content and cube registry on completion, disable editor during regeneration
+
+**Checkpoint**: Users can regenerate smart models from the toolbar. Merge strategy preserves user content.
+
+---
+
+## Phase 6: User Story 4 — Full Cube.js Spec Coverage (Priority: P2)
+
+**Goal**: Autocomplete covers the entire Cube.js v1.6 specification including advanced features
+
+**Independent Test**: Author a pre-aggregation with partitioning, a rollup_join, extends, refresh_key, and SECURITY_CONTEXT — all via autocomplete
+
+### Tests for User Story 4
+
+- [ ] T025 [P] [US4] Write failing unit tests for advanced completions at `../client-v2/src/utils/cubejs-language/__tests__/advancedCompletions.test.ts` — test: pre_aggregation properties (partition_granularity, refresh_key, indexes, build_range_start/end, rollup_join, rollup_lambda), refresh_key sub-properties (sql, every, incremental, update_window, immutable), view cubes/includes/excludes, access_policy structure, hierarchies, granularities for time dimensions, rolling_window options, multi-stage measure properties, FILTER_PARAMS callback syntax, SECURITY_CONTEXT.key.unsafeValue(), SQL_UTILS methods, COMPILE_CONTEXT
+
+### Implementation for User Story 4
+
+- [ ] T026 [US4] Extend the completion provider at `../client-v2/src/utils/cubejs-language/completionProvider.ts` — add context cases for: pre_aggregation member_body (all type-specific properties), refresh_key nested properties, view cubes/includes/excludes, access_policy/member_level/row_level, hierarchies/levels, granularities (standard + custom), rolling_window (fixed vs to_date types), all FILTER_PARAMS/SECURITY_CONTEXT/SQL_UTILS/COMPILE_CONTEXT template completions with proper callback syntax snippets
+- [ ] T027 [US4] Extend client-side validation at `../client-v2/src/utils/cubejs-language/diagnosticProvider.ts` — validate pre-aggregation type-specific required properties (e.g., rollups required for rollup_join), validate refresh_key mutual exclusivity (every+sql vs immutable), validate view cubes array structure, warn on deprecated properties (shown, visible, refresh_range_start/end)
+
+**Checkpoint**: Full Cube.js spec autocomplete — every property in CubeValidator.js has a completion and validation rule.
+
+---
+
+## Phase 7: User Story 5 — Hover Documentation (Priority: P3)
+
+**Goal**: Hover tooltips on Cube.js keywords showing descriptions, valid values, and usage examples
+
+**Independent Test**: Hover over `relationship`, `FILTER_PARAMS`, and a cube reference — verify informative tooltips appear
+
+### Tests for User Story 5
+
+- [ ] T028 [P] [US5] Write failing unit tests for the hover provider at `../client-v2/src/utils/cubejs-language/__tests__/hoverProvider.test.ts` — test: hovering property names shows description + valid values, hovering type values shows what they mean, hovering template variables shows usage syntax, hovering cube references in join sql shows that cube's members, hovering deprecated properties shows replacement
+
+### Implementation for User Story 5
+
+- [ ] T029 [US5] Implement the hover provider at `../client-v2/src/utils/cubejs-language/hoverProvider.ts` — register with Monaco for both 'yaml' and 'javascript', use getCursorContext + word detection to find what's under cursor, look up PropertySpec from schema spec for descriptions, look up CubeRegistryEntry for cube references, return Hover with markdown contents (bold name, description, valid values as code block, usage example for template variables)
+- [ ] T030 [US5] Register the hover provider in the CodeEditor component at `../client-v2/src/components/CodeEditor/index.tsx` — import and register on editor mount, pass schema spec and cube registry instances, dispose on unmount
+
+**Checkpoint**: Hovering any Cube.js keyword shows helpful documentation inline.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [ ] T031 [P] Run `yarn codegen` in client-v2 if any GraphQL queries were modified
+- [ ] T036 [P] Validate zero false positives: create a test in `../client-v2/src/utils/cubejs-language/__tests__/diagnosticProvider.test.ts` that runs client-side validation against 3+ known-valid Cube.js model files (YAML and JS) and asserts zero error markers are produced (SC-007)
+- [ ] T037 [P] Manual smoke test for SC-004: in the Models IDE, author a complete join between two cubes using only autocomplete suggestions and tab navigation — verify no manual typing of cube or member names is required
+- [ ] T032 [P] Run `yarn lint` in client-v2 and fix any lint errors in new files
+- [ ] T033 Verify all StepCI tests pass (`./cli.sh tests stepci`)
+- [ ] T034 Run full client-v2 test suite (`cd ../client-v2 && yarn test`)
+- [ ] T035 Manual smoke test: open Models IDE, test autocomplete in YAML file, test autocomplete in JS file, test validation errors, test regenerate button, test hover tooltips
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately. T038 (language detection fix) is a PREREQUISITE for all Monaco provider work
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 Autocomplete (Phase 3)**: Depends on Phase 2
+- **US2 Validation (Phase 4)**: Depends on Phase 2
+- **US3 Regenerate (Phase 5)**: Depends on Phase 2 (no dependency on US1 or US2)
+- **US4 Full Spec (Phase 6)**: Depends on US1 (Phase 3) — extends completion provider
+- **US5 Hover (Phase 7)**: Depends on Phase 2 (no dependency on US1-US4)
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+```
+Phase 1 (Setup)
+    │
+Phase 2 (Foundational: spec, parsers, registry)
+    │
+    ├── Phase 3 (US1: Autocomplete) ─── Phase 6 (US4: Full Spec Coverage)
+    │
+    ├── Phase 4 (US2: Validation)
+    │
+    ├── Phase 5 (US3: Regenerate)
+    │
+    └── Phase 7 (US5: Hover)
+            │
+        Phase 8 (Polish)
+```
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation follows test → code → verify cycle
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- **Phase 2**: T006+T007 (YAML parser) and T008+T009 (JS parser) can run in parallel
+- **Phase 3-5**: US1, US2, and US3 can all start in parallel after Phase 2
+- **Phase 6-7**: US4 needs US1 done first; US5 can run parallel with anything after Phase 2
+- **Within stories**: Test tasks marked [P] can run in parallel with other [P] tests
+
+---
+
+## Parallel Example: After Phase 2 Completes
+
+```
+Agent 1: US1 — Autocomplete (T012 → T013 → T014)
+Agent 2: US2 — Validation (T015+T016 → T017 → T018 → T019 → T020 → T021)
+Agent 3: US3 — Regenerate (T022 → T023 → T024)
+```
+
+## Parallel Example: After US1 Completes
+
+```
+Agent 1: US4 — Full Spec (T025 → T026 → T027)
+Agent 2: US5 — Hover (T028 → T029 → T030)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (schema spec, parsers, registry)
+3. Complete Phase 3: User Story 1 (Autocomplete)
+4. **STOP and VALIDATE**: Test autocomplete independently in both YAML and JS
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 (Autocomplete) → Test → Deploy (MVP!)
+3. Add US2 (Validation) → Test → Deploy
+4. Add US3 (Regenerate) → Test → Deploy
+5. Add US4 (Full Spec) → Test → Deploy
+6. Add US5 (Hover) → Test → Deploy
+7. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers/agents:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Agent A: US1 (Autocomplete) → then US4 (Full Spec)
+   - Agent B: US2 (Validation)
+   - Agent C: US3 (Regenerate) → then US5 (Hover)
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing (TDD per constitution)
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- The schema spec (T005) is the largest single task (~1500 lines) — it defines the entire Cube.js property tree and is the foundation for everything else

--- a/tests/stepci/validate_flow.yml
+++ b/tests/stepci/validate_flow.yml
@@ -1,0 +1,95 @@
+tests:
+  validate_flow:
+    steps:
+      # T016-1: Valid files return valid: true
+      - name: validate_valid_files
+        http:
+          url: http://cubejs:4000/api/v1/validate
+          method: POST
+          headers:
+            Content-Type: application/json
+            Authorization: Bearer ${{captures.accessToken}}
+          json:
+            files:
+              - fileName: "test_cube.js"
+                content: "cube(`test_cube`, { sql_table: `public.test`, dimensions: { id: { sql: `${CUBE}.id`, type: `number` } } })"
+          check:
+            status: 200
+            jsonpath:
+              $.valid: true
+              $.errors:
+                - isArray: true
+              $.warnings:
+                - isArray: true
+
+      # T016-2: File with invalid property returns error with location
+      - name: validate_invalid_property
+        http:
+          url: http://cubejs:4000/api/v1/validate
+          method: POST
+          headers:
+            Content-Type: application/json
+            Authorization: Bearer ${{captures.accessToken}}
+          json:
+            files:
+              - fileName: "bad_cube.js"
+                content: "cube(`bad_cube`, { sql_table: `public.test`, dimensions: { id: { sql: `${CUBE}.id`, type: `number`, bogus_property: true } } })"
+          check:
+            status: 200
+            jsonpath:
+              $.valid: false
+              $.errors:
+                - isArray: true
+              $.errors[0].severity: "error"
+              $.errors[0].message:
+                - isString: true
+              $.errors[0].fileName: "bad_cube.js"
+
+      # T016-3: File referencing nonexistent cube in join returns semantic error
+      - name: validate_bad_join_reference
+        http:
+          url: http://cubejs:4000/api/v1/validate
+          method: POST
+          headers:
+            Content-Type: application/json
+            Authorization: Bearer ${{captures.accessToken}}
+          json:
+            files:
+              - fileName: "join_cube.js"
+                content: "cube(`join_cube`, { sql_table: `public.test`, joins: { nonexistent_cube: { relationship: `many_to_one`, sql: `${CUBE}.id = ${nonexistent_cube}.id` } }, dimensions: { id: { sql: `${CUBE}.id`, type: `number` } } })"
+          check:
+            status: 200
+            jsonpath:
+              $.valid: false
+              $.errors:
+                - isArray: true
+              $.errors[0].severity: "error"
+              $.errors[0].message:
+                - isString: true
+
+      # T016-4: Request without auth returns 401
+      - name: validate_no_auth
+        http:
+          url: http://cubejs:4000/api/v1/validate
+          method: POST
+          headers:
+            Content-Type: application/json
+          json:
+            files:
+              - fileName: "test_cube.js"
+                content: "cube(`test_cube`, { sql_table: `public.test`, dimensions: { id: { sql: `${CUBE}.id`, type: `number` } } })"
+          check:
+            status: 401
+
+      # T016-5: GET /api/v1/version returns version string
+      - name: get_version
+        http:
+          url: http://cubejs:4000/api/v1/version
+          method: GET
+          headers:
+            Authorization: Bearer ${{captures.accessToken}}
+          check:
+            status: 200
+            jsonpath:
+              $.version:
+                - isString: true

--- a/tests/stepci/workflow.yml
+++ b/tests/stepci/workflow.yml
@@ -15,3 +15,4 @@ include:
   - owner_flow.yml
   - smart_gen_flow.yml
   - cubesql_flow.yml
+  - validate_flow.yml


### PR DESCRIPTION
## Summary

- **Single-pass smart generation**: Profile data is cached and reused, eliminating the duplicate ClickHouse query during model regeneration (cuts generation time in half)
- **Change preview before applying**: New dry-run mode shows exactly what fields will be added, updated, removed, or preserved before committing changes
- **Structured diff engine**: New `diffModels` utility computes field-level merge previews with awareness of user-created fields, edited descriptions, and preserved blocks (joins, pre-aggregations, segments)
- **Cube.js-aware Monaco editor**: Full language service with autocomplete, validation, and hover docs for Cube.js YAML/JS models
- **JS validation snake_case support**: Smart-generated JS files using snake_case keys no longer produce false validation errors
- **Backend fixes**: Version endpoint made public, Hasura `{}` input normalization, reprofile auto-selects source table from provenance metadata

## Backend changes
- `profileTable.js` returns `raw_profile` blob for frontend caching
- `smartGenerate.js` accepts `profile_data` (skip re-profiling) and `dry_run` (preview mode)
- New `profileSerializer.js` handles Map↔JSON round-trip for GraphQL transport
- New `diffModels.js` computes structured change previews
- Hasura GraphQL schema updated with new inputs/outputs

## Test plan
- [ ] Smart-generate a new model from a ClickHouse table
- [ ] Reprofile an existing smart-generated model (should auto-select table)
- [ ] Verify change preview shows correct added/updated/removed/preserved counts
- [ ] Apply changes and verify model is saved correctly
- [ ] Test merge strategy (auto/merge/replace) with user-edited content
- [ ] Verify Monaco autocomplete and validation work for Cube.js models

🤖 Generated with [Claude Code](https://claude.com/claude-code)