### PR TITLE
007: WorkOS JWT query authentication with dual-path verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ JWT_KEY=<generate-a-random-32-char-key>
 # WorkOS Authentication
 WORKOS_API_KEY=<your-workos-api-key>
 WORKOS_CLIENT_ID=<your-workos-client-id>
+WORKOS_ISSUER=
 WORKOS_REDIRECT_URI=http://localhost:3000/auth/callback
 ALLOWED_RETURN_TO_HOSTS=localhost
 SIGNUP_ENABLED=false

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,6 +61,9 @@ services:
       - .dev.env
     environment:
       CUBEJS_SCHEDULED_REFRESH: false
+      WORKOS_API_KEY: ${WORKOS_API_KEY}
+      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID}
+      WORKOS_ISSUER: ${WORKOS_ISSUER:-}
     networks:
       - synmetrix_default
 

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -104,6 +104,10 @@ services:
     env_file:
       - .env
       - .stage.env
+    environment:
+      WORKOS_API_KEY: ${WORKOS_API_KEY}
+      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID}
+      WORKOS_ISSUER: ${WORKOS_ISSUER:-}
     networks:
       - synmetrix_default
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -48,6 +48,9 @@ services:
       - .test.env
     environment:
       CUBEJS_SCHEDULED_REFRESH: false
+      WORKOS_API_KEY: ${WORKOS_API_KEY}
+      WORKOS_CLIENT_ID: ${WORKOS_CLIENT_ID}
+      WORKOS_ISSUER: ${WORKOS_ISSUER:-}
     networks:
       - synmetrix_default
 

--- a/services/actions/src/auth/provision.js
+++ b/services/actions/src/auth/provision.js
@@ -211,6 +211,8 @@ export async function provisionUser(workosUser, options = {}) {
  * Derive team name from org context.
  * Priority: partition from JWT (e.g. "blue.is") > email domain (business) > full email (consumer).
  * The partition claim in WorkOS is the org's unique identifier/slug.
+ *
+ * NOTE: team derivation logic duplicated in services/{actions,cubejs} — keep in sync
  */
 function deriveTeamName(email, partition) {
   if (partition) {

--- a/services/actions/src/auth/token.js
+++ b/services/actions/src/auth/token.js
@@ -17,6 +17,9 @@ function isTokenExpired(token) {
   }
 }
 
+// Singleflight map: dedup concurrent refresh calls per session
+const inflightRefreshes = new Map();
+
 export default async function tokenHandler(req, res) {
   res.set("Cache-Control", "no-store");
 
@@ -55,32 +58,43 @@ export default async function tokenHandler(req, res) {
       session.workosAccessToken &&
       isTokenExpired(session.workosAccessToken)
     ) {
+      // Singleflight: dedup concurrent refresh calls for the same session
+      let refreshPromise = inflightRefreshes.get(sessionId);
+      if (!refreshPromise) {
+        refreshPromise = (async () => {
+          const refreshResult =
+            await workos.userManagement.authenticateWithRefreshToken({
+              clientId: process.env.WORKOS_CLIENT_ID,
+              refreshToken: session.refreshToken,
+            });
+          const freshJwt = await generateUserAccessToken(session.userId);
+          session.workosAccessToken = refreshResult.accessToken;
+          session.refreshToken = refreshResult.refreshToken;
+          session.accessToken = freshJwt;
+          await updateSession(sessionId, session);
+          return { accessToken: freshJwt, workosAccessToken: refreshResult.accessToken };
+        })();
+        inflightRefreshes.set(sessionId, refreshPromise);
+        refreshPromise.finally(() => inflightRefreshes.delete(sessionId));
+      }
+
       try {
-        const refreshResult =
-          await workos.userManagement.authenticateWithRefreshToken({
-            clientId: process.env.WORKOS_CLIENT_ID,
-            refreshToken: session.refreshToken,
-          });
-
-        // Mint fresh Hasura JWT
-        const freshJwt = await generateUserAccessToken(session.userId);
-
-        // Update session with new tokens
-        session.workosAccessToken = refreshResult.accessToken;
-        session.refreshToken = refreshResult.refreshToken;
-        session.accessToken = freshJwt;
-
-        await updateSession(sessionId, session);
-
+        const refreshed = await refreshPromise;
         return res.json({
-          accessToken: freshJwt,
+          accessToken: refreshed.accessToken,
+          workosAccessToken: refreshed.workosAccessToken || null,
           userId: session.userId,
           teamId: session.teamId || null,
           role: "user",
         });
       } catch (refreshError) {
         logger.warn("[Token] WorkOS token refresh failed:", refreshError);
-        // Fall through to return existing Hasura JWT
+        // Clear stale WorkOS token so frontend doesn't send an expired one
+        session.workosAccessToken = null;
+        updateSession(sessionId, session).catch((err) =>
+          logger.error("[Token] Failed to clear stale WorkOS token:", err)
+        );
+        // Fall through to return existing Hasura JWT (workosAccessToken now null)
       }
     }
 
@@ -98,6 +112,7 @@ export default async function tokenHandler(req, res) {
 
     return res.json({
       accessToken,
+      workosAccessToken: session.workosAccessToken || null,
       userId: session.userId,
       teamId: session.teamId || null,
       role: "user",

--- a/services/cubejs/index.js
+++ b/services/cubejs/index.js
@@ -104,7 +104,7 @@ if (String(CUBEJS_SQL_API) === "true") {
 app.use((err, req, res, next) => {
   console.error(err.stack);
 
-  res.status(500).send(err.message);
+  res.status(err.status || 500).send(err.message);
 });
 
 app.listen(port);

--- a/services/cubejs/package-lock.json
+++ b/services/cubejs/package-lock.json
@@ -4,39 +4,42 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "cubejs",
       "dependencies": {
-        "@cubejs-backend/api-gateway": "^1.3.23",
-        "@cubejs-backend/athena-driver": "^1.3.23",
-        "@cubejs-backend/bigquery-driver": "^1.3.23",
-        "@cubejs-backend/clickhouse-driver": "^1.3.23",
-        "@cubejs-backend/crate-driver": "^1.3.23",
-        "@cubejs-backend/cubestore-driver": "^1.3.23",
-        "@cubejs-backend/databricks-jdbc-driver": "^1.3.23",
-        "@cubejs-backend/dremio-driver": "^1.3.23",
-        "@cubejs-backend/druid-driver": "^1.3.23",
-        "@cubejs-backend/duckdb-driver": "^1.3.23",
-        "@cubejs-backend/elasticsearch-driver": "^1.3.23",
-        "@cubejs-backend/firebolt-driver": "^1.3.23",
-        "@cubejs-backend/hive-driver": "^1.3.23",
-        "@cubejs-backend/jdbc-driver": "^1.3.23",
-        "@cubejs-backend/ksql-driver": "^1.3.23",
-        "@cubejs-backend/materialize-driver": "^1.3.23",
-        "@cubejs-backend/mongobi-driver": "^1.3.23",
-        "@cubejs-backend/mssql-driver": "^1.3.23",
-        "@cubejs-backend/mysql-driver": "^1.3.23",
-        "@cubejs-backend/postgres-driver": "^1.3.23",
-        "@cubejs-backend/prestodb-driver": "^1.3.23",
-        "@cubejs-backend/query-orchestrator": "^1.3.23",
-        "@cubejs-backend/questdb-driver": "^1.3.23",
-        "@cubejs-backend/redshift-driver": "^1.3.23",
-        "@cubejs-backend/server-core": "^1.3.23",
-        "@cubejs-backend/snowflake-driver": "^1.3.23",
-        "@cubejs-backend/trino-driver": "^1.3.23",
+        "@cubejs-backend/api-gateway": "^1.6.19",
+        "@cubejs-backend/athena-driver": "^1.6.19",
+        "@cubejs-backend/bigquery-driver": "^1.6.19",
+        "@cubejs-backend/clickhouse-driver": "^1.6.19",
+        "@cubejs-backend/crate-driver": "^1.6.19",
+        "@cubejs-backend/cubestore-driver": "^1.6.19",
+        "@cubejs-backend/databricks-jdbc-driver": "^1.6.19",
+        "@cubejs-backend/dremio-driver": "^1.6.19",
+        "@cubejs-backend/druid-driver": "^1.6.19",
+        "@cubejs-backend/duckdb-driver": "^1.6.19",
+        "@cubejs-backend/elasticsearch-driver": "^1.6.19",
+        "@cubejs-backend/firebolt-driver": "^1.6.19",
+        "@cubejs-backend/hive-driver": "^1.6.19",
+        "@cubejs-backend/jdbc-driver": "^1.6.19",
+        "@cubejs-backend/ksql-driver": "^1.6.19",
+        "@cubejs-backend/materialize-driver": "^1.6.19",
+        "@cubejs-backend/mongobi-driver": "^1.6.19",
+        "@cubejs-backend/mssql-driver": "^1.6.19",
+        "@cubejs-backend/mysql-driver": "^1.6.19",
+        "@cubejs-backend/oracle-driver": "^1.6.19",
+        "@cubejs-backend/pinot-driver": "^1.6.19",
+        "@cubejs-backend/postgres-driver": "^1.6.19",
+        "@cubejs-backend/prestodb-driver": "^1.6.19",
+        "@cubejs-backend/query-orchestrator": "^1.6.19",
+        "@cubejs-backend/questdb-driver": "^1.6.19",
+        "@cubejs-backend/redshift-driver": "^1.6.19",
+        "@cubejs-backend/server-core": "^1.6.19",
+        "@cubejs-backend/snowflake-driver": "^1.6.19",
+        "@cubejs-backend/sqlite-driver": "^1.6.19",
+        "@cubejs-backend/trino-driver": "^1.6.19",
         "@cubejs-backend/vertica-driver": "npm:@knowitall/vertica-driver@^0.32.3",
         "body-parser": "^1.19.0",
         "express": "^4.18.2",
         "ioredis": "^5.3.2",
+        "jose": "^6.2.1",
         "jsdoc": "^4.0.2",
         "jsonwebtoken": "^9.0.0",
         "jsum": "^2.0.0-alpha.3",
@@ -337,6 +340,474 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-redshift": {
+      "version": "3.1006.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-redshift/-/client-redshift-3.1006.0.tgz",
+      "integrity": "sha512-uMVzJ5wcRHQSztsXqmLlpfD9WNEMxqX/78qgscE6IxYSRi1LJGkN6x+HsSMiQ5g6/TBJtczGdWHDicdnOOoYeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/credential-provider-node": "^3.972.19",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.12",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/core": {
+      "version": "3.973.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.19.tgz",
+      "integrity": "sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.17.tgz",
+      "integrity": "sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.19.tgz",
+      "integrity": "sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.18.tgz",
+      "integrity": "sha512-vthIAXJISZnj2576HeyLBj4WTeX+I7PwWeRkbOa0mVX39K13SCGxCgOFuKj2ytm9qTlLOmXe4cdEnroteFtJfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/credential-provider-env": "^3.972.17",
+        "@aws-sdk/credential-provider-http": "^3.972.19",
+        "@aws-sdk/credential-provider-login": "^3.972.18",
+        "@aws-sdk/credential-provider-process": "^3.972.17",
+        "@aws-sdk/credential-provider-sso": "^3.972.18",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.18",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.19.tgz",
+      "integrity": "sha512-yDWQ9dFTr+IMxwanFe7+tbN5++q8psZBjlUwOiCXn1EzANoBgtqBwcpYcHaMGtn0Wlfj4NuXdf2JaEx1lz5RaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.17",
+        "@aws-sdk/credential-provider-http": "^3.972.19",
+        "@aws-sdk/credential-provider-ini": "^3.972.18",
+        "@aws-sdk/credential-provider-process": "^3.972.17",
+        "@aws-sdk/credential-provider-sso": "^3.972.18",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.17.tgz",
+      "integrity": "sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.18.tgz",
+      "integrity": "sha512-YHYEfj5S2aqInRt5ub8nDOX8vAxgMvd84wm2Y3WVNfFa/53vOv9T7WOAqXI25qjj3uEcV46xxfqdDQk04h5XQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/token-providers": "3.1005.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.18.tgz",
+      "integrity": "sha512-OqlEQpJ+J3T5B96qtC1zLLwkBloechP+fezKbCH0sbd2cCc0Ra55XpxWpk/hRj69xAOYtHvoC4orx6eTa4zU7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.20.tgz",
+      "integrity": "sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.9",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-retry": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.8.tgz",
+      "integrity": "sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1005.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1005.0.tgz",
+      "integrity": "sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/types": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.5.tgz",
+      "integrity": "sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-redshift/node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.919.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.919.0.tgz",
@@ -595,6 +1066,285 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.18.tgz",
+      "integrity": "sha512-kINzc5BBxdYBkPZ0/i1AMPMOk5b5QaFNbYMElVw5QTX13AKj6jcxnv/YNl9oW9mg+Y08ti19hh01HhyEAxsSJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/nested-clients": "^3.996.8",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
+      "version": "3.973.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.19.tgz",
+      "integrity": "sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.20.tgz",
+      "integrity": "sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.9",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-retry": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.8.tgz",
+      "integrity": "sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.19",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.9",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-retry": "^4.4.40",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.39",
+        "@smithy/util-defaults-mode-node": "^4.2.42",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.5.tgz",
+      "integrity": "sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.20",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
@@ -2836,13 +3586,14 @@
       }
     },
     "node_modules/@cubejs-backend/api-gateway": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/api-gateway/-/api-gateway-1.3.86.tgz",
-      "integrity": "sha512-EgixpwUc9PIso7W49APCp0URSuWqqEzNDEAeCjA0iA3vGFaAgGw2zApz0umyPD36Ea6Iid2W2/FWKSbLkvpWaQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/api-gateway/-/api-gateway-1.6.21.tgz",
+      "integrity": "sha512-7CruAT2EFPfYLs1HGvdg7ma18P8LVGsJ9CVJgo/PJYORocJBzsuh9phZHT/584So7UxnRvD+RLpUFQOwFXm+VA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/native": "1.3.86",
-        "@cubejs-backend/query-orchestrator": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
+        "@cubejs-backend/native": "1.6.21",
+        "@cubejs-backend/query-orchestrator": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "@ungap/structured-clone": "^0.3.4",
         "assert-never": "^1.4.0",
         "body-parser": "^1.19.0",
@@ -2862,55 +3613,8 @@
         "nexus": "^1.1.0",
         "node-fetch": "^2.6.1",
         "ramda": "^0.27.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/api-gateway/node_modules/@cubejs-backend/cubesql": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.3.86.tgz",
-      "integrity": "sha512-jOhn3FYojeqNcN4Jdx/ke72Vqw0/sA8wDtjcFGtr4uj+gcRThJggKCdTLflBkqNSs6O/Mzdr0LsIJ59NJD9k4g==",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/api-gateway/node_modules/@cubejs-backend/native": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.3.86.tgz",
-      "integrity": "sha512-vt2Bw207S4A9N/+bu/mYGbyifrF9FOI+s+u+cH1QU+uhv2RNXKH7jenJ2gzpL2VM05LgqUf22MtJK0ysrk7jGw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@cubejs-backend/cubesql": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
-        "@cubejs-infra/post-installer": "^0.0.7"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/api-gateway/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
+        "uuid": "^8.3.2",
+        "zod": "^4.1.13"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
@@ -2925,19 +3629,21 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cubejs-backend/athena-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/athena-driver/-/athena-driver-1.3.85.tgz",
-      "integrity": "sha512-YtJPZ03h3KjkYBko+BEyDmdV4WJXM3JypySbiMMiVxfuXu47MFr1WdKC6om6WH2Lm4GZ7UgfCtZbAlLSbMin9A==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/athena-driver/-/athena-driver-1.6.21.tgz",
+      "integrity": "sha512-/auh/zZq3CQNsTK17hMFs9uzJrn+H/WwAP4fWi77GQQ4V8mGRThaBQo5GkytwAyghppEC/fN+6p954A+e1jwkQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-athena": "^3.22.0",
         "@aws-sdk/credential-providers": "^3.22.0",
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "sqlstring": "^2.3.1"
       },
       "engines": {
@@ -2945,15 +3651,16 @@
       }
     },
     "node_modules/@cubejs-backend/base-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.3.85.tgz",
-      "integrity": "sha512-A3zat+PEPKjW7aHQYe6Xp/q6E2cQG9HDHICwKuFWwODlV3bJEbGrVZQUSarhh6XxG+8C5dsmdPMhV7yg8398uQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.6.21.tgz",
+      "integrity": "sha512-5F44jPXttVLKmAiRjGqvpO6PLoUHsrsEeOBtIvL7hwIXDdqCwwz6H84XDyPcIeckyzM2qQVVmxCoL7kVq0Dmdg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.49.0",
         "@aws-sdk/s3-request-presigner": "^3.49.0",
         "@azure/identity": "^4.4.1",
         "@azure/storage-blob": "^12.9.0",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/shared": "1.6.21",
         "@google-cloud/storage": "^7.13.0"
       },
       "engines": {
@@ -2961,13 +3668,14 @@
       }
     },
     "node_modules/@cubejs-backend/bigquery-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/bigquery-driver/-/bigquery-driver-1.3.85.tgz",
-      "integrity": "sha512-GYS1B00sSfFwDmlwG9s59fuxZnxvWp46Fi4RxE1658LgPJsoCquwK+8Vq7wVY2WVjT78rRzIRSJY23DK0OSOvA==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/bigquery-driver/-/bigquery-driver-1.6.21.tgz",
+      "integrity": "sha512-blEyLjNpfQPkEXW34JUHJBcunOpshjZZJn8QK+3F8ie9v0VGLQ1sVp0XPc2N0WUYGSCNjqORclI/pFtE4Q9Znw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/shared": "1.6.21",
         "@google-cloud/bigquery": "^7.7.0",
         "@google-cloud/storage": "^7.13.0",
         "ramda": "^0.27.2"
@@ -2982,13 +3690,14 @@
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
     "node_modules/@cubejs-backend/clickhouse-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/clickhouse-driver/-/clickhouse-driver-1.3.85.tgz",
-      "integrity": "sha512-52N6qfJQZ2ZsEa7COIkJTcZqsv0PTF2aT8g6B9/WIHkqlKg4GOH5mZy7Eh1zdHJIzJsQhNP88cMTmzRAS48q1g==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/clickhouse-driver/-/clickhouse-driver-1.6.21.tgz",
+      "integrity": "sha512-Q4NgoG2KybZmEoEwmBqLXmzrJdoPm9GEq4lajcmWj9YT+R1j0/ogNm4AtolzpHL+1uEO84pPQNbMh6wCwFfPtA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@clickhouse/client": "^1.12.0",
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "moment": "^2.24.0",
         "sqlstring": "^2.3.1",
         "uuid": "^8.3.2"
@@ -3006,12 +3715,13 @@
       }
     },
     "node_modules/@cubejs-backend/cloud": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cloud/-/cloud-1.3.86.tgz",
-      "integrity": "sha512-a5zTbccCxpussv+bVA6KRWDwpY7EOOI2qnlzOqWp45wxYD0xf+MeBRLsAvOHiQiBti0rFE9cml8LCyPs6HmvWA==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cloud/-/cloud-1.6.21.tgz",
+      "integrity": "sha512-8RLVtUkiznVemO0PphoZhb8/jq38SOBnKjN3zG3LZGBFvAUY8Wz+/6AxwA07cju6IF8ejwcE8p2IS+7TTm7xxw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/shared": "1.3.86",
+        "@cubejs-backend/shared": "1.6.21",
         "chokidar": "^3.5.1",
         "env-var": "^6.3.0",
         "form-data": "^4.0.0",
@@ -3023,68 +3733,36 @@
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/@cubejs-backend/cloud/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/cloud/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@cubejs-backend/crate-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/crate-driver/-/crate-driver-1.3.85.tgz",
-      "integrity": "sha512-v76IHkisdeZYLMshxvcgKUs7+wCcpoymPMdBohAVFcfWPgdtQk4f6H+cohuIrGwApk+HJ6zlhOVPPvcPXPhKsw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/crate-driver/-/crate-driver-1.6.21.tgz",
+      "integrity": "sha512-kritQUokwzq56bY+8jutTWMfwzhxxKZO7Daweri9TDZNXHZvPpsHZViMP1rmZcwamtPKELM+nqGfXSl4DxsCNw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/postgres-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
-        "pg": "^8.7.1"
+        "@cubejs-backend/postgres-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/@cubejs-backend/cubesql": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.3.85.tgz",
-      "integrity": "sha512-nFQWAmmXCTinrIhKDb+76ugIwWIp/nmQCTAcoCApklVrCHdf6itBq8MhJ1znJtKKuUHeYOxFEKOdD3ZLKDbIig==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.6.21.tgz",
+      "integrity": "sha512-tc56NqRhrS/D8QAFCcJVEuKKK2aMMzqTecEkwXc8ASEElTqssnd61pqw0vfCw0YdDfv/h5lJS0Ap/vGGCLl8Hg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@cubejs-backend/cubestore": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore/-/cubestore-1.3.86.tgz",
-      "integrity": "sha512-38Embcvv/hye/qlOYej4PlUQCWtnNdiPcLyP7tFVCi14erePn2jUVYSeRDmJfly6oXX0dDBn2cQP89Hed31nSQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore/-/cubestore-1.6.21.tgz",
+      "integrity": "sha512-Qae5PErRyXVn/hSmdmgXYJD+R7WiE4KqzDhagq2Joqlf10hgMzR9w7L0o1ayxO+8oamHX8mXnujO0ERsWykPyw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/shared": "1.3.86",
+        "@cubejs-backend/shared": "1.6.21",
         "@octokit/core": "^3.2.5",
         "source-map-support": "^0.5.19"
       },
@@ -3096,18 +3774,18 @@
       }
     },
     "node_modules/@cubejs-backend/cubestore-driver": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore-driver/-/cubestore-driver-1.3.86.tgz",
-      "integrity": "sha512-GZMHiLteFyeu1o2LwABPiV8ciRGlRKJhXHmR6++R1+OFyGUlQP0km5zvPqot7rMxGrygMiZ5XnnlHqDMCUVYvA==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubestore-driver/-/cubestore-driver-1.6.21.tgz",
+      "integrity": "sha512-5ithEUSXuBwwEjaws5eo9qQ4CfleXOSRUIffVvV0vem/+7kHn49RWehI3vh5NPwYBP5M/BvWVZx34/0IHCi02Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.86",
-        "@cubejs-backend/cubestore": "1.3.86",
-        "@cubejs-backend/native": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/cubestore": "1.6.21",
+        "@cubejs-backend/native": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "csv-write-stream": "^2.0.0",
         "flatbuffers": "23.3.3",
         "fs-extra": "^9.1.0",
-        "generic-pool": "^3.8.2",
         "node-fetch": "^2.6.1",
         "sqlstring": "^2.3.3",
         "tempy": "^1.0.1",
@@ -3118,122 +3796,26 @@
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/@cubejs-backend/cubestore-driver/node_modules/@cubejs-backend/base-driver": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.3.86.tgz",
-      "integrity": "sha512-BB7xqtThocXIjTMCwwTpk3S1erau6UHEScnodt+HHxsXYrPGMsUNlw1qoUHeGalHyX/qfWN8hl6uDzYx3vdxRQ==",
-      "dependencies": {
-        "@aws-sdk/client-s3": "^3.49.0",
-        "@aws-sdk/s3-request-presigner": "^3.49.0",
-        "@azure/identity": "^4.4.1",
-        "@azure/storage-blob": "^12.9.0",
-        "@cubejs-backend/shared": "1.3.86",
-        "@google-cloud/storage": "^7.13.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/cubestore-driver/node_modules/@cubejs-backend/cubesql": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.3.86.tgz",
-      "integrity": "sha512-jOhn3FYojeqNcN4Jdx/ke72Vqw0/sA8wDtjcFGtr4uj+gcRThJggKCdTLflBkqNSs6O/Mzdr0LsIJ59NJD9k4g==",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/cubestore-driver/node_modules/@cubejs-backend/native": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.3.86.tgz",
-      "integrity": "sha512-vt2Bw207S4A9N/+bu/mYGbyifrF9FOI+s+u+cH1QU+uhv2RNXKH7jenJ2gzpL2VM05LgqUf22MtJK0ysrk7jGw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@cubejs-backend/cubesql": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
-        "@cubejs-infra/post-installer": "^0.0.7"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/cubestore-driver/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
     "node_modules/@cubejs-backend/cubestore-driver/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@cubejs-backend/cubestore/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/cubestore/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cubejs-backend/databricks-jdbc-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/databricks-jdbc-driver/-/databricks-jdbc-driver-1.3.85.tgz",
-      "integrity": "sha512-RJv/9zRQFKokcdol15r6I/ShV/txj42snmoan5FWIe6TFMQ6xxENDRbZOl2iEOWZgcqksw3kJvhSR7pYiphw1g==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/databricks-jdbc-driver/-/databricks-jdbc-driver-1.6.21.tgz",
+      "integrity": "sha512-zhjSK9XJh0uXPVIhjtybTirG1+EftmqqRbpdnU+1Lo0tBMpYhxgu6u61zn2maV5MG7rhZVN6VgPqNrGq7c7L0A==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/jdbc-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/jdbc-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "node-fetch": "^2.6.1",
         "ramda": "^0.27.2",
         "source-map-support": "^0.5.19",
@@ -3265,13 +3847,14 @@
       }
     },
     "node_modules/@cubejs-backend/dremio-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/dremio-driver/-/dremio-driver-1.3.85.tgz",
-      "integrity": "sha512-Hk6NWDmVgKUJ+u2fwgDing+nJTNHHOa1fqYZJNTOU8L5DUYPiSkII4LvQmvsFlrPca1AgKTSpnEmIHitExfXyQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/dremio-driver/-/dremio-driver-1.6.21.tgz",
+      "integrity": "sha512-PImAs/kG1JgQiGuJKDJEERnoEoZ74xWZORBkbQsBVOS/31LYS8yHuNYlVgjLhQ498IrvBDd/HJefgQ4cDrKC5Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "axios": "^1.8.3",
         "sqlstring": "^2.3.1"
       },
@@ -3280,13 +3863,14 @@
       }
     },
     "node_modules/@cubejs-backend/druid-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/druid-driver/-/druid-driver-1.3.85.tgz",
-      "integrity": "sha512-xx0jaieVvuB67yMruFDhlXf2RNmOrSF/CY2a/OjXxLAUGt2v0JMef4gVNA+GCzOLqSaJE6sFJgt7zeMKMjGbnw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/druid-driver/-/druid-driver-1.6.21.tgz",
+      "integrity": "sha512-B50NuXTPATKPVJK/Ek8FUVxwblV93ia0RoGcQKH9Vc9+taap55/9/mJCJENxCFzpM3HRusThcZrjf2fs34/yfA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "axios": "^1.8.3"
       },
       "engines": {
@@ -3294,26 +3878,28 @@
       }
     },
     "node_modules/@cubejs-backend/duckdb-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/duckdb-driver/-/duckdb-driver-1.3.85.tgz",
-      "integrity": "sha512-F0Yz2j5Hmbj5VlkAMVa0ZXAHzkiEi+DXuT5BMBPcyNx11n478SJ4x3MJjRlXT1WumxgQtyFOTNJTolAhWE7hvA==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/duckdb-driver/-/duckdb-driver-1.6.21.tgz",
+      "integrity": "sha512-mY6rz4l6atpH8jJxHClaOWeVm9JWCUMeNSUyUWwJTBH8uQMvxx1FcUpNtcwFSSkkwvaAmKdRYfM7BrZHFSKNUg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
-        "duckdb": "^1.3.1"
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
+        "duckdb": "^1.4.1"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/@cubejs-backend/elasticsearch-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/elasticsearch-driver/-/elasticsearch-driver-1.3.85.tgz",
-      "integrity": "sha512-DLFc+tOJ/bocn3n5FkIa9chPENGVkYmLuH++PXUK5FWFISgi62BMa/ctMoWjoj96H4xi0pFQ6lZRmNENduhFxg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/elasticsearch-driver/-/elasticsearch-driver-1.6.21.tgz",
+      "integrity": "sha512-vNFZsgoP3RU9AIQuHkOB+U/NaRvkGAydEmkOKWvtvBm5bp/o66boqiqdlq8NSr6PMYKDWfY/8alOENeCbtow3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "@elastic/elasticsearch": "7.12.0",
         "sqlstring": "^2.3.1"
       },
@@ -3322,13 +3908,14 @@
       }
     },
     "node_modules/@cubejs-backend/firebolt-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/firebolt-driver/-/firebolt-driver-1.3.85.tgz",
-      "integrity": "sha512-Z3DogTZ1vlys1eY5h9jByFP3IVxVmEriNfq7yLp1UYlKiJof4AMO3YUd3F5YpI0itgWcjXLO4xgfvS/ntwrRXg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/firebolt-driver/-/firebolt-driver-1.6.21.tgz",
+      "integrity": "sha512-fZq8SESpTPRdBwDe7QJrwvqlAdYgk5zg6OGRPI3Amtacx5F/ayUjdvUeQLyvll2H6lJrI0IIYS9FjQN3w/Yj0Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "firebolt-sdk": "1.10.0"
       },
       "engines": {
@@ -3336,13 +3923,13 @@
       }
     },
     "node_modules/@cubejs-backend/hive-driver": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/hive-driver/-/hive-driver-1.3.86.tgz",
-      "integrity": "sha512-zB3iMEKlkS08loJJ5YN82B1BA9dRMp75WNq4cEcAIBwrr7FKjVCAtd9kLDtBTZOKWfn8jjkceMsXO8L2VkQ9Ng==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/hive-driver/-/hive-driver-1.6.21.tgz",
+      "integrity": "sha512-Y7v+xiUGw1f256AooULrHdcr/aNW1UngsV0rj5LOT9FBHfZoO7pJzunK5wz6BkuDtEupxswX7DK7j0yVxxGYyA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
-        "generic-pool": "^3.8.2",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "jshs2": "^0.4.4",
         "sasl-plain": "^0.1.0",
         "saslmechanisms": "^0.1.1",
@@ -3353,60 +3940,11 @@
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/@cubejs-backend/hive-driver/node_modules/@cubejs-backend/base-driver": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.3.86.tgz",
-      "integrity": "sha512-BB7xqtThocXIjTMCwwTpk3S1erau6UHEScnodt+HHxsXYrPGMsUNlw1qoUHeGalHyX/qfWN8hl6uDzYx3vdxRQ==",
-      "dependencies": {
-        "@aws-sdk/client-s3": "^3.49.0",
-        "@aws-sdk/s3-request-presigner": "^3.49.0",
-        "@azure/identity": "^4.4.1",
-        "@azure/storage-blob": "^12.9.0",
-        "@cubejs-backend/shared": "1.3.86",
-        "@google-cloud/storage": "^7.13.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/hive-driver/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/hive-driver/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@cubejs-backend/jdbc": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cubejs-backend/jdbc/-/jdbc-0.8.1.tgz",
       "integrity": "sha512-dM/9V4IFe6vEcgHqAAAJ84EUnjxk1KjqJW26q2zKvDDW+31Fk9WzLEbzR1KdfYySWK7j+rMdOqGvHp8w89XGTQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "async": "^3.2.6",
@@ -3420,14 +3958,14 @@
       }
     },
     "node_modules/@cubejs-backend/jdbc-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/jdbc-driver/-/jdbc-driver-1.3.85.tgz",
-      "integrity": "sha512-dyqjhc7xGtMuVSdE2QHjDpvZ+++1fRlPnOpg6hJZlC8TXS09YAbR0zwgo9MrHq3EMiF5t2c3Fg8ZVMT27ruaRQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/jdbc-driver/-/jdbc-driver-1.6.21.tgz",
+      "integrity": "sha512-33rePBa0vOGQNg5AUpijxrX5ev0DdXWq7i5PRkN9mek29DR4UjDs3nlDMbdaKF/WE1yXrqYi55a8d593SInvIg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
         "@cubejs-backend/node-java-maven": "^0.1.3",
-        "@cubejs-backend/shared": "1.3.85",
-        "generic-pool": "^3.9.0",
+        "@cubejs-backend/shared": "1.6.21",
         "sqlstring": "^2.3.0"
       },
       "engines": {
@@ -3446,19 +3984,21 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "optional": true,
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@cubejs-backend/ksql-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/ksql-driver/-/ksql-driver-1.3.85.tgz",
-      "integrity": "sha512-1hRrkOz/nMCQPHgYDdT/t15FNHSwNgzvcCPNh3m9ql92G6SOIbM4787+P+F+rEI6oRAkrp8R48aZ0fomeOo5gQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/ksql-driver/-/ksql-driver-1.6.21.tgz",
+      "integrity": "sha512-YEk3TH1FjERgoiA/kf5oSlrmnl+NviCtZNqi0fsh5X+qEOb00MOnWCXZQ4L1JE2HKchZ+JNbOfY1tQ6Wl4od8w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "async-mutex": "0.3.2",
         "axios": "^1.8.3",
         "kafkajs": "^2.2.3",
@@ -3469,15 +4009,14 @@
       }
     },
     "node_modules/@cubejs-backend/materialize-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/materialize-driver/-/materialize-driver-1.3.85.tgz",
-      "integrity": "sha512-HH9GboIKic0iR32ScmcSSKS+z8hsQ2YXRzQAl2RACf8LPxcyjhFTPFAYYt08gvBLI9wnl2gFJjLaw5xvhcCj5Q==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/materialize-driver/-/materialize-driver-1.6.21.tgz",
+      "integrity": "sha512-oHAwY09l+dg2I6Fi2UZS8K+KyTWxKPhwbQKayHlgZnPe1nFYkpveBmLKhsa9IoVeGk5jMaxtnMDIeFwdK7RUPg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/postgres-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
-        "@types/pg": "^8.6.0",
-        "pg": "^8.6.0",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/postgres-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "semver": "^7.6.3"
       },
       "engines": {
@@ -3485,14 +4024,14 @@
       }
     },
     "node_modules/@cubejs-backend/mongobi-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/mongobi-driver/-/mongobi-driver-1.3.85.tgz",
-      "integrity": "sha512-g6lNVh8haWfoeZvI02+oQl8XJ/rBOeX9ff1X7OcKa9jkvEuFMXlkkBXgbGdflQx1tIuncTbZeCTB39RhjS1AUw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/mongobi-driver/-/mongobi-driver-1.6.21.tgz",
+      "integrity": "sha512-sGXGQojr6xyS3JgfJxAffhhZKzAHc28AoNaCV2Z2OYv7bae4jAvlz3sG/iVu49yFifiaSD785GeTD50ASE6ekQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "@types/node": "^20",
-        "generic-pool": "^3.9.0",
         "moment": "^2.29.1",
         "mysql2": "^3.11.5"
       },
@@ -3501,12 +4040,13 @@
       }
     },
     "node_modules/@cubejs-backend/mssql-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/mssql-driver/-/mssql-driver-1.3.85.tgz",
-      "integrity": "sha512-QXoinkDZEScc9UiKm5oFE+ohufvXt5/1XywVPiSjkgtEtuFKrItWm+oV0w0VVkC2zMfqWiNcatt5dZPE9julrw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/mssql-driver/-/mssql-driver-1.6.21.tgz",
+      "integrity": "sha512-KLgXIAqI5nQ6zDDcEUaG6HEn10dhmPh5HF9Z3H0wmhQQo9bkLZAFaRD5kfM597a2tuwZslajOIUsXmb5nYbaMg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "mssql": "^11.0.1"
       },
       "engines": {
@@ -3514,13 +4054,13 @@
       }
     },
     "node_modules/@cubejs-backend/mysql-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/mysql-driver/-/mysql-driver-1.3.85.tgz",
-      "integrity": "sha512-PYRs/T6dSUnsjd1K/k2YrnZPbf+89N0wAP7GEPGswb01Jusr3VkNoCpB0xSzCjz7l1RecKTxMUFm4S2i1jpObg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/mysql-driver/-/mysql-driver-1.6.21.tgz",
+      "integrity": "sha512-oCLVD443YQwU5vkogrOkBJCkkPGp14DkHmiCi0MwnEs9IUxd08oRZFkW/F49QkgOh3HEF3a0vJdhMsaQsD+zkg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
-        "generic-pool": "^3.9.0",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "mysql": "^2.18.1"
       },
       "engines": {
@@ -3528,13 +4068,14 @@
       }
     },
     "node_modules/@cubejs-backend/native": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.3.85.tgz",
-      "integrity": "sha512-bvP1Hm1o0QORYGlSDrkDUPqv+J8oxpOpSNECt27ajlWr1ELfwCLSr7ugbfow9pXhI4IO14NUrRJWf9fj0njJLg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.6.21.tgz",
+      "integrity": "sha512-+JAyAe88moGWilAFduOeZaF7k5SjO/sdVkTHGjz+JdwJcvnPO3zWpHwgIedmvL3s7GDajE3i49eM/p+4BrHqaw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/cubesql": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/cubesql": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "@cubejs-infra/post-installer": "^0.0.7"
       },
       "engines": {
@@ -3545,6 +4086,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@cubejs-backend/node-java-maven/-/node-java-maven-0.1.3.tgz",
       "integrity": "sha512-H3Xwrt9FSLJo4tdL5Cw9B2iPnPTzlMnv8AfSvqKZQbXftBg6YH+sger5KG7gD128/RiU1Nv+yxPvbvKs6APJlA==",
+      "license": "MIT",
       "dependencies": {
         "async": "^3.2.6",
         "axios": "^1.8.1",
@@ -3555,17 +4097,63 @@
         "node-java-maven": "bin/node-java-maven"
       }
     },
-    "node_modules/@cubejs-backend/postgres-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/postgres-driver/-/postgres-driver-1.3.85.tgz",
-      "integrity": "sha512-HqVT1JQQeDa+ZhCNE0LR6t1pakNUUbge8VBhnusQdFQKEsax7YtsbU1p/LZfsNHYOUaTC8e3bYBWc2oBa612PA==",
+    "node_modules/@cubejs-backend/oracle-driver": {
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/oracle-driver/-/oracle-driver-1.6.21.tgz",
+      "integrity": "sha512-wbWIjtbhjTy3hs/c0FLbRDxFCG2+LCEP76Dzv6nnJhsWmjbHmIECPk7XXcnX0yKQWQTbULjZ9XsGJ02fXJC+Mw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
-        "@types/pg": "^8.6.0",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "ramda": "^0.27.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
+      },
+      "optionalDependencies": {
+        "oracledb": "^6.2.0"
+      }
+    },
+    "node_modules/@cubejs-backend/oracle-driver/node_modules/ramda": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "license": "MIT"
+    },
+    "node_modules/@cubejs-backend/pinot-driver": {
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/pinot-driver/-/pinot-driver-1.6.21.tgz",
+      "integrity": "sha512-OOB9BDJNVH9UwJcFAAYbwro/v/KHn7vbhFG621O17qzlYUP4S5kTFbGSiLJ7lJguM8Gh68uIWbzJC7jIV8Hfxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
+        "node-fetch": "^2.6.1",
+        "ramda": "^0.27.2",
+        "sqlstring": "^2.3.3"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@cubejs-backend/pinot-driver/node_modules/ramda": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "license": "MIT"
+    },
+    "node_modules/@cubejs-backend/postgres-driver": {
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/postgres-driver/-/postgres-driver-1.6.21.tgz",
+      "integrity": "sha512-xOF+bFXa0xYi1dhgXWzNqgEe6J5+q+oRA+hxAwHrgfI0TEIVCYsQzy9XeFhg/1MWEmT6QfcsehIeZ63T34WGHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
+        "@types/pg": "^8.16.0",
         "@types/pg-query-stream": "^1.0.3",
         "moment": "^2.24.0",
-        "pg": "^8.6.0",
+        "pg": "^8.18.0",
         "pg-query-stream": "^4.1.0"
       },
       "engines": {
@@ -3573,12 +4161,13 @@
       }
     },
     "node_modules/@cubejs-backend/prestodb-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/prestodb-driver/-/prestodb-driver-1.3.85.tgz",
-      "integrity": "sha512-DF6Dmtlrg6Xol4Wp9NE5bO1UVVJ7PZsGCGduqvmnlczQvVEB6uhWCpiGS861lSrdj5egPyvh/NCptgQOEXHLoA==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/prestodb-driver/-/prestodb-driver-1.6.21.tgz",
+      "integrity": "sha512-HONrOLsv7iRfRLmSAtLO06dPDFSt+wQQA24ZUc0Uk7yVVtzbpN4tY+0eqGC4hHCpWAPIrFagNZJ/GXHWS0cdpQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "presto-client": "^1.1.0",
         "ramda": "^0.27.0",
         "sqlstring": "^2.3.1"
@@ -3593,58 +4182,17 @@
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
     "node_modules/@cubejs-backend/query-orchestrator": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/query-orchestrator/-/query-orchestrator-1.3.86.tgz",
-      "integrity": "sha512-ZbwF7CqF2M7NyB3PSDbCG/V726spIrFkH/Tw5D8vlgY3Ty4v29pSK0Y7Mi16fcz1NUb4TpKYhmjh0uaYCpP06Q==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/query-orchestrator/-/query-orchestrator-1.6.21.tgz",
+      "integrity": "sha512-jlB68Cg4RIT9M4wJlmuuoBaFRBw155Zbg4yFz6bTq4hAlxbU2A3ykcqSeNM6UmBLzPjhlbpE7RVYwc6YXwPUqQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.86",
-        "@cubejs-backend/cubestore-driver": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/cubestore-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "csv-write-stream": "^2.0.0",
         "lru-cache": "^11.1.0",
         "ramda": "^0.27.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/query-orchestrator/node_modules/@cubejs-backend/base-driver": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.3.86.tgz",
-      "integrity": "sha512-BB7xqtThocXIjTMCwwTpk3S1erau6UHEScnodt+HHxsXYrPGMsUNlw1qoUHeGalHyX/qfWN8hl6uDzYx3vdxRQ==",
-      "dependencies": {
-        "@aws-sdk/client-s3": "^3.49.0",
-        "@aws-sdk/s3-request-presigner": "^3.49.0",
-        "@azure/identity": "^4.4.1",
-        "@azure/storage-blob": "^12.9.0",
-        "@cubejs-backend/shared": "1.3.86",
-        "@google-cloud/storage": "^7.13.0"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/query-orchestrator/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
@@ -3655,22 +4203,15 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
-    "node_modules/@cubejs-backend/query-orchestrator/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@cubejs-backend/questdb-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/questdb-driver/-/questdb-driver-1.3.85.tgz",
-      "integrity": "sha512-JFnKI6pcIr9Rh173VZAJHhR5D9P+eBIgs0ThhUBJH+YgvtF1ve6Eg3xWTbo6rHi6aLQXx2Wi8SRp/vqkX4nlzg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/questdb-driver/-/questdb-driver-1.6.21.tgz",
+      "integrity": "sha512-vhPSN/VXv9OL8/oc82QYkuC5xGOuNhuNdufPLhXNWFSDtQolrNJhEqk5SOk9jsNbZq76pWoeHpROgI6HCWBs5A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "@types/pg": "^8.6.0",
         "moment": "^2.24.0",
         "pg": "^8.7.0",
@@ -3686,22 +4227,26 @@
       "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
     "node_modules/@cubejs-backend/redshift-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/redshift-driver/-/redshift-driver-1.3.85.tgz",
-      "integrity": "sha512-IjZaAD/0nPJwVxX2dofi/9AgLYN2aXp2LMZwtA+H5xP2Gc2UP86kH+J63/XyGaRYeqbhH8/qBbHi9qHfo9PbTg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/redshift-driver/-/redshift-driver-1.6.21.tgz",
+      "integrity": "sha512-plqyLajs/paV6DDGH6jeYBTCkXmj1SPx8NCWcf0YrhWlDaB9y9/6pe5fwmm1QgJwlFThIYnZ7q7tRRzBMBqxmw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/postgres-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85"
+        "@aws-sdk/client-redshift": "^3.22.0",
+        "@aws-sdk/credential-providers": "^3.22.0",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/postgres-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/@cubejs-backend/schema-compiler": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.3.85.tgz",
-      "integrity": "sha512-yY10qXQTXaKaRKFlYuVBQY6/Wdk79JO9Ga4Z+P9W9mUnBRcWxoiq3F6kyQCTZ8a7W3WWQDMu93wUTtFLtvNb8w==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.6.21.tgz",
+      "integrity": "sha512-e7pZ4lmoZw4PamvVpUNy2oBKcrQKinjHZG1aS6sqdIMzIVVF8+sDIX+avqw27tUwuNNKW02OLeB0ivmo2JjMNg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.24",
         "@babel/core": "^7.24",
@@ -3711,8 +4256,8 @@
         "@babel/standalone": "^7.24",
         "@babel/traverse": "^7.24",
         "@babel/types": "^7.24",
-        "@cubejs-backend/native": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/native": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "antlr4": "^4.13.2",
         "camelcase": "^6.2.0",
         "cron-parser": "^4.9.0",
@@ -3736,32 +4281,38 @@
     "node_modules/@cubejs-backend/schema-compiler/node_modules/ramda": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "license": "MIT"
     },
     "node_modules/@cubejs-backend/schema-compiler/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cubejs-backend/server-core": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/server-core/-/server-core-1.3.86.tgz",
-      "integrity": "sha512-Irap2F2YezJcSgpFfTRUxDvLF7FdJGOB6zed2V8n52H3l6xgxrVWBM+4FOQuvdTkOrV5lsO4PHwT7cJ3OH1FMQ==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/server-core/-/server-core-1.6.21.tgz",
+      "integrity": "sha512-HIVjGOfT+2JTVNPYsoi+RnCUfxOPmFz0F34jq2iRFabuHVpv8acL2gvCUNsOlj3SaEZ8LgxBApYISO/m1ZPn/g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/api-gateway": "1.3.86",
-        "@cubejs-backend/cloud": "1.3.86",
+        "@cubejs-backend/api-gateway": "1.6.21",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/cloud": "1.6.21",
+        "@cubejs-backend/cubestore-driver": "1.6.21",
         "@cubejs-backend/dotenv": "^9.0.2",
-        "@cubejs-backend/native": "1.3.86",
-        "@cubejs-backend/query-orchestrator": "1.3.86",
-        "@cubejs-backend/schema-compiler": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
-        "@cubejs-backend/templates": "1.3.86",
+        "@cubejs-backend/native": "1.6.21",
+        "@cubejs-backend/query-orchestrator": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
+        "@cubejs-backend/templates": "1.6.21",
         "codesandbox-import-utils": "^2.1.12",
         "cross-spawn": "^7.0.1",
         "fs-extra": "^8.1.0",
+        "graphql": "^15.8.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-docker": "^2.1.1",
@@ -3782,122 +4333,6 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/cubesql": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.3.86.tgz",
-      "integrity": "sha512-jOhn3FYojeqNcN4Jdx/ke72Vqw0/sA8wDtjcFGtr4uj+gcRThJggKCdTLflBkqNSs6O/Mzdr0LsIJ59NJD9k4g==",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/native": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.3.86.tgz",
-      "integrity": "sha512-vt2Bw207S4A9N/+bu/mYGbyifrF9FOI+s+u+cH1QU+uhv2RNXKH7jenJ2gzpL2VM05LgqUf22MtJK0ysrk7jGw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@cubejs-backend/cubesql": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
-        "@cubejs-infra/post-installer": "^0.0.7"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/schema-compiler": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.3.86.tgz",
-      "integrity": "sha512-kMphaBZD6wyU9No9fei5d4Bt80294YRgZqZH/AiBDCo8qVNHQl6MdJZrEGnoiojL08yrqRUjusBkrfeBLoIDOA==",
-      "dependencies": {
-        "@babel/code-frame": "^7.24",
-        "@babel/core": "^7.24",
-        "@babel/generator": "^7.24",
-        "@babel/parser": "^7.24",
-        "@babel/preset-env": "^7.24",
-        "@babel/standalone": "^7.24",
-        "@babel/traverse": "^7.24",
-        "@babel/types": "^7.24",
-        "@cubejs-backend/native": "1.3.86",
-        "@cubejs-backend/shared": "1.3.86",
-        "antlr4": "^4.13.2",
-        "camelcase": "^6.2.0",
-        "cron-parser": "^4.9.0",
-        "humps": "^2.0.1",
-        "inflection": "^1.12.0",
-        "joi": "^17.13.3",
-        "js-yaml": "^4.1.0",
-        "lru-cache": "^11.1.0",
-        "moment-timezone": "^0.5.48",
-        "node-dijkstra": "^2.5.0",
-        "ramda": "^0.27.2",
-        "syntax-error": "^1.3.0",
-        "uuid": "^8.3.2",
-        "workerpool": "^9.2.0",
-        "yaml": "^2.7.1"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/shared/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/shared/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@cubejs-backend/server-core/node_modules/@cubejs-backend/shared/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@cubejs-backend/server-core/node_modules/fs-extra": {
@@ -3924,7 +4359,8 @@
     "node_modules/@cubejs-backend/server-core/node_modules/ramda": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "license": "MIT"
     },
     "node_modules/@cubejs-backend/server-core/node_modules/universalify": {
       "version": "0.1.2",
@@ -3938,14 +4374,16 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cubejs-backend/shared": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.85.tgz",
-      "integrity": "sha512-4iw194DwSM+fx4F5DWvZn+fccVwR76tjtpOUJ26YaDCokH1tQ3rFo1vtptVnY3YEoe0XakTr7FBxxDPyyec+Gg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.6.21.tgz",
+      "integrity": "sha512-XlEaWSGaOWB2DIaBbdisa5UMY9J9ZrbUdDOtdB25YpTrMjghQSlhVXr5FzO9IPX6eVdchUkvyG7Ox9aTrHU0Gw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@oclif/color": "^0.1.2",
         "bytes": "^3.1.2",
@@ -3954,7 +4392,7 @@
         "decompress": "^4.2.1",
         "env-var": "^6.3.0",
         "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
+        "generic-pool": "^3.9.0",
         "lru-cache": "^11.1.0",
         "moment-range": "^4.0.2",
         "moment-timezone": "^0.5.47",
@@ -3972,18 +4410,20 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cubejs-backend/snowflake-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/snowflake-driver/-/snowflake-driver-1.3.85.tgz",
-      "integrity": "sha512-PGFif3A2oXF5Df4F1wQgqwv5AC+hrqIVdRNj7/9vr2UlT1gsUXIBc7z50WlYn/jkLXGYO/K/Q04XcslbMIjKpg==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/snowflake-driver/-/snowflake-driver-1.6.21.tgz",
+      "integrity": "sha512-RHqjllJ8z13gNEtko9yPAlzDtkm3wfhtLy3BUXK0v0pTecJS43weBqgYlt8Rr7gF/0QAeMkvGozTG4QJ1T7xDQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.726.0",
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "date-fns-timezone": "^0.1.4",
         "snowflake-sdk": "^2.2.0"
       },
@@ -3991,12 +4431,27 @@
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/@cubejs-backend/templates": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/templates/-/templates-1.3.86.tgz",
-      "integrity": "sha512-s+/0WpDQgk9/a/Ddz+0NTmBYUYPtsJ+EKbGeyS8sL6OMYBP4Qo0bK2g+TcJ4IlSp4MK51My8fCYIZ7iNqPGMuA==",
+    "node_modules/@cubejs-backend/sqlite-driver": {
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/sqlite-driver/-/sqlite-driver-1.6.21.tgz",
+      "integrity": "sha512-++nGchlBTwLtJ7KkyArp6pRZW4hCLG/N9j9ou93Qxo411FP1J2CPfUr9Plr52N/9tm2Pw1gIe7MbrbXgW/ijVA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/shared": "1.3.86",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
+        "sqlite3": "^5.1.7"
+      },
+      "engines": {
+        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@cubejs-backend/templates": {
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/templates/-/templates-1.6.21.tgz",
+      "integrity": "sha512-CQrE0lG0fvxRknMYmU3jHG9kcMkpgDCt32uinZEVmdkwa+dyGBXMsT2Yvig8p6WvE4uovPgwvi4VNllo3Hrlhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cubejs-backend/shared": "1.6.21",
         "cross-spawn": "^7.0.3",
         "decompress": "^4.2.1",
         "decompress-targz": "^4.1.1",
@@ -4009,54 +4464,22 @@
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }
     },
-    "node_modules/@cubejs-backend/templates/node_modules/@cubejs-backend/shared": {
-      "version": "1.3.86",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz",
-      "integrity": "sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==",
-      "dependencies": {
-        "@oclif/color": "^0.1.2",
-        "bytes": "^3.1.2",
-        "cli-progress": "^3.9.0",
-        "cross-spawn": "^7.0.3",
-        "decompress": "^4.2.1",
-        "env-var": "^6.3.0",
-        "fs-extra": "^9.1.0",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^11.1.0",
-        "moment-range": "^4.0.2",
-        "moment-timezone": "^0.5.47",
-        "node-fetch": "^2.6.1",
-        "proxy-agent": "^6.5.0",
-        "shelljs": "^0.8.5",
-        "throttle-debounce": "^3.0.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
     "node_modules/@cubejs-backend/templates/node_modules/ramda": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
-    },
-    "node_modules/@cubejs-backend/templates/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
+      "license": "MIT"
     },
     "node_modules/@cubejs-backend/trino-driver": {
-      "version": "1.3.85",
-      "resolved": "https://registry.npmjs.org/@cubejs-backend/trino-driver/-/trino-driver-1.3.85.tgz",
-      "integrity": "sha512-9OmGFn0vwlf5VkA+lxy7x9sgU+Yls9MWEjFUzL4L9yNdLnK/vnQXZF5gxowZeMS4k2SJhFlxLe6LMvItIdVizw==",
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@cubejs-backend/trino-driver/-/trino-driver-1.6.21.tgz",
+      "integrity": "sha512-LA5aJFCyqIOvVn216umkmLlMGhaaiI5c3U+1CUahr193Ab5w4f7oOdaZ6Syoh+Fi+ZQc8ikGjgGc03fE6n7PhQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@cubejs-backend/base-driver": "1.3.85",
-        "@cubejs-backend/prestodb-driver": "1.3.85",
-        "@cubejs-backend/schema-compiler": "1.3.85",
-        "@cubejs-backend/shared": "1.3.85",
+        "@cubejs-backend/base-driver": "1.6.21",
+        "@cubejs-backend/prestodb-driver": "1.6.21",
+        "@cubejs-backend/schema-compiler": "1.6.21",
+        "@cubejs-backend/shared": "1.6.21",
         "node-fetch": "^2.6.1",
         "presto-client": "^1.1.0",
         "sqlstring": "^2.3.1"
@@ -4752,6 +5175,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
       "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -4768,12 +5192,14 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
       "optional": true
     },
     "node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5006,11 +5432,12 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz",
-      "integrity": "sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5041,15 +5468,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz",
-      "integrity": "sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.3",
-        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5057,19 +5485,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.17.1.tgz",
-      "integrity": "sha512-V4Qc2CIb5McABYfaGiIYLTmo/vwNIK7WXI5aGveBd9UcdhbOMwcvIMxIw/DJj1S9QgOMa/7FBkarMdIC0EOTEQ==",
+      "version": "3.23.9",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
+      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.3",
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.3",
-        "@smithy/util-stream": "^4.5.4",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5077,14 +5506,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz",
-      "integrity": "sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.3",
-        "@smithy/property-provider": "^4.2.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/url-parser": "^4.2.3",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5157,14 +5587,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz",
-      "integrity": "sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==",
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/querystring-builder": "^4.2.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5186,13 +5617,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz",
-      "integrity": "sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5213,11 +5645,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz",
-      "integrity": "sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5225,9 +5658,10 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5249,12 +5683,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz",
-      "integrity": "sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5262,17 +5697,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.5.tgz",
-      "integrity": "sha512-SIzKVTvEudFWJbxAaq7f2GvP3jh2FHDpIFI6/VAf4FOWGFZy0vnYMPSRj8PGYI8Hjt29mvmwSRgKuO3bK4ixDw==",
+      "version": "4.4.23",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
+      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.17.1",
-        "@smithy/middleware-serde": "^4.2.3",
-        "@smithy/node-config-provider": "^4.3.3",
-        "@smithy/shared-ini-file-loader": "^4.3.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/url-parser": "^4.2.3",
-        "@smithy/util-middleware": "^4.2.3",
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5280,18 +5716,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.5.tgz",
-      "integrity": "sha512-DCaXbQqcZ4tONMvvdz+zccDE21sLcbwWoNqzPLFlZaxt1lDtOE2tlVpRSwcTOJrjJSUThdgEYn7HrX5oLGlK9A==",
+      "version": "4.4.40",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
+      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.3",
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/service-error-classification": "^4.2.3",
-        "@smithy/smithy-client": "^4.9.1",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-middleware": "^4.2.3",
-        "@smithy/util-retry": "^4.2.3",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5299,12 +5736,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz",
-      "integrity": "sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5312,11 +5750,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz",
-      "integrity": "sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5324,13 +5763,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz",
-      "integrity": "sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.3",
-        "@smithy/shared-ini-file-loader": "^4.3.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5338,14 +5778,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.3.tgz",
-      "integrity": "sha512-MAwltrDB0lZB/H6/2M5PIsISSwdI5yIh6DaBB9r0Flo9nx3y0dzl/qTMJPd7tJvPdsx6Ks/cwVzheGNYzXyNbQ==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.3",
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/querystring-builder": "^4.2.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5353,11 +5794,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz",
-      "integrity": "sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5365,11 +5807,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz",
-      "integrity": "sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5377,12 +5820,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz",
-      "integrity": "sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5390,11 +5834,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz",
-      "integrity": "sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5402,22 +5847,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz",
-      "integrity": "sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0"
+        "@smithy/types": "^4.13.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz",
-      "integrity": "sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5425,17 +5872,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz",
-      "integrity": "sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.3",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5443,16 +5891,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.1.tgz",
-      "integrity": "sha512-Ngb95ryR5A9xqvQFT5mAmYkCwbXvoLavLFwmi7zVg/IowFPCfiqRfkOKnbc/ZRL8ZKJ4f+Tp6kSu6wjDQb8L/g==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
+      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.17.1",
-        "@smithy/middleware-endpoint": "^4.3.5",
-        "@smithy/middleware-stack": "^4.2.3",
-        "@smithy/protocol-http": "^5.3.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-stream": "^4.5.4",
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5460,9 +5909,10 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz",
-      "integrity": "sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5471,12 +5921,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz",
-      "integrity": "sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/querystring-parser": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5484,12 +5935,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5497,9 +5949,10 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5508,9 +5961,10 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5519,11 +5973,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5531,9 +5986,10 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5542,13 +5998,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.4.tgz",
-      "integrity": "sha512-qI5PJSW52rnutos8Bln8nwQZRpyoSRN6k2ajyoUHNMUzmWqHnOJCnDELJuV6m5PML0VkHI+XcXzdB+6awiqYUw==",
+      "version": "4.3.39",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
+      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.3",
-        "@smithy/smithy-client": "^4.9.1",
-        "@smithy/types": "^4.8.0",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5556,16 +6013,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.6.tgz",
-      "integrity": "sha512-c6M/ceBTm31YdcFpgfgQAJaw3KbaLuRKnAz91iMWFLSrgxRpYm03c3bu5cpYojNMfkV9arCUelelKA7XQT36SQ==",
+      "version": "4.2.42",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
+      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.0",
-        "@smithy/credential-provider-imds": "^4.2.3",
-        "@smithy/node-config-provider": "^4.3.3",
-        "@smithy/property-provider": "^4.2.3",
-        "@smithy/smithy-client": "^4.9.1",
-        "@smithy/types": "^4.8.0",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5573,12 +6031,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz",
-      "integrity": "sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5586,9 +6045,10 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5597,11 +6057,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz",
-      "integrity": "sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.8.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5609,12 +6070,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz",
-      "integrity": "sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5622,17 +6084,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.4.tgz",
-      "integrity": "sha512-+qDxSkiErejw1BAIXUFBSfM5xh3arbz1MmxlbMCKanDDZtVEQ7PSKW9FQS0Vud1eI/kYn0oCTVKyNzRlq+9MUw==",
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.4",
-        "@smithy/node-http-handler": "^4.4.3",
-        "@smithy/types": "^4.8.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5640,9 +6103,10 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5651,11 +6115,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5663,12 +6128,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.3.tgz",
-      "integrity": "sha512-5+nU///E5sAdD7t3hs4uwvCTWQtTR8JwKwOCSJtBRx0bY1isDo1QwH87vRK86vlFLBTISqoDA2V6xvP6nF1isQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.12.tgz",
+      "integrity": "sha512-ek5hyDrzS6mBFsNCEX8LpM+EWSLq6b9FdmPRlkpXXhiJE6aIZehKT9clC6+nFpZAA+i/Yg0xlaPeWGNbf5rzQA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.3",
-        "@smithy/types": "^4.8.0",
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5676,9 +6142,10 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -5723,7 +6190,8 @@
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
     },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
@@ -5771,9 +6239,10 @@
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.15.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
-      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -5966,6 +6435,7 @@
       "version": "4.13.2",
       "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.2.tgz",
       "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16"
       }
@@ -6073,6 +6543,7 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6228,9 +6699,10 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -6288,6 +6760,15 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -7111,6 +7592,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -7169,6 +7651,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decompress-tar": {
@@ -7242,6 +7739,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/default-browser": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
@@ -7299,6 +7805,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -7679,6 +8186,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -7713,6 +8221,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -7725,6 +8234,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -7773,6 +8283,15 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expand-tilde": {
@@ -7934,6 +8453,21 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz",
+      "integrity": "sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.2"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -8010,6 +8544,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8055,6 +8595,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-2.0.0.tgz",
       "integrity": "sha512-m4Cf5WM5Y9UupofsLgcJuY5oFXVfVnfHx43pg3HJoVdtY2PN4Wfs7ex9svf7W7eLTP+6wmyBToaqGOCffHBHVA==",
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "which": "~1.0.5",
@@ -8065,6 +8606,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
       "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "license": "ISC",
       "optional": true,
       "bin": {
         "which": "bin/which"
@@ -8417,6 +8959,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -8425,6 +8968,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -8846,6 +9395,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -9150,6 +9705,7 @@
       "resolved": "https://registry.npmjs.org/java/-/java-0.14.0.tgz",
       "integrity": "sha512-fXqNZvzQTl9cOFK4Rx7lobpgdWh9HKyjD56aerCZ9ETrVepvI6/wH1PUodieUc2ekf4cUOsHfM7aliWZAwU5Zg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "async": "^3.2.5",
@@ -9167,6 +9723,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
       "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -9179,6 +9736,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
       "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "license": "ISC",
       "optional": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9188,6 +9746,7 @@
       "version": "18.0.4",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
       "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
@@ -9211,6 +9770,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
@@ -9220,24 +9780,27 @@
       }
     },
     "node_modules/java/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/java/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
       "optional": true
     },
     "node_modules/java/node_modules/make-fetch-happen": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
       "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "@npmcli/agent": "^2.0.0",
@@ -9261,6 +9824,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
@@ -9273,6 +9837,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
       "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "minipass": "^7.0.3",
@@ -9290,6 +9855,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
       "optional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -9302,6 +9868,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
       "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
@@ -9326,6 +9893,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
       "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "abbrev": "^2.0.0"
@@ -9341,6 +9909,7 @@
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
       "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
@@ -9353,6 +9922,8 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -9370,6 +9941,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -9379,6 +9951,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
       "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "unique-slug": "^4.0.0"
@@ -9391,6 +9964,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
       "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -9403,6 +9977,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "isexe": "^3.1.1"
@@ -9424,6 +9999,15 @@
         "@sideway/address": "^4.1.5",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-md4": {
@@ -10099,6 +10683,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10281,6 +10877,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -10290,6 +10887,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
@@ -10464,10 +11067,17 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "license": "MIT",
       "optional": true
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/native-duplexpair": {
       "version": "1.0.0",
@@ -10500,6 +11110,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -10519,6 +11130,18 @@
       },
       "peerDependencies": {
         "graphql": "15.x || 16.x"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -10876,6 +11499,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/oracledb": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.10.0.tgz",
+      "integrity": "sha512-kGUumXmrEWbSpBuKJyb9Ip3rXcNgKK6grunI3/cLPzrRvboZ6ZoLi9JQ+z6M/RIG924tY8BLflihL4CKKQAYMA==",
+      "hasInstallScript": true,
+      "license": "(Apache-2.0 OR UPL-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10908,6 +11542,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -10926,6 +11561,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -10939,6 +11575,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -10971,6 +11608,21 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz",
+      "integrity": "sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -11038,13 +11690,14 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/pg": {
-      "version": "8.16.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.9.1",
-        "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.3",
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -11052,7 +11705,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.2.7"
+        "pg-cloudflare": "^1.3.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -11064,15 +11717,17 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
     },
     "node_modules/pg-cursor": {
       "version": "2.15.3",
@@ -11091,17 +11746,19 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
     },
     "node_modules/pg-query-stream": {
       "version": "4.10.3",
@@ -11231,6 +11888,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/presto-client": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/presto-client/-/presto-client-1.1.0.tgz",
@@ -11243,6 +11927,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
       "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "license": "ISC",
       "optional": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11307,6 +11992,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -11325,6 +12011,7 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -11333,6 +12020,7 @@
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -11441,6 +12129,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -11765,9 +12477,13 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -12054,6 +12770,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/simple-lru-cache": {
@@ -12388,6 +13149,381 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sqlite3/node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/sqlite3/node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/sqlite3/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/sqlite3/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/sqlite3/node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sqlite3/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sqlite3/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sqlite3/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/sqlite3/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/sqlite3/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sqlite3/node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sqlite3/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sqlite3/node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/sqlite3/node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -12576,15 +13712,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -12656,6 +13793,51 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar-stream": {
@@ -13111,6 +14293,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
@@ -13486,6 +14680,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.5.tgz",
       "integrity": "sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==",
+      "license": "BSD-2-Clause",
       "optional": true
     },
     "node_modules/winston": {
@@ -13536,7 +14731,8 @@
     "node_modules/workerpool": {
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg=="
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -13720,6 +14916,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -13732,6 +14929,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -13783,6 +14981,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/services/cubejs/package.json
+++ b/services/cubejs/package.json
@@ -41,6 +41,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.18.2",
     "ioredis": "^5.3.2",
+    "jose": "^6.2.1",
     "jsdoc": "^4.0.2",
     "jsonwebtoken": "^9.0.0",
     "jsum": "^2.0.0-alpha.3",

--- a/services/cubejs/src/routes/index.js
+++ b/services/cubejs/src/routes/index.js
@@ -1,7 +1,10 @@
 import express from "express";
 
 import checkAuthMiddleware from "../utils/checkAuth.js";
-import { invalidateUserCache } from "../utils/dataSourceHelpers.js";
+import {
+  invalidateUserCache,
+  invalidateWorkosSubCache,
+} from "../utils/dataSourceHelpers.js";
 import { invalidateRulesCache } from "../utils/queryRewrite.js";
 import generateDataSchema from "./generateDataSchema.js";
 import getSchema from "./getSchema.js";
@@ -23,10 +26,13 @@ export default ({ basePath, cubejs }) => {
 
     if (type === "user") {
       invalidateUserCache(userId || null);
+    } else if (type === "workos") {
+      invalidateWorkosSubCache(req.body.sub || null);
     } else if (type === "rules") {
       invalidateRulesCache();
     } else if (type === "all") {
       invalidateUserCache(null);
+      invalidateWorkosSubCache(null);
       invalidateRulesCache();
     }
 

--- a/services/cubejs/src/utils/checkAuth.js
+++ b/services/cubejs/src/utils/checkAuth.js
@@ -1,37 +1,34 @@
 import jwt from "jsonwebtoken";
 
-import { findUser } from "./dataSourceHelpers.js";
+import {
+  findUser,
+  provisionUserFromWorkOS,
+} from "./dataSourceHelpers.js";
+import { detectTokenType, verifyWorkOSToken } from "./workosAuth.js";
 import defineUserScope from "./defineUserScope.js";
 
 const { JWT_KEY, JWT_ALGORITHM } = process.env;
 
 /**
  * Checks the authorization of the request and sets the security context.
+ * Supports dual-token verification: WorkOS RS256 and Hasura HS256.
  *
  * @param {Object} req - The request object.
- * @throws {Error} If the Hasura Authorization token is not provided.
- * @throws {Error} If no x-hasura-datasource-id is provided in the headers.
- * @throws {Error} If there are no permissions for the specified data source.
- * @throws {Error} If there is no default branch for the specified data source.
- * @throws {Error} If the specified data source is not found.
  * @returns {Promise<void>} A promise that resolves when the security context is set.
  */
 const checkAuth = async (req) => {
-  // Extract the authorization header from the request
   const authHeader = req.headers.authorization;
 
   if (!authHeader) {
-    throw new Error("Provide Hasura Authorization token");
+    const error = new Error("Provide Hasura Authorization token");
+    error.status = 403;
+    throw error;
   }
 
-  // Extract the data source ID from the request headers
   const dataSourceId = req.headers["x-hasura-datasource-id"];
-  // Extract the branch ID from the request headers
   const branchId = req.headers["x-hasura-branch-id"];
-  // Extract the branch version ID from the request headers
   const branchVersionId = req.headers["x-hasura-branch-version-id"];
 
-  let jwtDecoded;
   let authToken;
 
   if (authHeader.startsWith("Bearer ")) {
@@ -41,32 +38,47 @@ const checkAuth = async (req) => {
   }
 
   if (!authToken) {
-    throw new Error("Provide Hasura Authorization token");
+    const error = new Error("Provide Hasura Authorization token");
+    error.status = 403;
+    throw error;
   }
 
-  try {
-    jwtDecoded = jwt.verify(authToken, JWT_KEY, {
-      algorithms: [JWT_ALGORITHM],
-    });
-  } catch (err) {
-    throw err;
-  }
+  let userId;
+  const tokenType = detectTokenType(authToken);
 
-  const { "x-hasura-user-id": userId } = jwtDecoded?.hasura || {};
+  if (tokenType === "workos") {
+    // WorkOS RS256 path
+    const payload = await verifyWorkOSToken(authToken);
+    userId = await provisionUserFromWorkOS(payload);
+  } else {
+    // Hasura HS256 path (existing)
+    let jwtDecoded;
+    try {
+      jwtDecoded = jwt.verify(authToken, JWT_KEY, {
+        algorithms: [JWT_ALGORITHM],
+      });
+    } catch (err) {
+      throw err;
+    }
+
+    userId = jwtDecoded?.hasura?.["x-hasura-user-id"];
+  }
 
   if (!dataSourceId) {
-    throw new Error(
+    const error = new Error(
       "400: No x-hasura-datasource-id provided, headers: " +
         JSON.stringify(req.headers)
     );
+    error.status = 400;
+    throw error;
   }
 
-  const user = await findUser({
-    userId,
-  });
+  const user = await findUser({ userId });
 
   if (!user.dataSources?.length || !user.members?.length) {
-    throw new Error(`404: user "${userId}" not found`);
+    const error = new Error(`404: user "${userId}" not found`);
+    error.status = 404;
+    throw error;
   }
 
   const userScope = defineUserScope(

--- a/services/cubejs/src/utils/checkSqlAuth.js
+++ b/services/cubejs/src/utils/checkSqlAuth.js
@@ -1,7 +1,14 @@
-import { findSqlCredentials } from "./dataSourceHelpers.js";
+import {
+  findSqlCredentials,
+  findUser,
+  provisionUserFromWorkOS,
+} from "./dataSourceHelpers.js";
+import { detectTokenType, verifyWorkOSToken } from "./workosAuth.js";
 
 import buildSecurityContext from "./buildSecurityContext.js";
-import { getDataSourceAccessList } from "./defineUserScope.js";
+import defineUserScope, {
+  getDataSourceAccessList,
+} from "./defineUserScope.js";
 
 const buildSqlSecurityContext = (sqlCredentials) => {
   if (!sqlCredentials) {
@@ -27,16 +34,68 @@ const buildSqlSecurityContext = (sqlCredentials) => {
 };
 
 /**
- * Asynchronous function to check the SQL authentication for a user.
+ * Check SQL authentication for a user.
+ * Supports two authentication methods:
+ * 1. WorkOS JWT as password (new): password is a JWT, username is datasource ID
+ * 2. Legacy sql_credentials lookup (existing): username/password from sql_credentials table
  *
  * @param {null} _ - Unused parameter.
- * @param {Object} user - The user object.
- * @returns {Promise} - A promise that resolves to an object containing the password and the security context for the user.
- *
- * @throws {Error} - Throws an error if the SQL credentials for the user are not found.
+ * @param {Object} user - The user object with username and password.
+ * @returns {Promise} - Resolves to { password, securityContext }
  */
 const checkSqlAuth = async (_, user) => {
-  const sqlCredentials = await findSqlCredentials(user);
+  const password = typeof user === "string" ? user : user?.password;
+  const username = typeof user === "string" ? _ : user?.username;
+
+  // Detect if password looks like a JWT (WorkOS RS256)
+  if (password && password.includes(".") && password.split(".").length === 3) {
+    const tokenType = detectTokenType(password);
+
+    if (tokenType === "workos") {
+      // WorkOS JWT path — fail closed on verification failure
+      const payload = await verifyWorkOSToken(password);
+      const userId = await provisionUserFromWorkOS(payload);
+
+      const userData = await findUser({ userId });
+
+      if (!userData.dataSources?.length || !userData.members?.length) {
+        const error = new Error(`404: user "${userId}" not found`);
+        error.status = 404;
+        throw error;
+      }
+
+      // Username is the datasource ID
+      const datasourceId = username;
+      const dataSource = userData.dataSources.find(
+        (ds) => ds.id === datasourceId
+      );
+
+      if (!dataSource) {
+        const error = new Error(
+          `403: access denied for datasource "${datasourceId}"`
+        );
+        error.status = 403;
+        throw error;
+      }
+
+      const userScope = defineUserScope(
+        userData.dataSources,
+        userData.members,
+        datasourceId
+      );
+
+      return {
+        password,
+        securityContext: {
+          userId,
+          userScope,
+        },
+      };
+    }
+  }
+
+  // Legacy sql_credentials path (unchanged)
+  const sqlCredentials = await findSqlCredentials(username || user);
 
   return {
     password: sqlCredentials?.password,

--- a/services/cubejs/src/utils/dataSourceHelpers.js
+++ b/services/cubejs/src/utils/dataSourceHelpers.js
@@ -1,9 +1,45 @@
 import { fetchGraphQL } from "./graphql.js";
+import { fetchWorkOSUserProfile } from "./workosAuth.js";
 
 // --- User scope cache: keyed by userId, 30s TTL ---
 const userCache = new Map();
 const USER_CACHE_TTL = 30_000;
 const USER_CACHE_MAX_SIZE = 500;
+
+// --- WorkOS identity mapping cache: keyed by WorkOS sub, 5min TTL ---
+// Stores { userId, membershipVerified, time } to avoid re-reconciling membership on every cache miss
+const workosSubCache = new Map();
+const WORKOS_SUB_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const WORKOS_SUB_CACHE_MAX_SIZE = 1000;
+
+// Singleflight map: dedup concurrent provision calls for the same sub
+const inflightProvisions = new Map();
+
+export function getWorkosSubCacheEntry(sub) {
+  const entry = workosSubCache.get(sub);
+  if (!entry) return null;
+  if (Date.now() - entry.time > WORKOS_SUB_CACHE_TTL) {
+    workosSubCache.delete(sub);
+    return null;
+  }
+  return entry;
+}
+
+export function setWorkosSubCacheEntry(sub, userId, membershipVerified = false) {
+  if (workosSubCache.size >= WORKOS_SUB_CACHE_MAX_SIZE) {
+    const oldest = workosSubCache.keys().next().value;
+    workosSubCache.delete(oldest);
+  }
+  workosSubCache.set(sub, { userId, membershipVerified, time: Date.now() });
+}
+
+export function invalidateWorkosSubCache(sub) {
+  if (sub) {
+    workosSubCache.delete(sub);
+  } else {
+    workosSubCache.clear();
+  }
+}
 
 function getUserCacheEntry(userId) {
   const entry = userCache.get(userId);
@@ -238,3 +274,383 @@ export const findDataSchemasByIds = async ({ ids }) => {
 
   return dataSchemas;
 };
+
+// --- Identity resolution functions (T007) ---
+
+const findAccountByWorkosIdQuery = `
+  query FindAccountByWorkosId($workos_user_id: String!) {
+    accounts: auth_accounts(where: { workos_user_id: { _eq: $workos_user_id } }, limit: 1) {
+      id
+      user_id
+      email
+      workos_user_id
+    }
+  }
+`;
+
+const findAccountByEmailQuery = `
+  query FindAccountByEmail($email: citext!) {
+    accounts: auth_accounts(where: { email: { _eq: $email } }, limit: 1) {
+      id
+      user_id
+      email
+      workos_user_id
+    }
+  }
+`;
+
+const backfillWorkosIdMutation = `
+  mutation BackfillWorkosId($id: uuid!, $workos_user_id: String!) {
+    update_auth_accounts_by_pk(pk_columns: { id: $id }, _set: { workos_user_id: $workos_user_id }) {
+      id
+    }
+  }
+`;
+
+export async function findAccountByWorkosId(workosUserId) {
+  const result = await fetchGraphQL(findAccountByWorkosIdQuery, {
+    workos_user_id: workosUserId,
+  });
+  return result.data?.accounts?.[0] || null;
+}
+
+export async function findAccountByEmail(email) {
+  const result = await fetchGraphQL(findAccountByEmailQuery, { email });
+  return result.data?.accounts?.[0] || null;
+}
+
+export async function backfillWorkosId(accountId, workosUserId) {
+  await fetchGraphQL(backfillWorkosIdMutation, {
+    id: accountId,
+    workos_user_id: workosUserId,
+  });
+}
+
+// --- JIT Provisioning (T009) ---
+// NOTE: team derivation logic duplicated in services/{actions,cubejs} — keep in sync
+
+const CONSUMER_DOMAINS = [
+  "gmail.com",
+  "outlook.com",
+  "hotmail.com",
+  "yahoo.com",
+  "icloud.com",
+  "aol.com",
+  "protonmail.com",
+  "live.com",
+  "msn.com",
+  "ymail.com",
+  "googlemail.com",
+  "me.com",
+  "mac.com",
+];
+
+function isConsumerDomain(domain) {
+  return CONSUMER_DOMAINS.includes(domain.toLowerCase());
+}
+
+function deriveTeamName(email, partition) {
+  if (partition) {
+    return partition.toLowerCase().trim();
+  }
+  const emailDomain = email.split("@")[1]?.toLowerCase().trim();
+  return (isConsumerDomain(emailDomain) ? email : emailDomain)
+    .toLowerCase()
+    .trim();
+}
+
+const findTeamByNameQuery = `
+  query FindTeamByName($name: String!) {
+    teams(where: { name: { _eq: $name } }, limit: 1) {
+      id
+      user_id
+    }
+  }
+`;
+
+const createUserMutation = `
+  mutation CreateUser($display_name: String, $avatar_url: String) {
+    insert_users_one(object: { display_name: $display_name, avatar_url: $avatar_url }) {
+      id
+    }
+  }
+`;
+
+const createAccountMutation = `
+  mutation CreateAccount($user_id: uuid!, $email: citext!, $workos_user_id: String!) {
+    insert_auth_accounts_one(
+      object: {
+        user_id: $user_id,
+        email: $email,
+        workos_user_id: $workos_user_id,
+        active: true,
+        default_role: "user"
+      },
+      on_conflict: { constraint: accounts_email_key, update_columns: [workos_user_id] }
+    ) {
+      id
+      user_id
+    }
+  }
+`;
+
+const createTeamMutation = `
+  mutation CreateTeam($name: String!, $user_id: uuid!, $settings: jsonb) {
+    insert_teams_one(
+      object: { name: $name, user_id: $user_id, settings: $settings },
+      on_conflict: { constraint: teams_name_unique, update_columns: [] }
+    ) {
+      id
+    }
+  }
+`;
+
+const createMemberMutation = `
+  mutation CreateMember($user_id: uuid!, $team_id: uuid!) {
+    insert_members_one(
+      object: { user_id: $user_id, team_id: $team_id },
+      on_conflict: { constraint: members_user_id_team_id_key, update_columns: [] }
+    ) {
+      id
+    }
+  }
+`;
+
+const createMemberRoleMutation = `
+  mutation CreateMemberRole($member_id: uuid!, $team_role: team_roles_enum!) {
+    insert_member_roles_one(
+      object: { member_id: $member_id, team_role: $team_role },
+      on_conflict: { constraint: member_roles_member_id_team_role_key, update_columns: [] }
+    ) {
+      id
+    }
+  }
+`;
+
+const findMemberByUserAndTeamQuery = `
+  query FindMember($user_id: uuid!, $team_id: uuid!) {
+    members(where: { user_id: { _eq: $user_id }, team_id: { _eq: $team_id } }, limit: 1) {
+      id
+      member_roles { id }
+    }
+  }
+`;
+
+async function findTeamByName(name) {
+  const normalized = name.toLowerCase().trim();
+  const result = await fetchGraphQL(findTeamByNameQuery, { name: normalized });
+  return result.data?.teams?.[0] || null;
+}
+
+/**
+ * Ensure a user has membership + role in the org's team.
+ * Matches the Actions flow's ensureOrgTeam() in provision.js:230.
+ * Handles: existing account with missing membership, or membership with missing role.
+ */
+async function ensureTeamMembership(userId, email, partition) {
+  const teamName = deriveTeamName(email, partition);
+  let team = await findTeamByName(teamName);
+
+  if (!team) {
+    // Team doesn't exist yet — create it with this user as owner
+    const initialSettings = partition ? { partition } : {};
+    const teamResult = await fetchGraphQL(createTeamMutation, {
+      name: teamName,
+      user_id: userId,
+      settings: Object.keys(initialSettings).length > 0 ? initialSettings : null,
+    });
+    const teamId = teamResult.data?.insert_teams_one?.id;
+    if (teamId) {
+      team = { id: teamId };
+    } else {
+      team = await findTeamByName(teamName);
+    }
+  }
+
+  if (!team) return; // Can't reconcile without a team
+
+  // Ensure membership exists (on_conflict handles duplicate)
+  const memberResult = await fetchGraphQL(createMemberMutation, {
+    user_id: userId,
+    team_id: team.id,
+  });
+  let memberId = memberResult.data?.insert_members_one?.id;
+
+  // If on_conflict returned null, membership already exists — look it up
+  // and ensure member role exists (fixes partial provisioning retry)
+  if (!memberId) {
+    const existing = await fetchGraphQL(findMemberByUserAndTeamQuery, {
+      user_id: userId,
+      team_id: team.id,
+    });
+    const member = existing.data?.members?.[0];
+    if (member) {
+      memberId = member.id;
+      // If role already exists, skip
+      if (member.member_roles?.length > 0) return;
+    }
+  }
+
+  if (memberId) {
+    await fetchGraphQL(createMemberRoleMutation, {
+      member_id: memberId,
+      team_role: "member",
+    });
+  }
+}
+
+/**
+ * Provision a new user from WorkOS JWT payload.
+ * Identity resolution chain:
+ * 1. Check identity cache for payload.sub
+ * 2. DB lookup by workos_user_id
+ * 3. Fetch email from WorkOS API, DB lookup by email
+ * 4. If email match found, backfill workos_user_id
+ * 5. If no account found, create user + account + team + membership + role
+ *
+ * @param {Object} workosPayload - Verified WorkOS JWT payload
+ * @returns {Promise<string>} userId
+ */
+export async function provisionUserFromWorkOS(workosPayload) {
+  const sub = workosPayload.sub;
+  const partition = workosPayload.partition;
+
+  // Step 1: Check identity cache
+  const cached = getWorkosSubCacheEntry(sub);
+  if (cached) return cached.userId;
+
+  // Singleflight: dedup concurrent provision calls for the same sub
+  let inflight = inflightProvisions.get(sub);
+  if (inflight) return inflight;
+
+  const provision = _provisionUserFromWorkOS(sub, partition);
+  inflightProvisions.set(sub, provision);
+  provision.finally(() => inflightProvisions.delete(sub));
+  return provision;
+}
+
+async function _provisionUserFromWorkOS(sub, partition) {
+  // Re-check cache after acquiring singleflight (another request may have filled it)
+  const cached = getWorkosSubCacheEntry(sub);
+  if (cached) return cached.userId;
+
+  // Step 2: DB lookup by workos_user_id
+  let account = await findAccountByWorkosId(sub);
+  if (account) {
+    // Ensure membership exists in org team (matches Actions ensureOrgTeam)
+    await ensureTeamMembership(account.user_id, account.email, partition);
+    setWorkosSubCacheEntry(sub, account.user_id, true);
+    return account.user_id;
+  }
+
+  // Step 3: Fetch email from WorkOS API
+  const profile = await fetchWorkOSUserProfile(sub);
+
+  // Step 4: DB lookup by email
+  account = await findAccountByEmail(profile.email);
+  if (account) {
+    // Backfill workos_user_id if missing
+    if (!account.workos_user_id) {
+      await backfillWorkosId(account.id, sub);
+    }
+    // Ensure membership exists in org team (matches Actions ensureOrgTeam)
+    await ensureTeamMembership(account.user_id, profile.email, partition);
+    setWorkosSubCacheEntry(sub, account.user_id, true);
+    return account.user_id;
+  }
+
+  // Step 5: Create new user, account, team, membership, role
+  try {
+    const displayName =
+      [profile.firstName, profile.lastName].filter(Boolean).join(" ") ||
+      profile.email;
+
+    // Create user
+    const userResult = await fetchGraphQL(createUserMutation, {
+      display_name: displayName,
+      avatar_url: profile.profilePictureUrl || null,
+    });
+    const userId = userResult.data?.insert_users_one?.id;
+    if (!userId) {
+      const error = new Error("503: Unable to provision user");
+      error.status = 503;
+      throw error;
+    }
+
+    // Create account (on_conflict: accounts_email_key)
+    await fetchGraphQL(createAccountMutation, {
+      user_id: userId,
+      email: profile.email,
+      workos_user_id: sub,
+    });
+
+    // Find or create team (on_conflict: teams_name_unique)
+    const teamName = deriveTeamName(profile.email, partition);
+    let team = await findTeamByName(teamName);
+    let isTeamCreator = false;
+
+    if (!team) {
+      const initialSettings = partition ? { partition } : {};
+      const teamResult = await fetchGraphQL(createTeamMutation, {
+        name: teamName,
+        user_id: userId,
+        settings:
+          Object.keys(initialSettings).length > 0 ? initialSettings : null,
+      });
+
+      const teamId = teamResult.data?.insert_teams_one?.id;
+      if (teamId) {
+        team = { id: teamId };
+        isTeamCreator = true;
+      } else {
+        // on_conflict returned null — team was created concurrently, re-fetch
+        team = await findTeamByName(teamName);
+      }
+    }
+
+    if (!team) {
+      const error = new Error("503: Unable to provision user");
+      error.status = 503;
+      throw error;
+    }
+
+    // Create membership (on_conflict: members_user_id_team_id_key)
+    const memberResult = await fetchGraphQL(createMemberMutation, {
+      user_id: userId,
+      team_id: team.id,
+    });
+    let memberId = memberResult.data?.insert_members_one?.id;
+
+    // If on_conflict returned null, membership exists — look up the ID
+    // to ensure member role exists (retry-safety for partial provisioning)
+    if (!memberId) {
+      const existing = await fetchGraphQL(findMemberByUserAndTeamQuery, {
+        user_id: userId,
+        team_id: team.id,
+      });
+      const member = existing.data?.members?.[0];
+      memberId = member?.id;
+      // If role already exists, skip creation
+      if (member?.member_roles?.length > 0) memberId = null;
+    }
+
+    // Create member role (on_conflict: member_roles_member_id_team_role_key)
+    if (memberId) {
+      await fetchGraphQL(createMemberRoleMutation, {
+        member_id: memberId,
+        team_role: isTeamCreator ? "owner" : "member",
+      });
+    }
+
+    // Cache ONLY on full success (FR-013), mark membership verified
+    setWorkosSubCacheEntry(sub, userId, true);
+    return userId;
+  } catch (err) {
+    // Do NOT cache on failure — let next request retry
+    if (err.status) throw err;
+    const error = new Error("503: Unable to provision user");
+    error.status = 503;
+    throw error;
+  }
+}
+

--- a/services/cubejs/src/utils/defineUserScope.js
+++ b/services/cubejs/src/utils/defineUserScope.js
@@ -10,7 +10,9 @@ export const getDataSourceAccessList = (
   )?.member_roles?.[0];
 
   if (!dataSourceMemberRole) {
-    throw new Error(`403: member role not found`);
+    const error = new Error(`403: member role not found`);
+    error.status = 403;
+    throw error;
   }
 
   const { access_list: accessList } = dataSourceMemberRole;
@@ -35,7 +37,9 @@ const defineUserScope = (
   );
 
   if (!dataSource) {
-    throw new Error(`404: source "${selectedDataSourceId}" not found`);
+    const error = new Error(`404: source "${selectedDataSourceId}" not found`);
+    error.status = 404;
+    throw error;
   }
 
   let selectedBranch;
@@ -47,7 +51,9 @@ const defineUserScope = (
     );
 
     if (!branch) {
-      throw new Error(`404: branch "${selectedBranchId}" not found`);
+      const error = new Error(`404: branch "${selectedBranchId}" not found`);
+      error.status = 404;
+      throw error;
     }
 
     selectedBranch = branch;
@@ -57,7 +63,9 @@ const defineUserScope = (
     );
 
     if (!defaultBranch) {
-      throw new Error(`400: default branch not found`);
+      const error = new Error(`400: default branch not found`);
+      error.status = 400;
+      throw error;
     }
 
     selectedBranch = defaultBranch;
@@ -69,7 +77,9 @@ const defineUserScope = (
     );
 
     if (!version) {
-      throw new Error(`404: version "${selectedVersionId}" not found`);
+      const error = new Error(`404: version "${selectedVersionId}" not found`);
+      error.status = 404;
+      throw error;
     }
 
     selectedVersion = version;

--- a/services/cubejs/src/utils/graphql.js
+++ b/services/cubejs/src/utils/graphql.js
@@ -25,7 +25,9 @@ export const fetchGraphQL = async (query, variables, authToken) => {
   const res = await result.json();
 
   if (res.errors) {
-    throw new Error(JSON.stringify(res.errors));
+    const error = new Error(JSON.stringify(res.errors));
+    error.status = 503;
+    throw error;
   }
 
   return res;

--- a/services/cubejs/src/utils/workosAuth.js
+++ b/services/cubejs/src/utils/workosAuth.js
@@ -1,0 +1,126 @@
+import * as jose from "jose";
+
+const { WORKOS_CLIENT_ID, WORKOS_API_KEY, WORKOS_ISSUER } = process.env;
+
+// JWKS endpoint: use custom issuer if provided, otherwise default WorkOS URL
+const jwksBaseUrl = WORKOS_ISSUER || "https://api.workos.com";
+const JWKS_URL = new URL(`/sso/jwks/${WORKOS_CLIENT_ID}`, jwksBaseUrl);
+// WorkOS issuer format: {baseUrl}/user_management/{clientId}
+const issuer = WORKOS_ISSUER
+  ? `${WORKOS_ISSUER}/user_management/${WORKOS_CLIENT_ID}`
+  : `https://api.workos.com/user_management/${WORKOS_CLIENT_ID}`;
+
+// jose handles key caching, rotation, and cooldown automatically
+const jwks = jose.createRemoteJWKSet(JWKS_URL);
+
+/**
+ * Detect token type by decoding the JWT header without verification.
+ * @param {string} token - Raw JWT string
+ * @returns {"workos" | "hasura"} Token type
+ */
+export function detectTokenType(token) {
+  try {
+    const header = jose.decodeProtectedHeader(token);
+    return header.alg === "RS256" ? "workos" : "hasura";
+  } catch {
+    return "hasura"; // Default to existing path on decode failure
+  }
+}
+
+/**
+ * Verify a WorkOS RS256 JWT using the JWKS endpoint.
+ * @param {string} token - Raw JWT string
+ * @returns {Promise<Object>} Decoded JWT payload
+ * @throws {Error} With `status` property (403 for auth errors, 503 for JWKS failures)
+ */
+export async function verifyWorkOSToken(token) {
+  try {
+    const { payload } = await jose.jwtVerify(token, jwks, {
+      algorithms: ["RS256"],
+      issuer,
+    });
+    return payload;
+  } catch (err) {
+    const error = new Error(err.message);
+
+    if (err.code === "ERR_JWT_EXPIRED") {
+      error.message = "TokenExpiredError: jwt expired";
+      error.status = 403;
+    } else if (
+      err.code === "ERR_JWS_SIGNATURE_VERIFICATION_FAILED" ||
+      err.code === "ERR_JWT_CLAIM_VALIDATION_FAILED"
+    ) {
+      error.message = "JsonWebTokenError: invalid signature";
+      error.status = 403;
+    } else if (err.code === "ERR_JWKS_NO_MATCHING_KEY") {
+      // Key mismatch — token's kid doesn't match any JWKS key
+      error.message = "JsonWebTokenError: invalid signature";
+      error.status = 403;
+    } else if (
+      err.message.includes("fetch") ||
+      err.message.includes("ECONNREFUSED") ||
+      err.message.includes("network")
+    ) {
+      error.message = "503: Unable to verify token";
+      error.status = 503;
+    } else {
+      error.message = `JsonWebTokenError: ${err.message}`;
+      error.status = 403;
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Fetch a WorkOS user profile by their WorkOS user ID.
+ * @param {string} workosUserId - WorkOS user ID (e.g., "user_01KEC615...")
+ * @returns {Promise<{email: string, firstName: string|null, lastName: string|null, profilePictureUrl: string|null}>}
+ * @throws {Error} With `status` property (404, 503)
+ */
+export async function fetchWorkOSUserProfile(workosUserId) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const res = await fetch(
+      `https://api.workos.com/user_management/users/${workosUserId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${WORKOS_API_KEY}`,
+        },
+        signal: controller.signal,
+      }
+    );
+
+    if (!res.ok) {
+      const error = new Error(
+        res.status === 404
+          ? `404: WorkOS user "${workosUserId}" not found`
+          : `503: Unable to provision user`
+      );
+      error.status = res.status === 404 ? 404 : 503;
+      throw error;
+    }
+
+    const data = await res.json();
+    const firstName = data.first_name || data.firstName || null;
+    const lastName = data.last_name || data.lastName || null;
+
+    return {
+      email: data.email,
+      firstName,
+      lastName,
+      profilePictureUrl:
+        data.profile_picture_url || data.profilePictureUrl || null,
+    };
+  } catch (err) {
+    if (err.status) throw err; // Already has status property
+
+    const error = new Error("503: Unable to provision user");
+    error.status = 503;
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/services/cubejs/yarn.lock
+++ b/services/cubejs/yarn.lock
@@ -161,6 +161,52 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-redshift@^3.22.0":
+  version "3.1006.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/client-redshift/-/client-redshift-3.1006.0.tgz"
+  integrity sha512-uMVzJ5wcRHQSztsXqmLlpfD9WNEMxqX/78qgscE6IxYSRi1LJGkN6x+HsSMiQ5g6/TBJtczGdWHDicdnOOoYeA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/credential-provider-node" "^3.972.19"
+    "@aws-sdk/middleware-host-header" "^3.972.7"
+    "@aws-sdk/middleware-logger" "^3.972.7"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.7"
+    "@aws-sdk/middleware-user-agent" "^3.972.20"
+    "@aws-sdk/region-config-resolver" "^3.972.7"
+    "@aws-sdk/types" "^3.973.5"
+    "@aws-sdk/util-endpoints" "^3.996.4"
+    "@aws-sdk/util-user-agent-browser" "^3.972.7"
+    "@aws-sdk/util-user-agent-node" "^3.973.5"
+    "@smithy/config-resolver" "^4.4.10"
+    "@smithy/core" "^3.23.9"
+    "@smithy/fetch-http-handler" "^5.3.13"
+    "@smithy/hash-node" "^4.2.11"
+    "@smithy/invalid-dependency" "^4.2.11"
+    "@smithy/middleware-content-length" "^4.2.11"
+    "@smithy/middleware-endpoint" "^4.4.23"
+    "@smithy/middleware-retry" "^4.4.40"
+    "@smithy/middleware-serde" "^4.2.12"
+    "@smithy/middleware-stack" "^4.2.11"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/node-http-handler" "^4.4.14"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
+    "@smithy/url-parser" "^4.2.11"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.39"
+    "@smithy/util-defaults-mode-node" "^4.2.42"
+    "@smithy/util-endpoints" "^3.3.2"
+    "@smithy/util-middleware" "^4.2.11"
+    "@smithy/util-retry" "^4.2.11"
+    "@smithy/util-utf8" "^4.2.2"
+    "@smithy/util-waiter" "^4.2.12"
+    tslib "^2.6.2"
+
 "@aws-sdk/client-s3@^3.49.0", "@aws-sdk/client-s3@^3.726.0":
   version "3.919.0"
   resolved "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.919.0.tgz"
@@ -313,6 +359,25 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/core@^3.973.19":
+  version "3.973.19"
+  resolved "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.19.tgz"
+  integrity sha512-56KePyOcZnKTWCd89oJS1G6j3HZ9Kc+bh/8+EbvtaCCXdP6T7O7NzCiPuHRhFLWnzXIaXX3CxAz0nI5My9spHQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@aws-sdk/xml-builder" "^3.972.10"
+    "@smithy/core" "^3.23.9"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/signature-v4" "^5.3.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-middleware" "^4.2.11"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
 "@aws-sdk/core@3.916.0":
   version "3.916.0"
   resolved "https://registry.npmjs.org/@aws-sdk/core/-/core-3.916.0.tgz"
@@ -343,6 +408,17 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-env@^3.972.17":
+  version "3.972.17"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.17.tgz"
+  integrity sha512-MBAMW6YELzE1SdkOniqr51mrjapQUv8JXSGxtwRjQV0mwVDutVsn22OPAUt4RcLRvdiHQmNBDEFP9iTeSVCOlA==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-env@3.916.0":
   version "3.916.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.916.0.tgz"
@@ -352,6 +428,22 @@
     "@aws-sdk/types" "3.914.0"
     "@smithy/property-provider" "^4.2.3"
     "@smithy/types" "^4.8.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.19":
+  version "3.972.19"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.19.tgz"
+  integrity sha512-9EJROO8LXll5a7eUFqu48k6BChrtokbmgeMWmsH7lBb6lVbtjslUYz/ShLi+SHkYzTomiGBhmzTW7y+H4BxsnA==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/fetch-http-handler" "^5.3.13"
+    "@smithy/node-http-handler" "^4.4.14"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-stream" "^4.5.17"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-http@3.916.0":
@@ -368,6 +460,26 @@
     "@smithy/smithy-client" "^4.9.1"
     "@smithy/types" "^4.8.0"
     "@smithy/util-stream" "^4.5.4"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.972.18":
+  version "3.972.18"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.18.tgz"
+  integrity sha512-vthIAXJISZnj2576HeyLBj4WTeX+I7PwWeRkbOa0mVX39K13SCGxCgOFuKj2ytm9qTlLOmXe4cdEnroteFtJfw==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/credential-provider-env" "^3.972.17"
+    "@aws-sdk/credential-provider-http" "^3.972.19"
+    "@aws-sdk/credential-provider-login" "^3.972.18"
+    "@aws-sdk/credential-provider-process" "^3.972.17"
+    "@aws-sdk/credential-provider-sso" "^3.972.18"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.18"
+    "@aws-sdk/nested-clients" "^3.996.8"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/credential-provider-imds" "^4.2.11"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-ini@3.919.0":
@@ -389,6 +501,20 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-login@^3.972.18":
+  version "3.972.18"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.18.tgz"
+  integrity sha512-kINzc5BBxdYBkPZ0/i1AMPMOk5b5QaFNbYMElVw5QTX13AKj6jcxnv/YNl9oW9mg+Y08ti19hh01HhyEAxsSJQ==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/nested-clients" "^3.996.8"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-node@^3.823.0", "@aws-sdk/credential-provider-node@3.919.0":
   version "3.919.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.919.0.tgz"
@@ -407,6 +533,36 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@^3.972.19":
+  version "3.972.19"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.19.tgz"
+  integrity sha512-yDWQ9dFTr+IMxwanFe7+tbN5++q8psZBjlUwOiCXn1EzANoBgtqBwcpYcHaMGtn0Wlfj4NuXdf2JaEx1lz5RaQ==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.17"
+    "@aws-sdk/credential-provider-http" "^3.972.19"
+    "@aws-sdk/credential-provider-ini" "^3.972.18"
+    "@aws-sdk/credential-provider-process" "^3.972.17"
+    "@aws-sdk/credential-provider-sso" "^3.972.18"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.18"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/credential-provider-imds" "^4.2.11"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.17":
+  version "3.972.17"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.17.tgz"
+  integrity sha512-c8G8wT1axpJDgaP3xzcy+q8Y1fTi9A2eIQJvyhQ9xuXrUZhlCfXbC0vM9bM1CUXiZppFQ1p7g0tuUMvil/gCPg==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@3.916.0":
   version "3.916.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.916.0.tgz"
@@ -417,6 +573,20 @@
     "@smithy/property-provider" "^4.2.3"
     "@smithy/shared-ini-file-loader" "^4.3.3"
     "@smithy/types" "^4.8.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.972.18":
+  version "3.972.18"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.18.tgz"
+  integrity sha512-YHYEfj5S2aqInRt5ub8nDOX8vAxgMvd84wm2Y3WVNfFa/53vOv9T7WOAqXI25qjj3uEcV46xxfqdDQk04h5XQA==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/nested-clients" "^3.996.8"
+    "@aws-sdk/token-providers" "3.1005.0"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-sso@3.919.0":
@@ -431,6 +601,19 @@
     "@smithy/property-provider" "^4.2.3"
     "@smithy/shared-ini-file-loader" "^4.3.3"
     "@smithy/types" "^4.8.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.18":
+  version "3.972.18"
+  resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.18.tgz"
+  integrity sha512-OqlEQpJ+J3T5B96qtC1zLLwkBloechP+fezKbCH0sbd2cCc0Ra55XpxWpk/hRj69xAOYtHvoC4orx6eTa4zU7g==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/nested-clients" "^3.996.8"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-web-identity@3.919.0":
@@ -526,6 +709,16 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-host-header@^3.972.7":
+  version "3.972.7"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz"
+  integrity sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-host-header@3.914.0":
   version "3.914.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.914.0.tgz"
@@ -545,6 +738,15 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-logger@^3.972.7":
+  version "3.972.7"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz"
+  integrity sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-logger@3.914.0":
   version "3.914.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.914.0.tgz"
@@ -552,6 +754,17 @@
   dependencies:
     "@aws-sdk/types" "3.914.0"
     "@smithy/types" "^4.8.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@^3.972.7":
+  version "3.972.7"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz"
+  integrity sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@aws/lambda-invoke-store" "^0.2.2"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@aws-sdk/middleware-recursion-detection@3.919.0":
@@ -594,6 +807,20 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-user-agent@^3.972.20":
+  version "3.972.20"
+  resolved "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.20.tgz"
+  integrity sha512-3kNTLtpUdeahxtnJRnj/oIdLAUdzTfr9N40KtxNhtdrq+Q1RPMdCJINRXq37m4t5+r3H70wgC3opW46OzFcZYA==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/types" "^3.973.5"
+    "@aws-sdk/util-endpoints" "^3.996.4"
+    "@smithy/core" "^3.23.9"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-retry" "^4.2.11"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-user-agent@3.916.0":
   version "3.916.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.916.0.tgz"
@@ -605,6 +832,50 @@
     "@smithy/core" "^3.17.1"
     "@smithy/protocol-http" "^5.3.3"
     "@smithy/types" "^4.8.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.996.8":
+  version "3.996.8"
+  resolved "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.8.tgz"
+  integrity sha512-6HlLm8ciMW8VzfB80kfIx16PBA9lOa9Dl+dmCBi78JDhvGlx3I7Rorwi5PpVRkL31RprXnYna3yBf6UKkD/PqA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/middleware-host-header" "^3.972.7"
+    "@aws-sdk/middleware-logger" "^3.972.7"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.7"
+    "@aws-sdk/middleware-user-agent" "^3.972.20"
+    "@aws-sdk/region-config-resolver" "^3.972.7"
+    "@aws-sdk/types" "^3.973.5"
+    "@aws-sdk/util-endpoints" "^3.996.4"
+    "@aws-sdk/util-user-agent-browser" "^3.972.7"
+    "@aws-sdk/util-user-agent-node" "^3.973.5"
+    "@smithy/config-resolver" "^4.4.10"
+    "@smithy/core" "^3.23.9"
+    "@smithy/fetch-http-handler" "^5.3.13"
+    "@smithy/hash-node" "^4.2.11"
+    "@smithy/invalid-dependency" "^4.2.11"
+    "@smithy/middleware-content-length" "^4.2.11"
+    "@smithy/middleware-endpoint" "^4.4.23"
+    "@smithy/middleware-retry" "^4.4.40"
+    "@smithy/middleware-serde" "^4.2.12"
+    "@smithy/middleware-stack" "^4.2.11"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/node-http-handler" "^4.4.14"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
+    "@smithy/url-parser" "^4.2.11"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-body-length-node" "^4.2.3"
+    "@smithy/util-defaults-mode-browser" "^4.3.39"
+    "@smithy/util-defaults-mode-node" "^4.2.42"
+    "@smithy/util-endpoints" "^3.3.2"
+    "@smithy/util-middleware" "^4.2.11"
+    "@smithy/util-retry" "^4.2.11"
+    "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
 "@aws-sdk/nested-clients@3.919.0":
@@ -651,6 +922,17 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/region-config-resolver@^3.972.7":
+  version "3.972.7"
+  resolved "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz"
+  integrity sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/config-resolver" "^4.4.10"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/region-config-resolver@3.914.0":
   version "3.914.0"
   resolved "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.914.0.tgz"
@@ -687,6 +969,19 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/token-providers@3.1005.0":
+  version "3.1005.0"
+  resolved "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1005.0.tgz"
+  integrity sha512-vMxd+ivKqSxU9bHx5vmAlFKDAkjGotFU56IOkDa5DaTu1WWwbcse0yFHEm9I537oVvodaiwMl3VBwgHfzQ2rvw==
+  dependencies:
+    "@aws-sdk/core" "^3.973.19"
+    "@aws-sdk/nested-clients" "^3.996.8"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/token-providers@3.919.0":
   version "3.919.0"
   resolved "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.919.0.tgz"
@@ -708,11 +1003,30 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
+"@aws-sdk/types@^3.973.5":
+  version "3.973.5"
+  resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz"
+  integrity sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-arn-parser@3.893.0":
   version "3.893.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz"
   integrity sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==
   dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-endpoints@^3.996.4":
+  version "3.996.4"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz"
+  integrity sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/types" "^4.13.0"
+    "@smithy/url-parser" "^4.2.11"
+    "@smithy/util-endpoints" "^3.3.2"
     tslib "^2.6.2"
 
 "@aws-sdk/util-endpoints@3.916.0":
@@ -743,6 +1057,16 @@
   dependencies:
     tslib "^2.6.2"
 
+"@aws-sdk/util-user-agent-browser@^3.972.7":
+  version "3.972.7"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz"
+  integrity sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==
+  dependencies:
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/types" "^4.13.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-user-agent-browser@3.914.0":
   version "3.914.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.914.0.tgz"
@@ -751,6 +1075,17 @@
     "@aws-sdk/types" "3.914.0"
     "@smithy/types" "^4.8.0"
     bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@^3.973.5":
+  version "3.973.5"
+  resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.5.tgz"
+  integrity sha512-Dyy38O4GeMk7UQ48RupfHif//gqnOPbq/zlvRssc11E2mClT+aUfc3VS2yD8oLtzqO3RsqQ9I3gOBB4/+HjPOw==
+  dependencies:
+    "@aws-sdk/middleware-user-agent" "^3.972.20"
+    "@aws-sdk/types" "^3.973.5"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@aws-sdk/util-user-agent-node@3.916.0":
@@ -762,6 +1097,15 @@
     "@aws-sdk/types" "3.914.0"
     "@smithy/node-config-provider" "^4.3.3"
     "@smithy/types" "^4.8.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.10":
+  version "3.972.10"
+  resolved "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz"
+  integrity sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    fast-xml-parser "5.4.1"
     tslib "^2.6.2"
 
 "@aws-sdk/xml-builder@3.914.0":
@@ -777,6 +1121,11 @@
   version "0.1.1"
   resolved "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz"
   integrity sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==
+
+"@aws/lambda-invoke-store@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz"
+  integrity sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==
 
 "@azure-rest/core-client@^2.3.3":
   version "2.5.1"
@@ -1818,14 +2167,14 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz"
   integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
 
-"@cubejs-backend/api-gateway@^1.3.23", "@cubejs-backend/api-gateway@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/api-gateway/-/api-gateway-1.3.86.tgz"
-  integrity sha512-EgixpwUc9PIso7W49APCp0URSuWqqEzNDEAeCjA0iA3vGFaAgGw2zApz0umyPD36Ea6Iid2W2/FWKSbLkvpWaQ==
+"@cubejs-backend/api-gateway@^1.6.19", "@cubejs-backend/api-gateway@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/api-gateway/-/api-gateway-1.6.21.tgz"
+  integrity sha512-7CruAT2EFPfYLs1HGvdg7ma18P8LVGsJ9CVJgo/PJYORocJBzsuh9phZHT/584So7UxnRvD+RLpUFQOwFXm+VA==
   dependencies:
-    "@cubejs-backend/native" "1.3.86"
-    "@cubejs-backend/query-orchestrator" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/native" "1.6.21"
+    "@cubejs-backend/query-orchestrator" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     "@ungap/structured-clone" "^0.3.4"
     assert-never "^1.4.0"
     body-parser "^1.19.0"
@@ -1846,16 +2195,17 @@
     node-fetch "^2.6.1"
     ramda "^0.27.0"
     uuid "^8.3.2"
+    zod "^4.1.13"
 
-"@cubejs-backend/athena-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/athena-driver/-/athena-driver-1.3.85.tgz"
-  integrity sha512-YtJPZ03h3KjkYBko+BEyDmdV4WJXM3JypySbiMMiVxfuXu47MFr1WdKC6om6WH2Lm4GZ7UgfCtZbAlLSbMin9A==
+"@cubejs-backend/athena-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/athena-driver/-/athena-driver-1.6.21.tgz"
+  integrity sha512-/auh/zZq3CQNsTK17hMFs9uzJrn+H/WwAP4fWi77GQQ4V8mGRThaBQo5GkytwAyghppEC/fN+6p954A+e1jwkQ==
   dependencies:
     "@aws-sdk/client-athena" "^3.22.0"
     "@aws-sdk/credential-providers" "^3.22.0"
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     sqlstring "^2.3.1"
 
 "@cubejs-backend/base-driver@^0.36.11":
@@ -1871,61 +2221,49 @@
     "@google-cloud/storage" "^7.13.0"
     ramda "^0.27.0"
 
-"@cubejs-backend/base-driver@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.3.85.tgz"
-  integrity sha512-A3zat+PEPKjW7aHQYe6Xp/q6E2cQG9HDHICwKuFWwODlV3bJEbGrVZQUSarhh6XxG+8C5dsmdPMhV7yg8398uQ==
+"@cubejs-backend/base-driver@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.6.21.tgz"
+  integrity sha512-5F44jPXttVLKmAiRjGqvpO6PLoUHsrsEeOBtIvL7hwIXDdqCwwz6H84XDyPcIeckyzM2qQVVmxCoL7kVq0Dmdg==
   dependencies:
     "@aws-sdk/client-s3" "^3.49.0"
     "@aws-sdk/s3-request-presigner" "^3.49.0"
     "@azure/identity" "^4.4.1"
     "@azure/storage-blob" "^12.9.0"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/shared" "1.6.21"
     "@google-cloud/storage" "^7.13.0"
 
-"@cubejs-backend/base-driver@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/base-driver/-/base-driver-1.3.86.tgz"
-  integrity sha512-BB7xqtThocXIjTMCwwTpk3S1erau6UHEScnodt+HHxsXYrPGMsUNlw1qoUHeGalHyX/qfWN8hl6uDzYx3vdxRQ==
+"@cubejs-backend/bigquery-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/bigquery-driver/-/bigquery-driver-1.6.21.tgz"
+  integrity sha512-blEyLjNpfQPkEXW34JUHJBcunOpshjZZJn8QK+3F8ie9v0VGLQ1sVp0XPc2N0WUYGSCNjqORclI/pFtE4Q9Znw==
   dependencies:
-    "@aws-sdk/client-s3" "^3.49.0"
-    "@aws-sdk/s3-request-presigner" "^3.49.0"
-    "@azure/identity" "^4.4.1"
-    "@azure/storage-blob" "^12.9.0"
-    "@cubejs-backend/shared" "1.3.86"
-    "@google-cloud/storage" "^7.13.0"
-
-"@cubejs-backend/bigquery-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/bigquery-driver/-/bigquery-driver-1.3.85.tgz"
-  integrity sha512-GYS1B00sSfFwDmlwG9s59fuxZnxvWp46Fi4RxE1658LgPJsoCquwK+8Vq7wVY2WVjT78rRzIRSJY23DK0OSOvA==
-  dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
     "@cubejs-backend/dotenv" "^9.0.2"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/shared" "1.6.21"
     "@google-cloud/bigquery" "^7.7.0"
     "@google-cloud/storage" "^7.13.0"
     ramda "^0.27.2"
 
-"@cubejs-backend/clickhouse-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/clickhouse-driver/-/clickhouse-driver-1.3.85.tgz"
-  integrity sha512-52N6qfJQZ2ZsEa7COIkJTcZqsv0PTF2aT8g6B9/WIHkqlKg4GOH5mZy7Eh1zdHJIzJsQhNP88cMTmzRAS48q1g==
+"@cubejs-backend/clickhouse-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/clickhouse-driver/-/clickhouse-driver-1.6.21.tgz"
+  integrity sha512-Q4NgoG2KybZmEoEwmBqLXmzrJdoPm9GEq4lajcmWj9YT+R1j0/ogNm4AtolzpHL+1uEO84pPQNbMh6wCwFfPtA==
   dependencies:
     "@clickhouse/client" "^1.12.0"
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     moment "^2.24.0"
     sqlstring "^2.3.1"
     uuid "^8.3.2"
 
-"@cubejs-backend/cloud@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/cloud/-/cloud-1.3.86.tgz"
-  integrity sha512-a5zTbccCxpussv+bVA6KRWDwpY7EOOI2qnlzOqWp45wxYD0xf+MeBRLsAvOHiQiBti0rFE9cml8LCyPs6HmvWA==
+"@cubejs-backend/cloud@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/cloud/-/cloud-1.6.21.tgz"
+  integrity sha512-8RLVtUkiznVemO0PphoZhb8/jq38SOBnKjN3zG3LZGBFvAUY8Wz+/6AxwA07cju6IF8ejwcE8p2IS+7TTm7xxw==
   dependencies:
     "@cubejs-backend/dotenv" "^9.0.2"
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/shared" "1.6.21"
     chokidar "^3.5.1"
     env-var "^6.3.0"
     form-data "^4.0.0"
@@ -1933,29 +2271,23 @@
     jsonwebtoken "^9.0.2"
     node-fetch "^2.7.0"
 
-"@cubejs-backend/crate-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/crate-driver/-/crate-driver-1.3.85.tgz"
-  integrity sha512-v76IHkisdeZYLMshxvcgKUs7+wCcpoymPMdBohAVFcfWPgdtQk4f6H+cohuIrGwApk+HJ6zlhOVPPvcPXPhKsw==
+"@cubejs-backend/crate-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/crate-driver/-/crate-driver-1.6.21.tgz"
+  integrity sha512-kritQUokwzq56bY+8jutTWMfwzhxxKZO7Daweri9TDZNXHZvPpsHZViMP1rmZcwamtPKELM+nqGfXSl4DxsCNw==
   dependencies:
-    "@cubejs-backend/postgres-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
-    pg "^8.7.1"
+    "@cubejs-backend/postgres-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
 
 "@cubejs-backend/cubesql@^0.36.9":
   version "0.36.9"
   resolved "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-0.36.9.tgz"
   integrity sha512-W/9qvvZFy3Xq655/D2leVkx3EEJJs1Agw6gE6HMFLsReuxBvbkWywOrxNsbHZiwZJgVh/ylRuBKF7EW6PIDwig==
 
-"@cubejs-backend/cubesql@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.3.85.tgz"
-  integrity sha512-nFQWAmmXCTinrIhKDb+76ugIwWIp/nmQCTAcoCApklVrCHdf6itBq8MhJ1znJtKKuUHeYOxFEKOdD3ZLKDbIig==
-
-"@cubejs-backend/cubesql@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.3.86.tgz"
-  integrity sha512-jOhn3FYojeqNcN4Jdx/ke72Vqw0/sA8wDtjcFGtr4uj+gcRThJggKCdTLflBkqNSs6O/Mzdr0LsIJ59NJD9k4g==
+"@cubejs-backend/cubesql@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/cubesql/-/cubesql-1.6.21.tgz"
+  integrity sha512-tc56NqRhrS/D8QAFCcJVEuKKK2aMMzqTecEkwXc8ASEElTqssnd61pqw0vfCw0YdDfv/h5lJS0Ap/vGGCLl8Hg==
 
 "@cubejs-backend/cubestore-driver@^0.36.11":
   version "0.36.11"
@@ -1976,19 +2308,18 @@
     uuid "^8.3.2"
     ws "^7.4.3"
 
-"@cubejs-backend/cubestore-driver@^1.3.23", "@cubejs-backend/cubestore-driver@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/cubestore-driver/-/cubestore-driver-1.3.86.tgz"
-  integrity sha512-GZMHiLteFyeu1o2LwABPiV8ciRGlRKJhXHmR6++R1+OFyGUlQP0km5zvPqot7rMxGrygMiZ5XnnlHqDMCUVYvA==
+"@cubejs-backend/cubestore-driver@^1.6.19", "@cubejs-backend/cubestore-driver@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/cubestore-driver/-/cubestore-driver-1.6.21.tgz"
+  integrity sha512-5ithEUSXuBwwEjaws5eo9qQ4CfleXOSRUIffVvV0vem/+7kHn49RWehI3vh5NPwYBP5M/BvWVZx34/0IHCi02Q==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.86"
-    "@cubejs-backend/cubestore" "1.3.86"
-    "@cubejs-backend/native" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/cubestore" "1.6.21"
+    "@cubejs-backend/native" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     csv-write-stream "^2.0.0"
     flatbuffers "23.3.3"
     fs-extra "^9.1.0"
-    generic-pool "^3.8.2"
     node-fetch "^2.6.1"
     sqlstring "^2.3.3"
     tempy "^1.0.1"
@@ -2004,24 +2335,24 @@
     "@octokit/core" "^3.2.5"
     source-map-support "^0.5.19"
 
-"@cubejs-backend/cubestore@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/cubestore/-/cubestore-1.3.86.tgz"
-  integrity sha512-38Embcvv/hye/qlOYej4PlUQCWtnNdiPcLyP7tFVCi14erePn2jUVYSeRDmJfly6oXX0dDBn2cQP89Hed31nSQ==
+"@cubejs-backend/cubestore@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/cubestore/-/cubestore-1.6.21.tgz"
+  integrity sha512-Qae5PErRyXVn/hSmdmgXYJD+R7WiE4KqzDhagq2Joqlf10hgMzR9w7L0o1ayxO+8oamHX8mXnujO0ERsWykPyw==
   dependencies:
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/shared" "1.6.21"
     "@octokit/core" "^3.2.5"
     source-map-support "^0.5.19"
 
-"@cubejs-backend/databricks-jdbc-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/databricks-jdbc-driver/-/databricks-jdbc-driver-1.3.85.tgz"
-  integrity sha512-RJv/9zRQFKokcdol15r6I/ShV/txj42snmoan5FWIe6TFMQ6xxENDRbZOl2iEOWZgcqksw3kJvhSR7pYiphw1g==
+"@cubejs-backend/databricks-jdbc-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/databricks-jdbc-driver/-/databricks-jdbc-driver-1.6.21.tgz"
+  integrity sha512-zhjSK9XJh0uXPVIhjtybTirG1+EftmqqRbpdnU+1Lo0tBMpYhxgu6u61zn2maV5MG7rhZVN6VgPqNrGq7c7L0A==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/jdbc-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/jdbc-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     node-fetch "^2.6.1"
     ramda "^0.27.2"
     source-map-support "^0.5.19"
@@ -2032,139 +2363,133 @@
   resolved "https://registry.npmjs.org/@cubejs-backend/dotenv/-/dotenv-9.0.2.tgz"
   integrity sha512-yC1juhXEjM7K97KfXubDm7WGipd4Lpxe+AT8XeTRE9meRULrKlw0wtE2E8AQkGOfTBn+P1SCkePQ/BzIbOh1VA==
 
-"@cubejs-backend/dremio-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/dremio-driver/-/dremio-driver-1.3.85.tgz"
-  integrity sha512-Hk6NWDmVgKUJ+u2fwgDing+nJTNHHOa1fqYZJNTOU8L5DUYPiSkII4LvQmvsFlrPca1AgKTSpnEmIHitExfXyQ==
+"@cubejs-backend/dremio-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/dremio-driver/-/dremio-driver-1.6.21.tgz"
+  integrity sha512-PImAs/kG1JgQiGuJKDJEERnoEoZ74xWZORBkbQsBVOS/31LYS8yHuNYlVgjLhQ498IrvBDd/HJefgQ4cDrKC5Q==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     axios "^1.8.3"
     sqlstring "^2.3.1"
 
-"@cubejs-backend/druid-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/druid-driver/-/druid-driver-1.3.85.tgz"
-  integrity sha512-xx0jaieVvuB67yMruFDhlXf2RNmOrSF/CY2a/OjXxLAUGt2v0JMef4gVNA+GCzOLqSaJE6sFJgt7zeMKMjGbnw==
+"@cubejs-backend/druid-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/druid-driver/-/druid-driver-1.6.21.tgz"
+  integrity sha512-B50NuXTPATKPVJK/Ek8FUVxwblV93ia0RoGcQKH9Vc9+taap55/9/mJCJENxCFzpM3HRusThcZrjf2fs34/yfA==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     axios "^1.8.3"
 
-"@cubejs-backend/duckdb-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/duckdb-driver/-/duckdb-driver-1.3.85.tgz"
-  integrity sha512-F0Yz2j5Hmbj5VlkAMVa0ZXAHzkiEi+DXuT5BMBPcyNx11n478SJ4x3MJjRlXT1WumxgQtyFOTNJTolAhWE7hvA==
+"@cubejs-backend/duckdb-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/duckdb-driver/-/duckdb-driver-1.6.21.tgz"
+  integrity sha512-mY6rz4l6atpH8jJxHClaOWeVm9JWCUMeNSUyUWwJTBH8uQMvxx1FcUpNtcwFSSkkwvaAmKdRYfM7BrZHFSKNUg==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
-    duckdb "^1.3.1"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
+    duckdb "^1.4.1"
 
-"@cubejs-backend/elasticsearch-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/elasticsearch-driver/-/elasticsearch-driver-1.3.85.tgz"
-  integrity sha512-DLFc+tOJ/bocn3n5FkIa9chPENGVkYmLuH++PXUK5FWFISgi62BMa/ctMoWjoj96H4xi0pFQ6lZRmNENduhFxg==
+"@cubejs-backend/elasticsearch-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/elasticsearch-driver/-/elasticsearch-driver-1.6.21.tgz"
+  integrity sha512-vNFZsgoP3RU9AIQuHkOB+U/NaRvkGAydEmkOKWvtvBm5bp/o66boqiqdlq8NSr6PMYKDWfY/8alOENeCbtow3Q==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     "@elastic/elasticsearch" "7.12.0"
     sqlstring "^2.3.1"
 
-"@cubejs-backend/firebolt-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/firebolt-driver/-/firebolt-driver-1.3.85.tgz"
-  integrity sha512-Z3DogTZ1vlys1eY5h9jByFP3IVxVmEriNfq7yLp1UYlKiJof4AMO3YUd3F5YpI0itgWcjXLO4xgfvS/ntwrRXg==
+"@cubejs-backend/firebolt-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/firebolt-driver/-/firebolt-driver-1.6.21.tgz"
+  integrity sha512-fZq8SESpTPRdBwDe7QJrwvqlAdYgk5zg6OGRPI3Amtacx5F/ayUjdvUeQLyvll2H6lJrI0IIYS9FjQN3w/Yj0Q==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     firebolt-sdk "1.10.0"
 
-"@cubejs-backend/hive-driver@^1.3.23":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/hive-driver/-/hive-driver-1.3.86.tgz"
-  integrity sha512-zB3iMEKlkS08loJJ5YN82B1BA9dRMp75WNq4cEcAIBwrr7FKjVCAtd9kLDtBTZOKWfn8jjkceMsXO8L2VkQ9Ng==
+"@cubejs-backend/hive-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/hive-driver/-/hive-driver-1.6.21.tgz"
+  integrity sha512-Y7v+xiUGw1f256AooULrHdcr/aNW1UngsV0rj5LOT9FBHfZoO7pJzunK5wz6BkuDtEupxswX7DK7j0yVxxGYyA==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
-    generic-pool "^3.8.2"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     jshs2 "^0.4.4"
     sasl-plain "^0.1.0"
     saslmechanisms "^0.1.1"
     sqlstring "^2.3.1"
     thrift "^0.20.0"
 
-"@cubejs-backend/jdbc-driver@^1.3.23", "@cubejs-backend/jdbc-driver@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/jdbc-driver/-/jdbc-driver-1.3.85.tgz"
-  integrity sha512-dyqjhc7xGtMuVSdE2QHjDpvZ+++1fRlPnOpg6hJZlC8TXS09YAbR0zwgo9MrHq3EMiF5t2c3Fg8ZVMT27ruaRQ==
+"@cubejs-backend/jdbc-driver@^1.6.19", "@cubejs-backend/jdbc-driver@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/jdbc-driver/-/jdbc-driver-1.6.21.tgz"
+  integrity sha512-33rePBa0vOGQNg5AUpijxrX5ev0DdXWq7i5PRkN9mek29DR4UjDs3nlDMbdaKF/WE1yXrqYi55a8d593SInvIg==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
     "@cubejs-backend/node-java-maven" "^0.1.3"
-    "@cubejs-backend/shared" "1.3.85"
-    generic-pool "^3.9.0"
+    "@cubejs-backend/shared" "1.6.21"
     sqlstring "^2.3.0"
   optionalDependencies:
     "@cubejs-backend/jdbc" "^0.8.1"
     java "^0.14.0"
 
-"@cubejs-backend/ksql-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/ksql-driver/-/ksql-driver-1.3.85.tgz"
-  integrity sha512-1hRrkOz/nMCQPHgYDdT/t15FNHSwNgzvcCPNh3m9ql92G6SOIbM4787+P+F+rEI6oRAkrp8R48aZ0fomeOo5gQ==
+"@cubejs-backend/ksql-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/ksql-driver/-/ksql-driver-1.6.21.tgz"
+  integrity sha512-YEk3TH1FjERgoiA/kf5oSlrmnl+NviCtZNqi0fsh5X+qEOb00MOnWCXZQ4L1JE2HKchZ+JNbOfY1tQ6Wl4od8w==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     async-mutex "0.3.2"
     axios "^1.8.3"
     kafkajs "^2.2.3"
     sqlstring "^2.3.1"
 
-"@cubejs-backend/materialize-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/materialize-driver/-/materialize-driver-1.3.85.tgz"
-  integrity sha512-HH9GboIKic0iR32ScmcSSKS+z8hsQ2YXRzQAl2RACf8LPxcyjhFTPFAYYt08gvBLI9wnl2gFJjLaw5xvhcCj5Q==
+"@cubejs-backend/materialize-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/materialize-driver/-/materialize-driver-1.6.21.tgz"
+  integrity sha512-oHAwY09l+dg2I6Fi2UZS8K+KyTWxKPhwbQKayHlgZnPe1nFYkpveBmLKhsa9IoVeGk5jMaxtnMDIeFwdK7RUPg==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/postgres-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
-    "@types/pg" "^8.6.0"
-    pg "^8.6.0"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/postgres-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     semver "^7.6.3"
 
-"@cubejs-backend/mongobi-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/mongobi-driver/-/mongobi-driver-1.3.85.tgz"
-  integrity sha512-g6lNVh8haWfoeZvI02+oQl8XJ/rBOeX9ff1X7OcKa9jkvEuFMXlkkBXgbGdflQx1tIuncTbZeCTB39RhjS1AUw==
+"@cubejs-backend/mongobi-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/mongobi-driver/-/mongobi-driver-1.6.21.tgz"
+  integrity sha512-sGXGQojr6xyS3JgfJxAffhhZKzAHc28AoNaCV2Z2OYv7bae4jAvlz3sG/iVu49yFifiaSD785GeTD50ASE6ekQ==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     "@types/node" "^20"
-    generic-pool "^3.9.0"
     moment "^2.29.1"
     mysql2 "^3.11.5"
 
-"@cubejs-backend/mssql-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/mssql-driver/-/mssql-driver-1.3.85.tgz"
-  integrity sha512-QXoinkDZEScc9UiKm5oFE+ohufvXt5/1XywVPiSjkgtEtuFKrItWm+oV0w0VVkC2zMfqWiNcatt5dZPE9julrw==
+"@cubejs-backend/mssql-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/mssql-driver/-/mssql-driver-1.6.21.tgz"
+  integrity sha512-KLgXIAqI5nQ6zDDcEUaG6HEn10dhmPh5HF9Z3H0wmhQQo9bkLZAFaRD5kfM597a2tuwZslajOIUsXmb5nYbaMg==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     mssql "^11.0.1"
 
-"@cubejs-backend/mysql-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/mysql-driver/-/mysql-driver-1.3.85.tgz"
-  integrity sha512-PYRs/T6dSUnsjd1K/k2YrnZPbf+89N0wAP7GEPGswb01Jusr3VkNoCpB0xSzCjz7l1RecKTxMUFm4S2i1jpObg==
+"@cubejs-backend/mysql-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/mysql-driver/-/mysql-driver-1.6.21.tgz"
+  integrity sha512-oCLVD443YQwU5vkogrOkBJCkkPGp14DkHmiCi0MwnEs9IUxd08oRZFkW/F49QkgOh3HEF3a0vJdhMsaQsD+zkg==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
-    generic-pool "^3.9.0"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     mysql "^2.18.1"
 
 "@cubejs-backend/native@^0.36.11":
@@ -2176,22 +2501,13 @@
     "@cubejs-backend/shared" "^0.36.11"
     "@cubejs-infra/post-installer" "^0.0.7"
 
-"@cubejs-backend/native@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.3.85.tgz"
-  integrity sha512-bvP1Hm1o0QORYGlSDrkDUPqv+J8oxpOpSNECt27ajlWr1ELfwCLSr7ugbfow9pXhI4IO14NUrRJWf9fj0njJLg==
+"@cubejs-backend/native@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.6.21.tgz"
+  integrity sha512-+JAyAe88moGWilAFduOeZaF7k5SjO/sdVkTHGjz+JdwJcvnPO3zWpHwgIedmvL3s7GDajE3i49eM/p+4BrHqaw==
   dependencies:
-    "@cubejs-backend/cubesql" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
-    "@cubejs-infra/post-installer" "^0.0.7"
-
-"@cubejs-backend/native@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/native/-/native-1.3.86.tgz"
-  integrity sha512-vt2Bw207S4A9N/+bu/mYGbyifrF9FOI+s+u+cH1QU+uhv2RNXKH7jenJ2gzpL2VM05LgqUf22MtJK0ysrk7jGw==
-  dependencies:
-    "@cubejs-backend/cubesql" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/cubesql" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     "@cubejs-infra/post-installer" "^0.0.7"
 
 "@cubejs-backend/node-java-maven@^0.1.3":
@@ -2204,26 +2520,48 @@
     mkdirp "^3.0.1"
     xml2js "^0.6.2"
 
-"@cubejs-backend/postgres-driver@^1.3.23", "@cubejs-backend/postgres-driver@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/postgres-driver/-/postgres-driver-1.3.85.tgz"
-  integrity sha512-HqVT1JQQeDa+ZhCNE0LR6t1pakNUUbge8VBhnusQdFQKEsax7YtsbU1p/LZfsNHYOUaTC8e3bYBWc2oBa612PA==
+"@cubejs-backend/oracle-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/oracle-driver/-/oracle-driver-1.6.21.tgz"
+  integrity sha512-wbWIjtbhjTy3hs/c0FLbRDxFCG2+LCEP76Dzv6nnJhsWmjbHmIECPk7XXcnX0yKQWQTbULjZ9XsGJ02fXJC+Mw==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
-    "@types/pg" "^8.6.0"
+    "@cubejs-backend/base-driver" "1.6.21"
+    ramda "^0.27.0"
+  optionalDependencies:
+    oracledb "^6.2.0"
+
+"@cubejs-backend/pinot-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/pinot-driver/-/pinot-driver-1.6.21.tgz"
+  integrity sha512-OOB9BDJNVH9UwJcFAAYbwro/v/KHn7vbhFG621O17qzlYUP4S5kTFbGSiLJ7lJguM8Gh68uIWbzJC7jIV8Hfxg==
+  dependencies:
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
+    node-fetch "^2.6.1"
+    ramda "^0.27.2"
+    sqlstring "^2.3.3"
+
+"@cubejs-backend/postgres-driver@^1.6.19", "@cubejs-backend/postgres-driver@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/postgres-driver/-/postgres-driver-1.6.21.tgz"
+  integrity sha512-xOF+bFXa0xYi1dhgXWzNqgEe6J5+q+oRA+hxAwHrgfI0TEIVCYsQzy9XeFhg/1MWEmT6QfcsehIeZ63T34WGHA==
+  dependencies:
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
+    "@types/pg" "^8.16.0"
     "@types/pg-query-stream" "^1.0.3"
     moment "^2.24.0"
-    pg "^8.6.0"
+    pg "^8.18.0"
     pg-query-stream "^4.1.0"
 
-"@cubejs-backend/prestodb-driver@^1.3.23", "@cubejs-backend/prestodb-driver@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/prestodb-driver/-/prestodb-driver-1.3.85.tgz"
-  integrity sha512-DF6Dmtlrg6Xol4Wp9NE5bO1UVVJ7PZsGCGduqvmnlczQvVEB6uhWCpiGS861lSrdj5egPyvh/NCptgQOEXHLoA==
+"@cubejs-backend/prestodb-driver@^1.6.19", "@cubejs-backend/prestodb-driver@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/prestodb-driver/-/prestodb-driver-1.6.21.tgz"
+  integrity sha512-HONrOLsv7iRfRLmSAtLO06dPDFSt+wQQA24ZUc0Uk7yVVtzbpN4tY+0eqGC4hHCpWAPIrFagNZJ/GXHWS0cdpQ==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     presto-client "^1.1.0"
     ramda "^0.27.0"
     sqlstring "^2.3.1"
@@ -2243,39 +2581,41 @@
     moment-timezone "^0.5.33"
     ramda "^0.27.2"
 
-"@cubejs-backend/query-orchestrator@^1.3.23", "@cubejs-backend/query-orchestrator@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/query-orchestrator/-/query-orchestrator-1.3.86.tgz"
-  integrity sha512-ZbwF7CqF2M7NyB3PSDbCG/V726spIrFkH/Tw5D8vlgY3Ty4v29pSK0Y7Mi16fcz1NUb4TpKYhmjh0uaYCpP06Q==
+"@cubejs-backend/query-orchestrator@^1.6.19", "@cubejs-backend/query-orchestrator@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/query-orchestrator/-/query-orchestrator-1.6.21.tgz"
+  integrity sha512-jlB68Cg4RIT9M4wJlmuuoBaFRBw155Zbg4yFz6bTq4hAlxbU2A3ykcqSeNM6UmBLzPjhlbpE7RVYwc6YXwPUqQ==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.86"
-    "@cubejs-backend/cubestore-driver" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/cubestore-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     csv-write-stream "^2.0.0"
     lru-cache "^11.1.0"
     ramda "^0.27.2"
 
-"@cubejs-backend/questdb-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/questdb-driver/-/questdb-driver-1.3.85.tgz"
-  integrity sha512-JFnKI6pcIr9Rh173VZAJHhR5D9P+eBIgs0ThhUBJH+YgvtF1ve6Eg3xWTbo6rHi6aLQXx2Wi8SRp/vqkX4nlzg==
+"@cubejs-backend/questdb-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/questdb-driver/-/questdb-driver-1.6.21.tgz"
+  integrity sha512-vhPSN/VXv9OL8/oc82QYkuC5xGOuNhuNdufPLhXNWFSDtQolrNJhEqk5SOk9jsNbZq76pWoeHpROgI6HCWBs5A==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     "@types/pg" "^8.6.0"
     moment "^2.24.0"
     pg "^8.7.0"
     ramda "^0.27.1"
 
-"@cubejs-backend/redshift-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/redshift-driver/-/redshift-driver-1.3.85.tgz"
-  integrity sha512-IjZaAD/0nPJwVxX2dofi/9AgLYN2aXp2LMZwtA+H5xP2Gc2UP86kH+J63/XyGaRYeqbhH8/qBbHi9qHfo9PbTg==
+"@cubejs-backend/redshift-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/redshift-driver/-/redshift-driver-1.6.21.tgz"
+  integrity sha512-plqyLajs/paV6DDGH6jeYBTCkXmj1SPx8NCWcf0YrhWlDaB9y9/6pe5fwmm1QgJwlFThIYnZ7q7tRRzBMBqxmw==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/postgres-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@aws-sdk/client-redshift" "^3.22.0"
+    "@aws-sdk/credential-providers" "^3.22.0"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/postgres-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
 
 "@cubejs-backend/schema-compiler@^0.36.0":
   version "0.36.11"
@@ -2306,10 +2646,10 @@
     syntax-error "^1.3.0"
     uuid "^8.3.2"
 
-"@cubejs-backend/schema-compiler@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.3.85.tgz"
-  integrity sha512-yY10qXQTXaKaRKFlYuVBQY6/Wdk79JO9Ga4Z+P9W9mUnBRcWxoiq3F6kyQCTZ8a7W3WWQDMu93wUTtFLtvNb8w==
+"@cubejs-backend/schema-compiler@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.6.21.tgz"
+  integrity sha512-e7pZ4lmoZw4PamvVpUNy2oBKcrQKinjHZG1aS6sqdIMzIVVF8+sDIX+avqw27tUwuNNKW02OLeB0ivmo2JjMNg==
   dependencies:
     "@babel/code-frame" "^7.24"
     "@babel/core" "^7.24"
@@ -2319,8 +2659,8 @@
     "@babel/standalone" "^7.24"
     "@babel/traverse" "^7.24"
     "@babel/types" "^7.24"
-    "@cubejs-backend/native" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/native" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     antlr4 "^4.13.2"
     camelcase "^6.2.0"
     cron-parser "^4.9.0"
@@ -2337,53 +2677,25 @@
     workerpool "^9.2.0"
     yaml "^2.7.1"
 
-"@cubejs-backend/schema-compiler@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/schema-compiler/-/schema-compiler-1.3.86.tgz"
-  integrity sha512-kMphaBZD6wyU9No9fei5d4Bt80294YRgZqZH/AiBDCo8qVNHQl6MdJZrEGnoiojL08yrqRUjusBkrfeBLoIDOA==
+"@cubejs-backend/server-core@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/server-core/-/server-core-1.6.21.tgz"
+  integrity sha512-HIVjGOfT+2JTVNPYsoi+RnCUfxOPmFz0F34jq2iRFabuHVpv8acL2gvCUNsOlj3SaEZ8LgxBApYISO/m1ZPn/g==
   dependencies:
-    "@babel/code-frame" "^7.24"
-    "@babel/core" "^7.24"
-    "@babel/generator" "^7.24"
-    "@babel/parser" "^7.24"
-    "@babel/preset-env" "^7.24"
-    "@babel/standalone" "^7.24"
-    "@babel/traverse" "^7.24"
-    "@babel/types" "^7.24"
-    "@cubejs-backend/native" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
-    antlr4 "^4.13.2"
-    camelcase "^6.2.0"
-    cron-parser "^4.9.0"
-    humps "^2.0.1"
-    inflection "^1.12.0"
-    joi "^17.13.3"
-    js-yaml "^4.1.0"
-    lru-cache "^11.1.0"
-    moment-timezone "^0.5.48"
-    node-dijkstra "^2.5.0"
-    ramda "^0.27.2"
-    syntax-error "^1.3.0"
-    uuid "^8.3.2"
-    workerpool "^9.2.0"
-    yaml "^2.7.1"
-
-"@cubejs-backend/server-core@^1.3.23":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/server-core/-/server-core-1.3.86.tgz"
-  integrity sha512-Irap2F2YezJcSgpFfTRUxDvLF7FdJGOB6zed2V8n52H3l6xgxrVWBM+4FOQuvdTkOrV5lsO4PHwT7cJ3OH1FMQ==
-  dependencies:
-    "@cubejs-backend/api-gateway" "1.3.86"
-    "@cubejs-backend/cloud" "1.3.86"
+    "@cubejs-backend/api-gateway" "1.6.21"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/cloud" "1.6.21"
+    "@cubejs-backend/cubestore-driver" "1.6.21"
     "@cubejs-backend/dotenv" "^9.0.2"
-    "@cubejs-backend/native" "1.3.86"
-    "@cubejs-backend/query-orchestrator" "1.3.86"
-    "@cubejs-backend/schema-compiler" "1.3.86"
-    "@cubejs-backend/shared" "1.3.86"
-    "@cubejs-backend/templates" "1.3.86"
+    "@cubejs-backend/native" "1.6.21"
+    "@cubejs-backend/query-orchestrator" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
+    "@cubejs-backend/templates" "1.6.21"
     codesandbox-import-utils "^2.1.12"
     cross-spawn "^7.0.1"
     fs-extra "^8.1.0"
+    graphql "^15.8.0"
     http-proxy-agent "^7.0.2"
     https-proxy-agent "^7.0.6"
     is-docker "^2.1.1"
@@ -2442,10 +2754,10 @@
     throttle-debounce "^3.0.1"
     uuid "^8.3.2"
 
-"@cubejs-backend/shared@1.3.85":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.85.tgz"
-  integrity sha512-4iw194DwSM+fx4F5DWvZn+fccVwR76tjtpOUJ26YaDCokH1tQ3rFo1vtptVnY3YEoe0XakTr7FBxxDPyyec+Gg==
+"@cubejs-backend/shared@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.6.21.tgz"
+  integrity sha512-XlEaWSGaOWB2DIaBbdisa5UMY9J9ZrbUdDOtdB25YpTrMjghQSlhVXr5FzO9IPX6eVdchUkvyG7Ox9aTrHU0Gw==
   dependencies:
     "@oclif/color" "^0.1.2"
     bytes "^3.1.2"
@@ -2454,7 +2766,7 @@
     decompress "^4.2.1"
     env-var "^6.3.0"
     fs-extra "^9.1.0"
-    https-proxy-agent "^7.0.6"
+    generic-pool "^3.9.0"
     lru-cache "^11.1.0"
     moment-range "^4.0.2"
     moment-timezone "^0.5.47"
@@ -2464,45 +2776,32 @@
     throttle-debounce "^3.0.1"
     uuid "^8.3.2"
 
-"@cubejs-backend/shared@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/shared/-/shared-1.3.86.tgz"
-  integrity sha512-axJwHRM+ensaf8xVegxCyaXct5NmMDAbhaYT4IjZJvDKSrbdi4ANPN4dkY04/DYmN3dqyj/kkJEkpW7DdtoVrg==
-  dependencies:
-    "@oclif/color" "^0.1.2"
-    bytes "^3.1.2"
-    cli-progress "^3.9.0"
-    cross-spawn "^7.0.3"
-    decompress "^4.2.1"
-    env-var "^6.3.0"
-    fs-extra "^9.1.0"
-    https-proxy-agent "^7.0.6"
-    lru-cache "^11.1.0"
-    moment-range "^4.0.2"
-    moment-timezone "^0.5.47"
-    node-fetch "^2.6.1"
-    proxy-agent "^6.5.0"
-    shelljs "^0.8.5"
-    throttle-debounce "^3.0.1"
-    uuid "^8.3.2"
-
-"@cubejs-backend/snowflake-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/snowflake-driver/-/snowflake-driver-1.3.85.tgz"
-  integrity sha512-PGFif3A2oXF5Df4F1wQgqwv5AC+hrqIVdRNj7/9vr2UlT1gsUXIBc7z50WlYn/jkLXGYO/K/Q04XcslbMIjKpg==
+"@cubejs-backend/snowflake-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/snowflake-driver/-/snowflake-driver-1.6.21.tgz"
+  integrity sha512-RHqjllJ8z13gNEtko9yPAlzDtkm3wfhtLy3BUXK0v0pTecJS43weBqgYlt8Rr7gF/0QAeMkvGozTG4QJ1T7xDQ==
   dependencies:
     "@aws-sdk/client-s3" "^3.726.0"
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     date-fns-timezone "^0.1.4"
     snowflake-sdk "^2.2.0"
 
-"@cubejs-backend/templates@1.3.86":
-  version "1.3.86"
-  resolved "https://registry.npmjs.org/@cubejs-backend/templates/-/templates-1.3.86.tgz"
-  integrity sha512-s+/0WpDQgk9/a/Ddz+0NTmBYUYPtsJ+EKbGeyS8sL6OMYBP4Qo0bK2g+TcJ4IlSp4MK51My8fCYIZ7iNqPGMuA==
+"@cubejs-backend/sqlite-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/sqlite-driver/-/sqlite-driver-1.6.21.tgz"
+  integrity sha512-++nGchlBTwLtJ7KkyArp6pRZW4hCLG/N9j9ou93Qxo411FP1J2CPfUr9Plr52N/9tm2Pw1gIe7MbrbXgW/ijVA==
   dependencies:
-    "@cubejs-backend/shared" "1.3.86"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
+    sqlite3 "^5.1.7"
+
+"@cubejs-backend/templates@1.6.21":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/templates/-/templates-1.6.21.tgz"
+  integrity sha512-CQrE0lG0fvxRknMYmU3jHG9kcMkpgDCt32uinZEVmdkwa+dyGBXMsT2Yvig8p6WvE4uovPgwvi4VNllo3Hrlhg==
+  dependencies:
+    "@cubejs-backend/shared" "1.6.21"
     cross-spawn "^7.0.3"
     decompress "^4.2.1"
     decompress-targz "^4.1.1"
@@ -2511,15 +2810,15 @@
     ramda "^0.27.2"
     source-map-support "^0.5.19"
 
-"@cubejs-backend/trino-driver@^1.3.23":
-  version "1.3.85"
-  resolved "https://registry.npmjs.org/@cubejs-backend/trino-driver/-/trino-driver-1.3.85.tgz"
-  integrity sha512-9OmGFn0vwlf5VkA+lxy7x9sgU+Yls9MWEjFUzL4L9yNdLnK/vnQXZF5gxowZeMS4k2SJhFlxLe6LMvItIdVizw==
+"@cubejs-backend/trino-driver@^1.6.19":
+  version "1.6.21"
+  resolved "https://registry.npmjs.org/@cubejs-backend/trino-driver/-/trino-driver-1.6.21.tgz"
+  integrity sha512-LA5aJFCyqIOvVn216umkmLlMGhaaiI5c3U+1CUahr193Ab5w4f7oOdaZ6Syoh+Fi+ZQc8ikGjgGc03fE6n7PhQ==
   dependencies:
-    "@cubejs-backend/base-driver" "1.3.85"
-    "@cubejs-backend/prestodb-driver" "1.3.85"
-    "@cubejs-backend/schema-compiler" "1.3.85"
-    "@cubejs-backend/shared" "1.3.85"
+    "@cubejs-backend/base-driver" "1.6.21"
+    "@cubejs-backend/prestodb-driver" "1.6.21"
+    "@cubejs-backend/schema-compiler" "1.6.21"
+    "@cubejs-backend/shared" "1.6.21"
     node-fetch "^2.6.1"
     presto-client "^1.1.0"
     sqlstring "^2.3.1"
@@ -2562,7 +2861,7 @@
     pump "^3.0.0"
     secure-json-parse "^2.3.1"
 
-"@gar/promisify@^1.1.3":
+"@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
@@ -2759,6 +3058,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@npmcli/fs@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz"
+  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
+  dependencies:
+    "@gar/promisify" "^1.0.1"
+    semver "^7.3.5"
+
 "@npmcli/fs@^2.1.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz"
@@ -2766,6 +3073,14 @@
   dependencies:
     "@gar/promisify" "^1.1.3"
     semver "^7.3.5"
+
+"@npmcli/move-file@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz"
+  integrity sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
+  dependencies:
+    mkdirp "^1.0.4"
+    rimraf "^3.0.2"
 
 "@npmcli/move-file@^2.0.0":
   version "2.0.1"
@@ -2918,12 +3233,12 @@
   resolved "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
-"@smithy/abort-controller@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.3.tgz"
-  integrity sha512-xWL9Mf8b7tIFuAlpjKtRPnHrR8XVrwTj5NPYO/QwZPtc0SDLsPxb56V5tzi5yspSMytISHybifez+4jlrx0vkQ==
+"@smithy/abort-controller@^4.2.11":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz"
+  integrity sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==
   dependencies:
-    "@smithy/types" "^4.8.0"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@smithy/chunked-blob-reader-native@^4.2.1":
@@ -2941,43 +3256,43 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/config-resolver@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.0.tgz"
-  integrity sha512-Kkmz3Mup2PGp/HNJxhCWkLNdlajJORLSjwkcfrj0E7nu6STAEdcMR1ir5P9/xOmncx8xXfru0fbUYLlZog/cFg==
+"@smithy/config-resolver@^4.4.0", "@smithy/config-resolver@^4.4.10":
+  version "4.4.10"
+  resolved "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz"
+  integrity sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==
   dependencies:
-    "@smithy/node-config-provider" "^4.3.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-config-provider" "^4.2.0"
-    "@smithy/util-endpoints" "^3.2.3"
-    "@smithy/util-middleware" "^4.2.3"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-config-provider" "^4.2.2"
+    "@smithy/util-endpoints" "^3.3.2"
+    "@smithy/util-middleware" "^4.2.11"
     tslib "^2.6.2"
 
-"@smithy/core@^3.17.1":
-  version "3.17.1"
-  resolved "https://registry.npmjs.org/@smithy/core/-/core-3.17.1.tgz"
-  integrity sha512-V4Qc2CIb5McABYfaGiIYLTmo/vwNIK7WXI5aGveBd9UcdhbOMwcvIMxIw/DJj1S9QgOMa/7FBkarMdIC0EOTEQ==
+"@smithy/core@^3.17.1", "@smithy/core@^3.23.9":
+  version "3.23.9"
+  resolved "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz"
+  integrity sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==
   dependencies:
-    "@smithy/middleware-serde" "^4.2.3"
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-base64" "^4.3.0"
-    "@smithy/util-body-length-browser" "^4.2.0"
-    "@smithy/util-middleware" "^4.2.3"
-    "@smithy/util-stream" "^4.5.4"
-    "@smithy/util-utf8" "^4.2.0"
-    "@smithy/uuid" "^1.1.0"
+    "@smithy/middleware-serde" "^4.2.12"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-body-length-browser" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.11"
+    "@smithy/util-stream" "^4.5.17"
+    "@smithy/util-utf8" "^4.2.2"
+    "@smithy/uuid" "^1.1.2"
     tslib "^2.6.2"
 
-"@smithy/credential-provider-imds@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.3.tgz"
-  integrity sha512-hA1MQ/WAHly4SYltJKitEsIDVsNmXcQfYBRv2e+q04fnqtAX5qXaybxy/fhUeAMCnQIdAjaGDb04fMHQefWRhw==
+"@smithy/credential-provider-imds@^4.2.11", "@smithy/credential-provider-imds@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz"
+  integrity sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==
   dependencies:
-    "@smithy/node-config-provider" "^4.3.3"
-    "@smithy/property-provider" "^4.2.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/url-parser" "^4.2.3"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/url-parser" "^4.2.11"
     tslib "^2.6.2"
 
 "@smithy/eventstream-codec@^4.2.3":
@@ -3025,15 +3340,15 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
-"@smithy/fetch-http-handler@^5.3.4":
-  version "5.3.4"
-  resolved "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.4.tgz"
-  integrity sha512-bwigPylvivpRLCm+YK9I5wRIYjFESSVwl8JQ1vVx/XhCw0PtCi558NwTnT2DaVCl5pYlImGuQTSwMsZ+pIavRw==
+"@smithy/fetch-http-handler@^5.3.13", "@smithy/fetch-http-handler@^5.3.4":
+  version "5.3.13"
+  resolved "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz"
+  integrity sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==
   dependencies:
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/querystring-builder" "^4.2.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-base64" "^4.3.0"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/querystring-builder" "^4.2.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-base64" "^4.3.2"
     tslib "^2.6.2"
 
 "@smithy/hash-blob-browser@^4.2.4":
@@ -3046,14 +3361,14 @@
     "@smithy/types" "^4.8.0"
     tslib "^2.6.2"
 
-"@smithy/hash-node@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.3.tgz"
-  integrity sha512-6+NOdZDbfuU6s1ISp3UOk5Rg953RJ2aBLNLLBEcamLjHAg1Po9Ha7QIB5ZWhdRUVuOUrT8BVFR+O2KIPmw027g==
+"@smithy/hash-node@^4.2.11", "@smithy/hash-node@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz"
+  integrity sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==
   dependencies:
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-buffer-from" "^4.2.0"
-    "@smithy/util-utf8" "^4.2.0"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
 "@smithy/hash-stream-node@^4.2.3":
@@ -3065,12 +3380,12 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/invalid-dependency@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.3.tgz"
-  integrity sha512-Cc9W5DwDuebXEDMpOpl4iERo8I0KFjTnomK2RMdhhR87GwrSmUmwMxS4P5JdRf+LsjOdIqumcerwRgYMr/tZ9Q==
+"@smithy/invalid-dependency@^4.2.11", "@smithy/invalid-dependency@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz"
+  integrity sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==
   dependencies:
-    "@smithy/types" "^4.8.0"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
 "@smithy/is-array-buffer@^2.2.0":
@@ -3080,10 +3395,10 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/is-array-buffer@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz"
-  integrity sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==
+"@smithy/is-array-buffer@^4.2.0", "@smithy/is-array-buffer@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz"
+  integrity sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==
   dependencies:
     tslib "^2.6.2"
 
@@ -3096,193 +3411,193 @@
     "@smithy/util-utf8" "^4.2.0"
     tslib "^2.6.2"
 
-"@smithy/middleware-content-length@^4.2.3":
+"@smithy/middleware-content-length@^4.2.11", "@smithy/middleware-content-length@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz"
+  integrity sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-endpoint@^4.3.5", "@smithy/middleware-endpoint@^4.4.23":
+  version "4.4.23"
+  resolved "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz"
+  integrity sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==
+  dependencies:
+    "@smithy/core" "^3.23.9"
+    "@smithy/middleware-serde" "^4.2.12"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
+    "@smithy/url-parser" "^4.2.11"
+    "@smithy/util-middleware" "^4.2.11"
+    tslib "^2.6.2"
+
+"@smithy/middleware-retry@^4.4.40", "@smithy/middleware-retry@^4.4.5":
+  version "4.4.40"
+  resolved "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz"
+  integrity sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==
+  dependencies:
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/service-error-classification" "^4.2.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-middleware" "^4.2.11"
+    "@smithy/util-retry" "^4.2.11"
+    "@smithy/uuid" "^1.1.2"
+    tslib "^2.6.2"
+
+"@smithy/middleware-serde@^4.2.12", "@smithy/middleware-serde@^4.2.3":
+  version "4.2.12"
+  resolved "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz"
+  integrity sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==
+  dependencies:
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-stack@^4.2.11", "@smithy/middleware-stack@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz"
+  integrity sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/node-config-provider@^4.3.11", "@smithy/node-config-provider@^4.3.3":
+  version "4.3.11"
+  resolved "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz"
+  integrity sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==
+  dependencies:
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/shared-ini-file-loader" "^4.4.6"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.0.1", "@smithy/node-http-handler@^4.4.14", "@smithy/node-http-handler@^4.4.3":
+  version "4.4.14"
+  resolved "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz"
+  integrity sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==
+  dependencies:
+    "@smithy/abort-controller" "^4.2.11"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/querystring-builder" "^4.2.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/property-provider@^4.2.11", "@smithy/property-provider@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz"
+  integrity sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/protocol-http@^5.1.3", "@smithy/protocol-http@^5.3.11", "@smithy/protocol-http@^5.3.3":
+  version "5.3.11"
+  resolved "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz"
+  integrity sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/querystring-builder@^4.2.11", "@smithy/querystring-builder@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz"
+  integrity sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-uri-escape" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/querystring-parser@^4.2.11":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz"
+  integrity sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/service-error-classification@^4.2.11":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz"
+  integrity sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+
+"@smithy/shared-ini-file-loader@^4.3.3", "@smithy/shared-ini-file-loader@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz"
+  integrity sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.2.1", "@smithy/signature-v4@^5.3.11", "@smithy/signature-v4@^5.3.3":
+  version "5.3.11"
+  resolved "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz"
+  integrity sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==
+  dependencies:
+    "@smithy/is-array-buffer" "^4.2.2"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-hex-encoding" "^4.2.2"
+    "@smithy/util-middleware" "^4.2.11"
+    "@smithy/util-uri-escape" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.12.3", "@smithy/smithy-client@^4.9.1":
+  version "4.12.3"
+  resolved "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz"
+  integrity sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==
+  dependencies:
+    "@smithy/core" "^3.23.9"
+    "@smithy/middleware-endpoint" "^4.4.23"
+    "@smithy/middleware-stack" "^4.2.11"
+    "@smithy/protocol-http" "^5.3.11"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-stream" "^4.5.17"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.13.0", "@smithy/types@^4.8.0":
+  version "4.13.0"
+  resolved "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz"
+  integrity sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/url-parser@^4.2.11", "@smithy/url-parser@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz"
+  integrity sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==
+  dependencies:
+    "@smithy/querystring-parser" "^4.2.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.3.0", "@smithy/util-base64@^4.3.2":
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz"
+  integrity sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==
+  dependencies:
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-browser@^4.2.0", "@smithy/util-body-length-browser@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz"
+  integrity sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-node@^4.2.1", "@smithy/util-body-length-node@^4.2.3":
   version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.3.tgz"
-  integrity sha512-/atXLsT88GwKtfp5Jr0Ks1CSa4+lB+IgRnkNrrYP0h1wL4swHNb0YONEvTceNKNdZGJsye+W2HH8W7olbcPUeA==
-  dependencies:
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/middleware-endpoint@^4.3.5":
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.5.tgz"
-  integrity sha512-SIzKVTvEudFWJbxAaq7f2GvP3jh2FHDpIFI6/VAf4FOWGFZy0vnYMPSRj8PGYI8Hjt29mvmwSRgKuO3bK4ixDw==
-  dependencies:
-    "@smithy/core" "^3.17.1"
-    "@smithy/middleware-serde" "^4.2.3"
-    "@smithy/node-config-provider" "^4.3.3"
-    "@smithy/shared-ini-file-loader" "^4.3.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/url-parser" "^4.2.3"
-    "@smithy/util-middleware" "^4.2.3"
-    tslib "^2.6.2"
-
-"@smithy/middleware-retry@^4.4.5":
-  version "4.4.5"
-  resolved "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.5.tgz"
-  integrity sha512-DCaXbQqcZ4tONMvvdz+zccDE21sLcbwWoNqzPLFlZaxt1lDtOE2tlVpRSwcTOJrjJSUThdgEYn7HrX5oLGlK9A==
-  dependencies:
-    "@smithy/node-config-provider" "^4.3.3"
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/service-error-classification" "^4.2.3"
-    "@smithy/smithy-client" "^4.9.1"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-middleware" "^4.2.3"
-    "@smithy/util-retry" "^4.2.3"
-    "@smithy/uuid" "^1.1.0"
-    tslib "^2.6.2"
-
-"@smithy/middleware-serde@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.3.tgz"
-  integrity sha512-8g4NuUINpYccxiCXM5s1/V+uLtts8NcX4+sPEbvYQDZk4XoJfDpq5y2FQxfmUL89syoldpzNzA0R9nhzdtdKnQ==
-  dependencies:
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/middleware-stack@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.3.tgz"
-  integrity sha512-iGuOJkH71faPNgOj/gWuEGS6xvQashpLwWB1HjHq1lNNiVfbiJLpZVbhddPuDbx9l4Cgl0vPLq5ltRfSaHfspA==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/node-config-provider@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.3.tgz"
-  integrity sha512-NzI1eBpBSViOav8NVy1fqOlSfkLgkUjUTlohUSgAEhHaFWA3XJiLditvavIP7OpvTjDp5u2LhtlBhkBlEisMwA==
-  dependencies:
-    "@smithy/property-provider" "^4.2.3"
-    "@smithy/shared-ini-file-loader" "^4.3.3"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/node-http-handler@^4.0.1", "@smithy/node-http-handler@^4.4.3":
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.3.tgz"
-  integrity sha512-MAwltrDB0lZB/H6/2M5PIsISSwdI5yIh6DaBB9r0Flo9nx3y0dzl/qTMJPd7tJvPdsx6Ks/cwVzheGNYzXyNbQ==
-  dependencies:
-    "@smithy/abort-controller" "^4.2.3"
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/querystring-builder" "^4.2.3"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/property-provider@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.3.tgz"
-  integrity sha512-+1EZ+Y+njiefCohjlhyOcy1UNYjT+1PwGFHCxA/gYctjg3DQWAU19WigOXAco/Ql8hZokNehpzLd0/+3uCreqQ==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/protocol-http@^5.1.3", "@smithy/protocol-http@^5.3.3":
-  version "5.3.3"
-  resolved "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.3.tgz"
-  integrity sha512-Mn7f/1aN2/jecywDcRDvWWWJF4uwg/A0XjFMJtj72DsgHTByfjRltSqcT9NyE9RTdBSN6X1RSXrhn/YWQl8xlw==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/querystring-builder@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.3.tgz"
-  integrity sha512-LOVCGCmwMahYUM/P0YnU/AlDQFjcu+gWbFJooC417QRB/lDJlWSn8qmPSDp+s4YVAHOgtgbNG4sR+SxF/VOcJQ==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-uri-escape" "^4.2.0"
-    tslib "^2.6.2"
-
-"@smithy/querystring-parser@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.3.tgz"
-  integrity sha512-cYlSNHcTAX/wc1rpblli3aUlLMGgKZ/Oqn8hhjFASXMCXjIqeuQBei0cnq2JR8t4RtU9FpG6uyl6PxyArTiwKA==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/service-error-classification@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.3.tgz"
-  integrity sha512-NkxsAxFWwsPsQiwFG2MzJ/T7uIR6AQNh1SzcxSUnmmIqIQMlLRQDKhc17M7IYjiuBXhrQRjQTo3CxX+DobS93g==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-
-"@smithy/shared-ini-file-loader@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.3.tgz"
-  integrity sha512-9f9Ixej0hFhroOK2TxZfUUDR13WVa8tQzhSzPDgXe5jGL3KmaM9s8XN7RQwqtEypI82q9KHnKS71CJ+q/1xLtQ==
-  dependencies:
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/signature-v4@^5.2.1", "@smithy/signature-v4@^5.3.3":
-  version "5.3.3"
-  resolved "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.3.tgz"
-  integrity sha512-CmSlUy+eEYbIEYN5N3vvQTRfqt0lJlQkaQUIf+oizu7BbDut0pozfDjBGecfcfWf7c62Yis4JIEgqQ/TCfodaA==
-  dependencies:
-    "@smithy/is-array-buffer" "^4.2.0"
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-hex-encoding" "^4.2.0"
-    "@smithy/util-middleware" "^4.2.3"
-    "@smithy/util-uri-escape" "^4.2.0"
-    "@smithy/util-utf8" "^4.2.0"
-    tslib "^2.6.2"
-
-"@smithy/smithy-client@^4.9.1":
-  version "4.9.1"
-  resolved "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.1.tgz"
-  integrity sha512-Ngb95ryR5A9xqvQFT5mAmYkCwbXvoLavLFwmi7zVg/IowFPCfiqRfkOKnbc/ZRL8ZKJ4f+Tp6kSu6wjDQb8L/g==
-  dependencies:
-    "@smithy/core" "^3.17.1"
-    "@smithy/middleware-endpoint" "^4.3.5"
-    "@smithy/middleware-stack" "^4.2.3"
-    "@smithy/protocol-http" "^5.3.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-stream" "^4.5.4"
-    tslib "^2.6.2"
-
-"@smithy/types@^4.8.0":
-  version "4.8.0"
-  resolved "https://registry.npmjs.org/@smithy/types/-/types-4.8.0.tgz"
-  integrity sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==
-  dependencies:
-    tslib "^2.6.2"
-
-"@smithy/url-parser@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.3.tgz"
-  integrity sha512-I066AigYvY3d9VlU3zG9XzZg1yT10aNqvCaBTw9EPgu5GrsEl1aUkcMvhkIXascYH1A8W0LQo3B1Kr1cJNcQEw==
-  dependencies:
-    "@smithy/querystring-parser" "^4.2.3"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/util-base64@^4.3.0":
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz"
-  integrity sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==
-  dependencies:
-    "@smithy/util-buffer-from" "^4.2.0"
-    "@smithy/util-utf8" "^4.2.0"
-    tslib "^2.6.2"
-
-"@smithy/util-body-length-browser@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz"
-  integrity sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==
-  dependencies:
-    tslib "^2.6.2"
-
-"@smithy/util-body-length-node@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz"
-  integrity sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==
+  resolved "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz"
+  integrity sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==
   dependencies:
     tslib "^2.6.2"
 
@@ -3294,95 +3609,95 @@
     "@smithy/is-array-buffer" "^2.2.0"
     tslib "^2.6.2"
 
-"@smithy/util-buffer-from@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz"
-  integrity sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==
+"@smithy/util-buffer-from@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz"
+  integrity sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==
   dependencies:
-    "@smithy/is-array-buffer" "^4.2.0"
+    "@smithy/is-array-buffer" "^4.2.2"
     tslib "^2.6.2"
 
-"@smithy/util-config-provider@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz"
-  integrity sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==
-  dependencies:
-    tslib "^2.6.2"
-
-"@smithy/util-defaults-mode-browser@^4.3.4":
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.4.tgz"
-  integrity sha512-qI5PJSW52rnutos8Bln8nwQZRpyoSRN6k2ajyoUHNMUzmWqHnOJCnDELJuV6m5PML0VkHI+XcXzdB+6awiqYUw==
-  dependencies:
-    "@smithy/property-provider" "^4.2.3"
-    "@smithy/smithy-client" "^4.9.1"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/util-defaults-mode-node@^4.2.6":
-  version "4.2.6"
-  resolved "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.6.tgz"
-  integrity sha512-c6M/ceBTm31YdcFpgfgQAJaw3KbaLuRKnAz91iMWFLSrgxRpYm03c3bu5cpYojNMfkV9arCUelelKA7XQT36SQ==
-  dependencies:
-    "@smithy/config-resolver" "^4.4.0"
-    "@smithy/credential-provider-imds" "^4.2.3"
-    "@smithy/node-config-provider" "^4.3.3"
-    "@smithy/property-provider" "^4.2.3"
-    "@smithy/smithy-client" "^4.9.1"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/util-endpoints@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.3.tgz"
-  integrity sha512-aCfxUOVv0CzBIkU10TubdgKSx5uRvzH064kaiPEWfNIvKOtNpu642P4FP1hgOFkjQIkDObrfIDnKMKkeyrejvQ==
-  dependencies:
-    "@smithy/node-config-provider" "^4.3.3"
-    "@smithy/types" "^4.8.0"
-    tslib "^2.6.2"
-
-"@smithy/util-hex-encoding@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz"
-  integrity sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==
+"@smithy/util-config-provider@^4.2.0", "@smithy/util-config-provider@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz"
+  integrity sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/util-middleware@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.3.tgz"
-  integrity sha512-v5ObKlSe8PWUHCqEiX2fy1gNv6goiw6E5I/PN2aXg3Fb/hse0xeaAnSpXDiWl7x6LamVKq7senB+m5LOYHUAHw==
+"@smithy/util-defaults-mode-browser@^4.3.39", "@smithy/util-defaults-mode-browser@^4.3.4":
+  version "4.3.39"
+  resolved "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz"
+  integrity sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==
   dependencies:
-    "@smithy/types" "^4.8.0"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
-"@smithy/util-retry@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.3.tgz"
-  integrity sha512-lLPWnakjC0q9z+OtiXk+9RPQiYPNAovt2IXD3CP4LkOnd9NpUsxOjMx1SnoUVB7Orb7fZp67cQMtTBKMFDvOGg==
+"@smithy/util-defaults-mode-node@^4.2.42", "@smithy/util-defaults-mode-node@^4.2.6":
+  version "4.2.42"
+  resolved "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz"
+  integrity sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==
   dependencies:
-    "@smithy/service-error-classification" "^4.2.3"
-    "@smithy/types" "^4.8.0"
+    "@smithy/config-resolver" "^4.4.10"
+    "@smithy/credential-provider-imds" "^4.2.11"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/property-provider" "^4.2.11"
+    "@smithy/smithy-client" "^4.12.3"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
-"@smithy/util-stream@^4.5.4":
-  version "4.5.4"
-  resolved "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.4.tgz"
-  integrity sha512-+qDxSkiErejw1BAIXUFBSfM5xh3arbz1MmxlbMCKanDDZtVEQ7PSKW9FQS0Vud1eI/kYn0oCTVKyNzRlq+9MUw==
+"@smithy/util-endpoints@^3.2.3", "@smithy/util-endpoints@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz"
+  integrity sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==
   dependencies:
-    "@smithy/fetch-http-handler" "^5.3.4"
-    "@smithy/node-http-handler" "^4.4.3"
-    "@smithy/types" "^4.8.0"
-    "@smithy/util-base64" "^4.3.0"
-    "@smithy/util-buffer-from" "^4.2.0"
-    "@smithy/util-hex-encoding" "^4.2.0"
-    "@smithy/util-utf8" "^4.2.0"
+    "@smithy/node-config-provider" "^4.3.11"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
-"@smithy/util-uri-escape@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz"
-  integrity sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==
+"@smithy/util-hex-encoding@^4.2.0", "@smithy/util-hex-encoding@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz"
+  integrity sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-middleware@^4.2.11", "@smithy/util-middleware@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz"
+  integrity sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==
+  dependencies:
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.2.11", "@smithy/util-retry@^4.2.3":
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz"
+  integrity sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==
+  dependencies:
+    "@smithy/service-error-classification" "^4.2.11"
+    "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@smithy/util-stream@^4.5.17", "@smithy/util-stream@^4.5.4":
+  version "4.5.17"
+  resolved "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz"
+  integrity sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==
+  dependencies:
+    "@smithy/fetch-http-handler" "^5.3.13"
+    "@smithy/node-http-handler" "^4.4.14"
+    "@smithy/types" "^4.13.0"
+    "@smithy/util-base64" "^4.3.2"
+    "@smithy/util-buffer-from" "^4.2.2"
+    "@smithy/util-hex-encoding" "^4.2.2"
+    "@smithy/util-utf8" "^4.2.2"
+    tslib "^2.6.2"
+
+"@smithy/util-uri-escape@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz"
+  integrity sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==
   dependencies:
     tslib "^2.6.2"
 
@@ -3394,27 +3709,27 @@
     "@smithy/util-buffer-from" "^2.2.0"
     tslib "^2.6.2"
 
-"@smithy/util-utf8@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz"
-  integrity sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==
+"@smithy/util-utf8@^4.2.0", "@smithy/util-utf8@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz"
+  integrity sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==
   dependencies:
-    "@smithy/util-buffer-from" "^4.2.0"
+    "@smithy/util-buffer-from" "^4.2.2"
     tslib "^2.6.2"
 
-"@smithy/util-waiter@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.3.tgz"
-  integrity sha512-5+nU///E5sAdD7t3hs4uwvCTWQtTR8JwKwOCSJtBRx0bY1isDo1QwH87vRK86vlFLBTISqoDA2V6xvP6nF1isQ==
+"@smithy/util-waiter@^4.2.12", "@smithy/util-waiter@^4.2.3":
+  version "4.2.12"
+  resolved "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.12.tgz"
+  integrity sha512-ek5hyDrzS6mBFsNCEX8LpM+EWSLq6b9FdmPRlkpXXhiJE6aIZehKT9clC6+nFpZAA+i/Yg0xlaPeWGNbf5rzQA==
   dependencies:
-    "@smithy/abort-controller" "^4.2.3"
-    "@smithy/types" "^4.8.0"
+    "@smithy/abort-controller" "^4.2.11"
+    "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
-"@smithy/uuid@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz"
-  integrity sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==
+"@smithy/uuid@^1.1.0", "@smithy/uuid@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz"
+  integrity sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==
   dependencies:
     tslib "^2.6.2"
 
@@ -3507,10 +3822,10 @@
     "@types/node" "*"
     "@types/pg" "*"
 
-"@types/pg@*", "@types/pg@^8.6.0":
-  version "8.15.6"
-  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz"
-  integrity sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==
+"@types/pg@*", "@types/pg@^8.16.0", "@types/pg@^8.6.0":
+  version "8.18.0"
+  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz"
+  integrity sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==
   dependencies:
     "@types/node" "*"
     pg-protocol "*"
@@ -3567,6 +3882,11 @@ abbrev@^3.0.0:
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz"
   integrity sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz"
@@ -3601,7 +3921,7 @@ acorn@^7.0.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-agent-base@^6.0.2:
+agent-base@^6.0.2, agent-base@6:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
@@ -3613,14 +3933,7 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
-agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
-
-agentkeepalive@^4.2.1, agentkeepalive@^4.5.0:
+agentkeepalive@^4.1.3, agentkeepalive@^4.2.1, agentkeepalive@^4.5.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz"
   integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
@@ -3865,9 +4178,9 @@ baseline-browser-mapping@^2.8.19:
   integrity sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==
 
 basic-ftp@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz"
-  integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz"
+  integrity sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==
 
 before-after-hook@^2.2.0:
   version "2.2.3"
@@ -3909,6 +4222,13 @@ binaryextensions@^2.1.2:
   resolved "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz"
   integrity sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bl@^1.0.0:
   version "1.2.3"
   resolved "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz"
@@ -3916,6 +4236,15 @@ bl@^1.0.0:
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bl@^6.0.11:
   version "6.1.4"
@@ -4051,7 +4380,7 @@ buffer-writer@2.0.0:
   resolved "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
 
-buffer@^5.2.1:
+buffer@^5.2.1, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -4078,6 +4407,30 @@ bytes@^3.1.0, bytes@^3.1.2, bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+cacache@^15.2.0:
+  version "15.3.0"
+  resolved "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz"
+  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
+  dependencies:
+    "@npmcli/fs" "^1.0.0"
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.1"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
 
 cacache@^16.1.0:
   version "16.1.3"
@@ -4168,6 +4521,11 @@ chokidar@^3.5.1, chokidar@^3.5.2:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -4453,6 +4811,13 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz"
@@ -4505,6 +4870,11 @@ decompress@^4.2.1:
     make-dir "^1.0.0"
     pify "^2.3.0"
     strip-dirs "^2.0.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-browser-id@^5.0.0:
   version "5.0.0"
@@ -4603,7 +4973,7 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-duckdb@^1.3.1:
+duckdb@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/duckdb/-/duckdb-1.4.1.tgz"
   integrity sha512-ynTVIsJjuUfF4GuTNpJn9xpVw8+gHz1wyHzQhfPJsVCemu3bf620HmJo5nRDTB0LMwfLW/3pTMmh+uze9kHAcw==
@@ -4699,7 +5069,7 @@ encodeurl@~2.0.0:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-encoding@^0.1.0, encoding@^0.1.13:
+encoding@^0.1.0, encoding@^0.1.12, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -4880,6 +5250,11 @@ events@^3.0.0, events@^3.3.0:
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz"
@@ -4962,6 +5337,13 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
+fast-xml-builder@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.0.tgz"
+  integrity sha512-7mtITW/we2/wTUZqMyBOR2F8xP4CRxMiSEcQxPIqdRWdO2L/HZSOlzoNyghmyDwNB8BDxePooV1ZTJpkOUhdRg==
+  dependencies:
+    path-expression-matcher "^1.1.2"
+
 fast-xml-parser@^4.2.5:
   version "4.5.3"
   resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz"
@@ -4982,6 +5364,14 @@ fast-xml-parser@^5.0.7, fast-xml-parser@5.2.5:
   integrity sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==
   dependencies:
     strnum "^2.1.0"
+
+fast-xml-parser@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz"
+  integrity sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==
+  dependencies:
+    fast-xml-builder "^1.0.0"
+    strnum "^2.1.2"
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -5029,6 +5419,11 @@ file-type@^6.1.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz"
   integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -5293,6 +5688,11 @@ get-uri@^6.0.1:
     basic-ftp "^5.0.2"
     data-uri-to-buffer "^6.0.2"
     debug "^4.3.4"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -5717,6 +6117,11 @@ inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@2, 
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz"
@@ -5924,6 +6329,11 @@ joi@^17.13.3, joi@^17.8.3:
     "@sideway/address" "^4.1.5"
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
+
+jose@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz"
+  integrity sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==
 
 js-md4@^0.3.2:
   version "0.3.2"
@@ -6268,6 +6678,28 @@ make-fetch-happen@^10.0.3:
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
 
+make-fetch-happen@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz"
+  integrity sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==
+  dependencies:
+    agentkeepalive "^4.1.3"
+    cacache "^15.2.0"
+    http-cache-semantics "^4.1.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-lambda "^1.0.1"
+    lru-cache "^6.0.0"
+    minipass "^3.1.3"
+    minipass-collect "^1.0.2"
+    minipass-fetch "^1.3.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^0.6.2"
+    promise-retry "^2.0.1"
+    socks-proxy-agent "^6.0.0"
+    ssri "^8.0.0"
+
 markdown-it-anchor@^8.6.7:
   version "8.6.7"
   resolved "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz"
@@ -6350,6 +6782,11 @@ mime@1.6.0:
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
@@ -6388,7 +6825,7 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0:
+minimist@^1.2.0, minimist@^1.2.3:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -6399,6 +6836,17 @@ minipass-collect@^1.0.2:
   integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
   dependencies:
     minipass "^3.0.0"
+
+minipass-fetch@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz"
+  integrity sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
+  dependencies:
+    minipass "^3.1.0"
+    minipass-sized "^1.0.3"
+    minizlib "^2.0.0"
+  optionalDependencies:
+    encoding "^0.1.12"
 
 minipass-fetch@^2.0.3:
   version "2.1.2"
@@ -6418,7 +6866,7 @@ minipass-flush@^1.0.5:
   dependencies:
     minipass "^3.0.0"
 
-minipass-pipeline@^1.2.4:
+minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz"
   integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
@@ -6439,7 +6887,7 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
-minipass@^3.1.1:
+minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
   version "3.3.6"
   resolved "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz"
   integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
@@ -6463,7 +6911,7 @@ minipass@^5.0.0:
   resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-minizlib@^2.1.1, minizlib@^2.1.2:
+minizlib@^2.0.0, minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -6477,6 +6925,11 @@ minizlib@^3.1.0:
   integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
   dependencies:
     minipass "^7.1.2"
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
@@ -6566,6 +7019,11 @@ nan@~1.0.0:
   resolved "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
   integrity sha512-Wm2/nFOm2y9HtJfgOLnctGbfvF23FcQZeyUZqDD8JQG3zO5kXh3MkQKiUaA68mJiVWrOzLFkAV1u6bC8P52DJA==
 
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
+
 native-duplexpair@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz"
@@ -6581,7 +7039,7 @@ ndjson@^1.3.0:
     split2 "^2.1.0"
     through2 "^2.0.3"
 
-negotiator@^0.6.3, negotiator@0.6.3:
+negotiator@^0.6.2, negotiator@^0.6.3, negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
@@ -6608,6 +7066,13 @@ nexus@^1.1.0:
   dependencies:
     iterall "^1.3.0"
     tslib "^2.0.3"
+
+node-abi@^3.3.0:
+  version "3.87.0"
+  resolved "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz"
+  integrity sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==
+  dependencies:
+    semver "^7.3.5"
 
 node-addon-api@^7.0.0:
   version "7.1.1"
@@ -6657,6 +7122,22 @@ node-gyp@^9.3.0, node-gyp@^9.3.1:
     tar "^6.1.2"
     which "^2.0.2"
 
+node-gyp@8.x:
+  version "8.4.1"
+  resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz"
+  integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
+  dependencies:
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^9.1.0"
+    nopt "^5.0.0"
+    npmlog "^6.0.0"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.2"
+    which "^2.0.2"
+
 node-int64@^0.3.3, node-int64@~0.3.0:
   version "0.3.3"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
@@ -6687,6 +7168,13 @@ nodemon@^2.0.2:
     supports-color "^5.5.0"
     touch "^3.1.0"
     undefsafe "^2.0.5"
+
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
 
 nopt@^6.0.0:
   version "6.0.0"
@@ -6776,6 +7264,11 @@ options@>=0.0.5:
   resolved "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
   integrity sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg==
 
+oracledb@^6.2.0:
+  version "6.10.0"
+  resolved "https://registry.npmjs.org/oracledb/-/oracledb-6.10.0.tgz"
+  integrity sha512-kGUumXmrEWbSpBuKJyb9Ip3rXcNgKK6grunI3/cLPzrRvboZ6ZoLi9JQ+z6M/RIG924tY8BLflihL4CKKQAYMA==
+
 p-limit@^3.0.1, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
@@ -6832,6 +7325,11 @@ parseurl@~1.3.3:
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+path-expression-matcher@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.2.tgz"
+  integrity sha512-LXWqJmcpp2BKOEmgt4CyuESFmBfPuhJlAHKJsFzuJU6CxErWk75BrO+Ni77M9OxHN6dCYKM4vj+21Z6cOL96YQ==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
@@ -6875,15 +7373,15 @@ pend@~1.2.0:
   resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-pg-cloudflare@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz"
-  integrity sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==
+pg-cloudflare@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz"
+  integrity sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==
 
-pg-connection-string@^2.2.0, pg-connection-string@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz"
-  integrity sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==
+pg-connection-string@^2.12.0, pg-connection-string@^2.2.0:
+  version "2.12.0"
+  resolved "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz"
+  integrity sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==
 
 pg-cursor@^2.15.3:
   version "2.15.3"
@@ -6895,15 +7393,15 @@ pg-int8@1.0.1:
   resolved "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
 
-pg-pool@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz"
-  integrity sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==
+pg-pool@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz"
+  integrity sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==
 
-pg-protocol@*, pg-protocol@^1.10.3:
-  version "1.10.3"
-  resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz"
-  integrity sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==
+pg-protocol@*, pg-protocol@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz"
+  integrity sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==
 
 pg-query-stream@^4.1.0:
   version "4.10.3"
@@ -6923,18 +7421,18 @@ pg-types@^2.1.0, pg-types@^2.2.0, pg-types@2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8, pg@^8.6.0, pg@^8.7.0, pg@^8.7.1, pg@>=8.0:
-  version "8.16.3"
-  resolved "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz"
-  integrity sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==
+pg@^8, pg@^8.18.0, pg@^8.7.0, pg@^8.7.1, pg@>=8.0:
+  version "8.20.0"
+  resolved "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz"
+  integrity sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==
   dependencies:
-    pg-connection-string "^2.9.1"
-    pg-pool "^3.10.1"
-    pg-protocol "^1.10.3"
+    pg-connection-string "^2.12.0"
+    pg-pool "^3.13.0"
+    pg-protocol "^1.13.0"
     pg-types "2.2.0"
     pgpass "1.0.5"
   optionalDependencies:
-    pg-cloudflare "^1.2.7"
+    pg-cloudflare "^1.3.0"
 
 pgpass@1.0.5, pgpass@1.x:
   version "1.0.5"
@@ -7001,6 +7499,24 @@ postgres-interval@^1.1.0:
   integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   dependencies:
     xtend "^4.0.0"
+
+prebuild-install@^7.1.1:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 presto-client@^1.1.0:
   version "1.1.0"
@@ -7133,6 +7649,16 @@ raw-body@^2.4.1, raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 readable-stream@^2.3.0:
   version "2.3.8"
@@ -7380,9 +7906,9 @@ saslmechanisms@^0.1.1:
   integrity sha512-pVlvK5ysevz8MzybRnDIa2YMxn0OJ7b9lDiWhMoaKPoJ7YkAg/7YtNjUgaYzElkwHxsw8dBMhaEn7UP6zxEwPg==
 
 sax@>=0.6.0:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz"
-  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz"
+  integrity sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==
 
 secure-json-parse@^2.3.1:
   version "2.7.0"
@@ -7548,6 +8074,20 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
 simple-lru-cache@^0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
@@ -7612,6 +8152,15 @@ snowflake-sdk@^2.2.0:
     uuid "^8.3.2"
     winston "^3.1.0"
 
+socks-proxy-agent@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz"
+  integrity sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==
+  dependencies:
+    agent-base "^6.0.2"
+    debug "^4.3.3"
+    socks "^2.6.2"
+
 socks-proxy-agent@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz"
@@ -7673,6 +8222,18 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+sqlite3@^5.1.7:
+  version "5.1.7"
+  resolved "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz"
+  integrity sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^7.0.0"
+    prebuild-install "^7.1.1"
+    tar "^6.1.11"
+  optionalDependencies:
+    node-gyp "8.x"
+
 sqlstring@^2.3.0, sqlstring@^2.3.1, sqlstring@^2.3.2, sqlstring@^2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz"
@@ -7682,6 +8243,13 @@ sqlstring@2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz"
   integrity sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==
+
+ssri@^8.0.0, ssri@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
+  dependencies:
+    minipass "^3.1.1"
 
 ssri@^9.0.0:
   version "9.0.1"
@@ -7819,15 +8387,20 @@ strip-json-comments@^3.1.0:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
+
 strnum@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz"
   integrity sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==
 
-strnum@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz"
-  integrity sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==
+strnum@^2.1.0, strnum@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz"
+  integrity sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==
 
 stubs@^3.0.0:
   version "3.0.0"
@@ -7874,6 +8447,16 @@ syntax-error@^1.3.0:
   dependencies:
     acorn-node "^1.2.0"
 
+tar-fs@^2.0.0:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz"
+  integrity sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
 tar-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz"
@@ -7887,19 +8470,18 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^6.1.11:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
-  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
   dependencies:
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    minipass "^5.0.0"
-    minizlib "^2.1.1"
-    mkdirp "^1.0.3"
-    yallist "^4.0.0"
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
-tar@^6.1.2:
+tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
   version "6.2.1"
   resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
@@ -8086,6 +8668,13 @@ tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.1, tslib@^2.5
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 type-fest@^0.16.0:
   version "0.16.0"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz"
@@ -8172,12 +8761,26 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz"
   integrity sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==
 
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz"
+  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+  dependencies:
+    unique-slug "^2.0.0"
+
 unique-filename@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz"
   integrity sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==
   dependencies:
     unique-slug "^3.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  dependencies:
+    imurmurhash "^0.1.4"
 
 unique-slug@^3.0.0:
   version "3.0.0"
@@ -8468,3 +9071,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^4.1.13:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==

--- a/specs/007-workos-jwt-query/checklists/requirements.md
+++ b/specs/007-workos-jwt-query/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Query with WorkOS JWT
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Spec updated to include JIT provisioning (User Stories 4-5) and two-layer caching requirements.
+- Provisioning logic mirrors the existing login-time flow: partition claim > email domain > full email for team derivation.
+- FR-005 through FR-012 cover provisioning and caching; SC-004 and SC-005 provide measurable outcomes for these paths.

--- a/specs/007-workos-jwt-query/contracts/cubejs-auth.md
+++ b/specs/007-workos-jwt-query/contracts/cubejs-auth.md
@@ -1,0 +1,114 @@
+# Contract: CubeJS Authentication (Updated)
+
+**Branch**: `007-workos-jwt-query` | **Date**: 2026-03-10
+
+## REST API Authentication
+
+All CubeJS REST endpoints (`/api/v1/*`) accept two token types:
+
+### Token Type 1: WorkOS JWT (new)
+
+**Headers**:
+```
+Authorization: Bearer <workos-jwt>
+x-hasura-datasource-id: <uuid>
+x-hasura-branch-id: <uuid>           (optional, defaults to active branch)
+x-hasura-branch-version-id: <uuid>   (optional, defaults to latest version)
+```
+
+**Token format**: RS256-signed JWT from WorkOS
+
+**Required claims**:
+```json
+{
+  "sub": "user_01KEC615YDR3NK2SPGW84ZASR3",
+  "partition": "blue.is",
+  "org_id": "org_01KEC612MEP1Z3FVQ6QD9HGAVG",
+  "exp": 1773152982,
+  "iat": 1773152682
+}
+```
+
+**Verification**: JWKS at `https://api.workos.com/sso/jwks/{WORKOS_CLIENT_ID}` (or custom issuer via `WORKOS_ISSUER` env var for custom domain deployments). Audience (`aud`) validated against `WORKOS_CLIENT_ID`.
+
+**User resolution**: `sub` → `auth_accounts.workos_user_id` → `user_id`
+
+### Token Type 2: Hasura JWT (existing, unchanged)
+
+**Headers**: Same as above.
+
+**Token format**: HS256-signed JWT minted by Actions service
+
+**Required claims**:
+```json
+{
+  "hasura": {
+    "x-hasura-user-id": "748e8a31-080f-4532-...",
+    "x-hasura-allowed-roles": ["user"],
+    "x-hasura-default-role": "user"
+  }
+}
+```
+
+**Verification**: Shared `JWT_KEY` with HS256 algorithm
+
+**User resolution**: `hasura.x-hasura-user-id` → direct `user_id`
+
+### Token Detection
+
+The system distinguishes tokens by decoding the JWT header (without verification):
+- `alg: "RS256"` → WorkOS token → JWKS verification path
+- `alg: "HS256"` → Hasura token → shared-key verification path
+
+### Error Responses
+
+| Scenario | HTTP Status | Error Message |
+|---|---|---|
+| Missing Authorization header | 403 | `Provide Hasura Authorization token` |
+| Expired token | 403 | `TokenExpiredError: jwt expired` |
+| Invalid signature (either type) | 403 | `JsonWebTokenError: invalid signature` |
+| User not found (after provisioning attempt fails) | 404 | `404: user "{sub}" not found` |
+| Missing datasource header | 400 | `400: No x-hasura-datasource-id provided` |
+| Datasource not found | 404 | `404: datasource not found` |
+| Datasource not authorized (SQL API) | 403 | `403: access denied for datasource "{id}"` |
+| WorkOS API unreachable during provisioning | 503 | `503: Unable to provision user` |
+| JWKS endpoint unreachable | 503 | `503: Unable to verify token` |
+
+**Important**: All errors MUST use structured error objects with a `status` property. The Express error handler reads `err.status` to set the HTTP response code. Errors without a `status` property default to 500.
+
+## SQL API Authentication
+
+### WorkOS JWT as password (new)
+
+```
+Username: <datasource-id>
+Password: <workos-jwt>
+```
+
+The username field specifies which datasource to query. The user must have access to this datasource (member of the owning team).
+
+**Detection**: If the password contains two dots and the decoded header has `alg: "RS256"`, use JWKS verification path. **Fail-closed**: if JWT verification fails (expired, invalid signature, JWKS unreachable), reject the connection immediately — do NOT fall through to legacy credential lookup. Only if the password does NOT look like a JWT, fall back to `sql_credentials` table lookup.
+
+### Existing credential method (unchanged)
+
+```
+Username: <sql_credentials.username>
+Password: <sql_credentials.password>
+```
+
+## Token Endpoint (Actions Service)
+
+### GET /auth/token
+
+**Response** (updated):
+```json
+{
+  "accessToken": "<hasura-jwt>",
+  "workosAccessToken": "<workos-jwt>",
+  "userId": "748e8a31-...",
+  "teamId": "abc123-...",
+  "role": "user"
+}
+```
+
+New field: `workosAccessToken` — the WorkOS JWT for direct CubeJS queries.

--- a/specs/007-workos-jwt-query/data-model.md
+++ b/specs/007-workos-jwt-query/data-model.md
@@ -1,0 +1,112 @@
+# Data Model: Query with WorkOS JWT
+
+**Branch**: `007-workos-jwt-query` | **Date**: 2026-03-10
+
+## Existing Entities (No Schema Changes)
+
+### auth_accounts
+The identity resolution table. No new columns needed — `workos_user_id` already exists.
+
+| Field | Type | Index | Purpose |
+|---|---|---|---|
+| id | uuid (PK) | `accounts_pkey` | Primary key |
+| user_id | uuid (unique) | `accounts_user_id_key` | FK to users.id |
+| email | citext (unique) | `accounts_email_key` | User email |
+| workos_user_id | text (unique) | `accounts_workos_user_id_unique` | WorkOS `sub` claim mapping |
+| active | boolean | — | Account status |
+| default_role | text | — | Default Hasura role |
+
+### users
+| Field | Type | Purpose |
+|---|---|---|
+| id | uuid (PK) | Platform user ID used throughout the system |
+| display_name | text | User display name (email fallback if null) |
+| avatar_url | text | Profile picture URL |
+
+### teams
+| Field | Type | Index | Purpose |
+|---|---|---|---|
+| id | uuid (PK) | `teams_pkey` | Team ID |
+| name | text | `teams_name_unique` (lower, trim) | Derived from JWT partition claim |
+| user_id | uuid | — | Team creator |
+| settings | jsonb | — | Contains `partition` value |
+
+### members
+| Field | Type | Index | Purpose |
+|---|---|---|---|
+| id | uuid (PK) | `members_pkey` | Membership ID |
+| user_id | uuid | `members_user_id_team_id_key` (composite) | FK to users |
+| team_id | uuid | `members_user_id_team_id_key` (composite) | FK to teams |
+
+### member_roles
+| Field | Type | Index | Purpose |
+|---|---|---|---|
+| id | uuid (PK) | `member_roles_pkey` | Role assignment ID |
+| member_id | uuid | `member_roles_member_id_team_role_key` | FK to members |
+| team_role | enum | `member_roles_member_id_team_role_key` | owner/admin/member/viewer |
+
+## New In-Memory Entities
+
+### Identity Mapping Cache (new)
+In-memory Map in CubeJS process. Not persisted.
+
+| Field | Type | Purpose |
+|---|---|---|
+| key: workos_sub | string | WorkOS `sub` claim (e.g., `user_01KEC615YDR3NK2SPGW84ZASR3`) |
+| value: user_id | uuid | Platform user ID (e.g., `748e8a31-080f-4532-...`) |
+| time | number | Cache entry timestamp (ms) |
+
+**TTL**: 5 minutes | **Max size**: 1000 entries | **Eviction**: FIFO (oldest entry removed when full)
+
+### User Scope Cache (existing, unchanged)
+In-memory Map in CubeJS process. Already exists in `dataSourceHelpers.js`.
+
+| Field | Type | Purpose |
+|---|---|---|
+| key: user_id | uuid | Platform user ID |
+| value: data | object | `{ dataSources: [...], members: [...] }` |
+| time | number | Cache entry timestamp (ms) |
+
+**TTL**: 30 seconds | **Max size**: 500 entries | **Eviction**: FIFO
+
+## Entity Relationships
+
+```
+WorkOS JWT (sub claim)
+  └─→ auth_accounts.workos_user_id  [unique index lookup]
+       └─→ auth_accounts.user_id
+            └─→ users.id
+            └─→ members.user_id  [composite index]
+                 └─→ members.team_id → teams.id
+                 └─→ member_roles.member_id
+                      └─→ member_roles.access_list → access control config
+                 └─→ team.datasources → datasource resolution
+```
+
+## State Transitions
+
+### User Resolution States
+
+```
+WorkOS JWT received
+  ├─ [Identity cache HIT] → userId known → check user scope cache
+  │   ├─ [Scope cache HIT] → fully resolved → execute query
+  │   └─ [Scope cache MISS] → findUser(userId) via GraphQL → cache → execute query
+  │
+  └─ [Identity cache MISS] → DB lookup: auth_accounts WHERE workos_user_id = sub
+      ├─ [Account EXISTS] → cache mapping → check user scope cache (above)
+      └─ [Account NOT FOUND by workos_user_id]
+          ├─ Fetch email from WorkOS API: GET /user_management/users/{sub}
+          ├─ DB lookup: auth_accounts WHERE email = fetched_email
+          │   ├─ [Account EXISTS, workos_user_id NULL] → backfill workos_user_id → cache mapping → check user scope cache
+          │   ├─ [Account EXISTS, workos_user_id SET] → cache mapping → check user scope cache (race condition: another request already backfilled)
+          │   └─ [Account NOT FOUND] → JIT Provision (below)
+          └─ JIT Provision (new user):
+              ├─ Create user (display_name = firstName+lastName or email)
+              ├─ Create account (email, workos_user_id) — on_conflict: accounts_email_key
+              ├─ Find or create team (from partition claim, _eq lookup) — on_conflict: teams_name_unique
+              ├─ Create membership + role — on_conflict: members_user_id_team_id_key
+              ├─ Cache identity mapping (ONLY on full success)
+              ├─ Cache user scope
+              └─ Execute query
+```

--- a/specs/007-workos-jwt-query/plan.md
+++ b/specs/007-workos-jwt-query/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Query with WorkOS JWT
+
+**Branch**: `007-workos-jwt-query` | **Date**: 2026-03-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-workos-jwt-query/spec.md`
+
+## Summary
+
+Enable the CubeJS analytics service to accept WorkOS JWT tokens directly for query authentication, eliminating the intermediary token-minting step. The system detects the token type (RS256 = WorkOS, HS256 = existing Hasura JWT), verifies accordingly, resolves the user (with JIT provisioning for new users), and caches aggressively so the happy path has zero DB queries and zero external API calls.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES modules), Node.js 22
+**Primary Dependencies**: `jose` ^6.x (new for CubeJS), `@workos-inc/node` (existing in Actions, NOT added to CubeJS — use direct fetch), `jsonwebtoken` (existing in CubeJS, kept for HS256 path)
+**Storage**: PostgreSQL via Hasura GraphQL (existing), In-memory Map caches (existing + new)
+**Testing**: StepCI workflow tests (`tests/`), manual curl verification
+**Target Platform**: Docker containers (Linux amd64)
+**Project Type**: Multi-service web platform (CubeJS service + Actions service + client-v2 frontend)
+**Performance Goals**: Happy path (cached user) adds <5ms overhead (SC-003).
+**Constraints**: Zero downtime deployment. Both token types must work simultaneously. No breaking changes to existing flows.
+**Scale/Scope**: ~15 files changed across 3 projects (including test files and docker-compose variants). No new database migrations (indexes verified to exist from 002-workos-auth).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Service Isolation
+- **PASS**: CubeJS learns to verify a new token type independently. No simultaneous deployment required — existing HS256 path continues working. New env vars (`WORKOS_API_KEY`, `WORKOS_CLIENT_ID`) added to CubeJS service only.
+- **Contract change**: `/auth/token` response adds `workosAccessToken` field (additive, non-breaking). CubeJS auth contract adds WorkOS JWT as accepted token type (additive).
+
+### II. Multi-Tenancy First
+- **PASS**: All queries still flow through `defineUserScope.js` → `buildSecurityContext.js`. The only change is HOW the `userId` is obtained (from WorkOS `sub` instead of Hasura `x-hasura-user-id`). Once resolved, the entire security context pipeline is identical.
+- JIT provisioning uses the `partition` claim for team assignment, preserving tenant isolation.
+
+### III. Test-Driven Development
+- **PASS**: StepCI tests will cover both token paths. Integration tests for: WorkOS token verification, HS256 backward compatibility, JIT provisioning, cache behavior.
+
+### IV. Security by Default
+- **PASS**: JWT validation occurs at every entry point. WorkOS JWKS verification is stricter than shared-key HS256 (asymmetric > symmetric). Algorithm pinning prevents downgrade attacks. `issuer` validation ensures tokens come from the correct WorkOS environment.
+- During dual-stack: both paths enforce identical security guarantees through the same `defineUserScope` → `buildSecurityContext` pipeline.
+
+### V. Simplicity / YAGNI
+- **PASS**: Direct fetch for WorkOS API (1 call) instead of adding full SDK. Three-layer cache uses same Map pattern as existing code. No new abstractions — just extending `checkAuth.js` with a second verification path.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-workos-jwt-query/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research decisions
+├── data-model.md        # Entity model and cache architecture
+├── quickstart.md        # Testing guide
+├── contracts/
+│   └── cubejs-auth.md   # Updated auth contract
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+services/cubejs/
+├── package.json                          # Add jose dependency
+└── src/utils/
+    ├── checkAuth.js                      # Dual-path verification + error mapping
+    ├── checkSqlAuth.js                   # WorkOS JWT as SQL password (username=datasource, fail-closed)
+    ├── workosAuth.js                     # NEW: JWKS verifier, token detection, WorkOS API client
+    └── dataSourceHelpers.js              # Identity mapping cache + provisioning helpers
+
+services/actions/
+└── src/auth/
+    └── token.js                          # Return workosAccessToken in response
+
+../client-v2/
+├── src/stores/AuthTokensStore.ts         # Store workosAccessToken
+├── src/hooks/useAuth.ts                  # Pass through workosAccessToken
+└── src/components/
+    ├── RestAPI/index.tsx                  # Use WorkOS token for CubeJS
+    └── SmartGeneration/index.tsx          # Use WorkOS token for CubeJS
+
+docker-compose.dev.yml                    # Add WORKOS env vars to cubejs service
+```
+
+**Structure Decision**: This feature modifies existing files across three services (CubeJS, Actions, client-v2). No new directories or modules — all changes fit within the existing architecture.
+
+## Complexity Tracking
+
+| Decision | Chosen | Rejected Alternative | Justification |
+|----------|--------|---------------------|---------------|
+| RS256 verification library | `jose` ^6.x (new dep) | Extend `jsonwebtoken` (existing) | `jsonwebtoken` lacks native JWKS support and `createRemoteJWKSet`. `jose` provides built-in JWKS fetching with automatic key rotation handling — eliminates custom cache/refresh logic. |
+| WorkOS API client | Direct `fetch()` | `@workos-inc/node` SDK | SDK adds ~50 dependencies for one API call (`GET /user_management/users/:id`). Direct fetch is simpler and avoids dependency bloat per Constitution §V. |
+| SQL API datasource selection | Username = datasource ID | "Pick first datasource" | Multi-datasource users need deterministic datasource selection. Username field is the natural place for this hint, matching the existing pattern where `sql_credentials.username` pins a specific datasource. |
+| SQL API JWT fail behavior | Fail-closed on JWT verification failure | Fall through to legacy credentials | Once a JWT is detected, falling through on failure would let an expired/invalid JWT accidentally match a stored credential. Fail-closed is the only secure option per Constitution §IV. |
+| CubeJS provisioning logic | Duplicate `deriveTeamName()` from Actions | Shared npm package | Constitution §I requires independent deployability. Duplication is ~50 lines, changes rarely. Cross-reference comments link the two implementations. |
+| Identity resolution chain | workos_user_id → email → backfill → provision | workos_user_id → provision (skip email) | Pre-existing users from before 002-workos-auth may have accounts without `workos_user_id`. Skipping email lookup would create duplicate identities. Must match the Actions provisioning chain (`provision.js:184-196`). |
+| Team name lookup operator | `_eq` with pre-normalized input | `_ilike` (case-insensitive) | `_ilike` cannot use the `teams_name_unique` index efficiently. Since `deriveTeamName()` already normalizes (lowercase + trim), `_eq` is correct and performant. Note: Actions provisioning uses `_ilike` — this is an intentional improvement. |
+| Audience validation | Validate `aud: WORKOS_CLIENT_ID` | No audience check | Without audience validation, a WorkOS token issued for a different application in the same environment would pass verification. One-line addition to `jose.jwtVerify()` options. |

--- a/specs/007-workos-jwt-query/quickstart.md
+++ b/specs/007-workos-jwt-query/quickstart.md
@@ -1,0 +1,115 @@
+# Quickstart: Query with WorkOS JWT
+
+**Branch**: `007-workos-jwt-query` | **Date**: 2026-03-10
+
+## Prerequisites
+
+- Docker services running: `./cli.sh compose up`
+- Client-v2 dev server: `cd ../client-v2 && yarn dev`
+- A valid WorkOS JWT (get from browser network tab or `TEST_TOKEN` in `.env`)
+
+## Deployment Prerequisites
+
+These must be configured in the WorkOS dashboard before this feature works:
+
+1. **JWT Template**: WorkOS must be configured with a JWT template that includes the `partition` claim. This claim provides the team/org identifier used for provisioning. Without it, team derivation falls back to email-domain logic.
+   - In WorkOS Dashboard → Authentication → JWT Templates → add a custom claim: `partition` mapped to the organization slug
+2. **Custom Domain (optional)**: If using a custom auth domain (e.g., `auth.yourdomain.com`), set `WORKOS_ISSUER` env var to the custom issuer URL. The JWKS endpoint and issuer validation will use this instead of the default `https://api.workos.com` prefix.
+
+## Testing the Feature
+
+### 1. Query CubeJS directly with WorkOS JWT
+
+```bash
+# Use the TEST_TOKEN from .env or grab from browser network tab
+TOKEN=$(grep TEST_TOKEN .env | cut -d= -f2)
+
+curl -s -X POST https://dbx.fraios.dev/api/v1/load \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-hasura-datasource-id: <datasource-uuid>" \
+  -H "x-hasura-branch-id: <branch-uuid>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":{"dimensions":["semantic_events.type"],"measures":[],"limit":10}}' | python3 -m json.tool
+```
+
+### 2. Verify backward compatibility
+
+```bash
+# Mint a Hasura JWT (existing flow) and query — should still work
+JWT=$(docker exec synmetrix-actions-1 node -e "
+const jwt = require('jsonwebtoken');
+const token = jwt.sign({
+  hasura: {
+    'x-hasura-user-id': '<user-uuid>',
+    'x-hasura-allowed-roles': ['user'],
+    'x-hasura-default-role': 'user'
+  }
+}, process.env.JWT_KEY, {algorithm: 'HS256', expiresIn: '1h'});
+process.stdout.write(token);
+")
+
+curl -s -X POST http://localhost:4000/api/v1/load \
+  -H "Authorization: Bearer $JWT" \
+  -H "x-hasura-datasource-id: <datasource-uuid>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":{"dimensions":["semantic_events.type"],"measures":[],"limit":10}}'
+```
+
+### 3. Verify JIT provisioning
+
+1. Create a new user in WorkOS dashboard
+2. Obtain their JWT (via AuthKit login flow or API)
+3. Send a query to CubeJS using their token
+4. Verify: user, account, team, and membership created in Postgres
+
+```bash
+# Check the user was provisioned
+docker exec synmetrix-postgres psql -U synmetrix -d synmetrix -c \
+  "SELECT u.id, u.display_name, a.email, a.workos_user_id
+   FROM auth.accounts a JOIN public.users u ON a.user_id = u.id
+   WHERE a.workos_user_id = 'user_<new-user-id>'"
+```
+
+### 4. Query via SQL API with WorkOS JWT
+
+```bash
+# Connect to SQL API using datasource ID as username, WorkOS JWT as password
+TOKEN=$(grep TEST_TOKEN .env | cut -d= -f2)
+PGPASSWORD=$TOKEN psql -h localhost -p 15432 -U "<datasource-uuid>" -c "SELECT 1"
+```
+
+## Environment Variables (new for CubeJS)
+
+Add to `.env` and `docker-compose.dev.yml` for the cubejs service:
+
+```
+WORKOS_API_KEY=sk_test_...     # Already in .env for Actions
+WORKOS_CLIENT_ID=client_01...  # Already in .env for Actions
+WORKOS_ISSUER=                 # Optional: custom auth domain issuer URL (leave empty for default)
+```
+
+## New Dependency (CubeJS)
+
+```bash
+cd services/cubejs && npm install jose
+```
+
+## Files Changed
+
+### CubeJS service (`services/cubejs/`)
+- `package.json` — add `jose` dependency
+- `src/utils/checkAuth.js` — dual-path verification (RS256 + HS256), JIT provisioning, identity cache
+- `src/utils/checkSqlAuth.js` — accept WorkOS JWT as password
+- `src/utils/dataSourceHelpers.js` — add identity mapping cache, add `findAccountByWorkosId()` and provisioning functions
+
+### Actions service (`services/actions/`)
+- `src/auth/token.js` — return `workosAccessToken` in response
+
+### Client-v2 (`../client-v2/`)
+- `src/stores/AuthTokensStore.ts` — store `workosAccessToken`
+- `src/hooks/useAuth.ts` — pass through `workosAccessToken` from token response
+- `src/components/RestAPI/index.tsx` — use WorkOS token for CubeJS requests
+- `src/components/SmartGeneration/index.tsx` — use WorkOS token for CubeJS requests
+
+### Docker/Config
+- `docker-compose.dev.yml` — add `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` to cubejs service

--- a/specs/007-workos-jwt-query/research.md
+++ b/specs/007-workos-jwt-query/research.md
@@ -1,0 +1,107 @@
+# Research: Query with WorkOS JWT
+
+**Branch**: `007-workos-jwt-query` | **Date**: 2026-03-10
+
+## Decision 1: Token Verification Method
+
+**Decision**: Use `jose.createRemoteJWKSet()` for WorkOS RS256 token verification, with dual-path auth supporting both WorkOS and existing HS256 tokens.
+
+**Rationale**:
+- WorkOS JWTs are RS256-signed; the JWKS endpoint is `https://api.workos.com/sso/jwks/{WORKOS_CLIENT_ID}`
+- `jose` already exists in the Actions service (`^4.11.2`) but NOT in CubeJS — needs adding
+- `createRemoteJWKSet()` handles key caching, rotation, and cooldown automatically (30s cooldown, configurable cache max age)
+- Token type detection: WorkOS tokens use RS256 (header `alg: "RS256"`), existing tokens use HS256. Can distinguish by decoding the header without verifying first.
+
+**Alternatives considered**:
+- Shared symmetric key (WorkOS doesn't support this — tokens are always RS256)
+- Proxy all CubeJS requests through Actions (unnecessary latency, Actions already has WorkOS SDK but CubeJS is the auth point)
+
+## Decision 2: User Resolution from WorkOS JWT
+
+**Decision**: Extract `sub` claim from verified WorkOS JWT → look up `auth_accounts.workos_user_id` → get `user_id` (Postgres UUID). Cache the `sub → user_id` mapping separately from the existing user scope cache.
+
+**Rationale**:
+- `accounts_workos_user_id_unique` index already exists — O(1) lookup
+- The existing `findUser()` already caches by `userId` (30s TTL, 500 max). Adding a `sub → userId` mapping cache avoids the DB lookup entirely on the happy path
+- WorkOS JWT claims available: `sub` (user ID), `partition` (team name), `org_id`, `role`, `roles`, `permissions`, `sid`, `exp`, `iat`
+- No `email` in the JWT — email must be fetched from WorkOS API for new user provisioning
+
+**Alternatives considered**:
+- Store WorkOS sub in a separate column on `users` table (unnecessary — `auth_accounts.workos_user_id` already exists)
+- Use `org_id` for team lookup (partition is more specific and already used in provisioning)
+
+## Decision 3: JIT Provisioning at CubeJS Layer
+
+**Decision**: When `workos_user_id` lookup returns no result, call `workos.userManagement.getUser(sub)` to get email/name, then run the same provisioning logic as `callback.js` (create user → account → team → membership).
+
+**Rationale**:
+- `partition` claim is always present in the JWT — team derivation is guaranteed without email
+- Email is needed for `createAccount` (DB constraint: `proper_email` CHECK, and email is used as display name fallback)
+- WorkOS API call: `GET /user_management/users/{user_id}` — returns `{ email, firstName, lastName, profilePictureUrl }`
+- This call happens once per user lifetime (then cached). Requires `WORKOS_API_KEY` env var in CubeJS service
+- The `@workos-inc/node` SDK is in Actions but NOT in CubeJS. For simplicity, use direct HTTP fetch rather than adding the full SDK
+
+**Alternatives considered**:
+- Add `@workos-inc/node` SDK to CubeJS (heavier dependency for a single API call)
+- Require users to log in via web UI first (breaks the "first query works" requirement)
+- Store email in a new JWT claim (requires WorkOS config change, makes token larger)
+
+## Decision 4: Caching Architecture
+
+**Decision**: Three-layer in-memory caching with consistent TTL and size limits.
+
+| Cache Layer | Key | Value | TTL | Max Size |
+|---|---|---|---|---|
+| JWKS keys | kid | Public key | Auto-managed by jose | N/A |
+| Identity mapping | WorkOS `sub` | Postgres `user_id` | 5 min | 1000 |
+| User scope | Postgres `user_id` | `{ dataSources, members }` | 30s (existing) | 500 (existing) |
+
+**Rationale**:
+- Layer 1 (JWKS): Handled by `jose.createRemoteJWKSet()` — no custom code needed
+- Layer 2 (Identity mapping): Longer TTL (5 min) because `sub → user_id` mapping is immutable after provisioning. Higher max size because it's lightweight (two strings)
+- Layer 3 (User scope): Keep existing 30s TTL — permission changes need to propagate reasonably fast
+- Happy path (all cached): JWKS verify (in-memory key) → identity cache hit → user scope cache hit → zero DB queries, zero API calls
+
+**Alternatives considered**:
+- Redis for identity mapping (overkill for string → string mapping; adds network hop)
+- Single unified cache (different TTL needs make this awkward)
+- Longer user scope TTL (30s is already a reasonable balance between performance and freshness)
+
+## Decision 5: Frontend Token Flow
+
+**Decision**: Return `workosAccessToken` alongside `accessToken` from `/auth/token` endpoint. Frontend stores both in `AuthTokensStore`. Use WorkOS token for CubeJS REST calls, keep Hasura JWT for GraphQL.
+
+**Rationale**:
+- Currently WorkOS token stays in Redis, never reaches the browser
+- `/auth/token` handler already has access to `session.workosAccessToken` and handles refresh
+- Only 3 frontend files need changes: `AuthTokensStore.ts`, `RestAPI/index.tsx`, `SmartGeneration/index.tsx`
+- `URQLClient.ts` continues using Hasura JWT for GraphQL (Hasura doesn't need to change)
+
+**Alternatives considered**:
+- Send WorkOS token in a separate cookie (more complex, CORS implications)
+- Have CubeJS accept the Hasura JWT and look up WorkOS user internally (defeats the purpose — still need the minted JWT)
+
+## Decision 6: Database Indexes
+
+**Decision**: No new indexes needed. All required indexes exist.
+
+**Verified indexes**:
+- `accounts_workos_user_id_unique` — primary lookup for identity resolution
+- `accounts_email_key` — email uniqueness during provisioning
+- `members_user_id_team_id_key` — composite index, leading column `user_id` used by `findUser()`
+- `teams_name_unique` — team lookup by name during provisioning
+- `member_roles_member_id_team_role_key` — role lookup
+
+## Decision 7: WorkOS API Key in CubeJS
+
+**Decision**: Add `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` environment variables to the CubeJS service. Use direct `fetch()` for the single WorkOS API call rather than adding the full SDK.
+
+**Rationale**:
+- Only one API call needed: `GET /user_management/users/{sub}`
+- Full `@workos-inc/node` SDK adds ~2MB of dependencies for one HTTP request
+- Direct fetch with `Authorization: Bearer ${WORKOS_API_KEY}` is simpler and lighter
+- `WORKOS_CLIENT_ID` needed for JWKS URL construction
+
+**Alternatives considered**:
+- Import WorkOS SDK (heavier, more maintenance)
+- Call Actions service to fetch user profile (adds latency and coupling)

--- a/specs/007-workos-jwt-query/spec.md
+++ b/specs/007-workos-jwt-query/spec.md
@@ -1,0 +1,189 @@
+# Feature Specification: Query with WorkOS JWT
+
+**Feature Branch**: `007-workos-jwt-query`
+**Created**: 2026-03-10
+**Status**: Draft
+**Input**: User description: "Query with WorkOS JWT"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query Analytics Using WorkOS Session Token (Priority: P1)
+
+A signed-in user navigates to the Explore page, selects a datasource, builds a query (choosing dimensions, measures, filters), and runs it. The analytics service accepts the user's existing WorkOS session token to authenticate and authorize the query, without requiring a separate intermediary token to be minted.
+
+**Why this priority**: This is the core feature. Today the system mints an intermediary token for every session refresh, adding latency and a point of failure. Accepting the WorkOS token directly simplifies the auth chain and removes token-minting as a bottleneck.
+
+**Independent Test**: Can be tested by signing in via WorkOS, navigating to Explore, running a query, and confirming data returns successfully using only the WorkOS-issued credential.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is signed in via WorkOS and has a valid session, **When** they run a query on the Explore page, **Then** the analytics service authenticates the request using the WorkOS token and returns query results.
+2. **Given** a user is signed in via WorkOS and has a valid session, **When** they view the REST API panel in the Explore page, **Then** the displayed bearer token is the WorkOS token and it can be used to query the analytics endpoint directly (e.g., via curl).
+3. **Given** a user's WorkOS token has expired, **When** they run a query, **Then** the system refreshes the token transparently and the query succeeds without user intervention.
+
+---
+
+### User Story 2 - Backward Compatibility with Existing Token (Priority: P1)
+
+The analytics service continues to accept the existing intermediary tokens so that internal service-to-service calls (e.g., Hasura Actions calling the analytics service) and any external integrations that use the current token format continue to work without disruption.
+
+**Why this priority**: Breaking internal service communication would cause a system-wide outage. Both token types must be accepted simultaneously.
+
+**Independent Test**: Can be tested by issuing a query through the existing Hasura Action path (e.g., `fetch_dataset` via GraphQL) and confirming it still works after the change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Hasura Action forwards a request with the existing intermediary token, **When** the analytics service receives it, **Then** it authenticates successfully and returns results.
+2. **Given** a user or system sends a request with either token type, **When** the analytics service receives it, **Then** it correctly identifies the token type and validates it accordingly.
+
+---
+
+### User Story 3 - Query via SQL API Using WorkOS Token (Priority: P2)
+
+A user connects to the SQL API (MySQL or PostgreSQL wire protocol) and authenticates using their WorkOS token as the password and a datasource identifier as the username. The system verifies the token, resolves the specified datasource, and grants access if the user has permission.
+
+**Why this priority**: The SQL API is a secondary access method used by advanced users and BI tools. It should support the same authentication but is not on the critical path for most users.
+
+**Independent Test**: Can be tested by connecting via a MySQL or PostgreSQL client using a datasource ID as the username and the WorkOS token as the password, then running a SQL query.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has a valid WorkOS token, **When** they connect to the SQL API using a datasource ID as the username and the WorkOS token as the password, **Then** they are authenticated and can run queries against that specific datasource.
+2. **Given** a user has an expired WorkOS token, **When** they attempt to connect to the SQL API, **Then** they receive a clear authentication error.
+3. **Given** a user provides a JWT-shaped password that fails verification, **When** the SQL API detects it as a JWT, **Then** it rejects the connection with an authentication error (fail-closed) — it does NOT fall through to legacy credential lookup.
+4. **Given** a user provides a datasource ID they do not have access to, **When** they connect to the SQL API, **Then** they receive an authorization error.
+
+---
+
+---
+
+### User Story 4 - First Query Automatically Provisions User (Priority: P1)
+
+A user who has authenticated via the identity provider but has never queried the analytics service before sends their first query. The system recognizes the token is valid, finds no matching platform user, and automatically provisions the user, their team (derived from the token's organization/partition claim), and their team membership — then executes the query. This happens transparently; the user simply sees their query results.
+
+**Why this priority**: Without JIT provisioning at the analytics layer, new users would get "user not found" errors on their first query, breaking the experience entirely. This is a prerequisite for User Story 1 to work for any user who hasn't previously logged in through the web UI.
+
+**Independent Test**: Can be tested by creating a new user in the identity provider, obtaining a token, and sending a query directly to the analytics REST API without first visiting the web UI. The query should succeed and the user/team/membership should exist in the database afterward.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid identity-provider token for a user with no platform account, **When** they send a query to the analytics service, **Then** the system fetches the user's email from the identity provider API, creates the user, account, team (derived from the token's partition claim), and membership, then returns query results.
+2. **Given** a valid identity-provider token for a user who has a platform account but no membership in the organization's team, **When** they send a query, **Then** the system creates the missing membership and returns query results.
+3. **Given** a valid identity-provider token for a user who already has full provisioning, **When** they send a query, **Then** the system resolves the user from cache (no database lookups on the happy path) and returns query results with no additional overhead.
+4. **Given** two users from the same organization query for the first time in quick succession, **When** the second user's provisioning attempts to create the same team, **Then** the system handles the duplicate gracefully (finds the existing team) and creates only the membership.
+
+---
+
+### User Story 5 - Cached User Resolution for Subsequent Queries (Priority: P1)
+
+After a user's first query triggers provisioning (or after their identity is resolved on any query), subsequent queries from the same user skip all provisioning lookups and resolve the user from an in-memory cache. The cache has a reasonable time-to-live so that permission changes eventually take effect without requiring a service restart.
+
+**Why this priority**: Without caching, every query would require multiple database roundtrips to resolve the user, their team memberships, and their datasource permissions — adding unacceptable latency to the happy path. The existing system already caches user lookups with a 30-second TTL; this must extend to cover the identity-provider-to-platform-user mapping as well.
+
+**Independent Test**: Can be tested by sending two identical queries in quick succession and verifying (via logs or timing) that the second query does not perform provisioning or identity resolution database lookups.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has already been resolved (via provisioning or lookup), **When** they send another query within the cache TTL, **Then** the system resolves the user from cache with no database calls for identity mapping.
+2. **Given** a user's permissions change (e.g., added to a new team or granted access to a new datasource), **When** the cache TTL expires, **Then** the next query reflects the updated permissions.
+3. **Given** the cache reaches its maximum size, **When** a new user queries, **Then** the oldest cache entry is evicted and the new user is resolved and cached.
+
+---
+
+### Edge Cases
+
+- What happens when the identity provider's user management API is temporarily unreachable during new user provisioning? The system returns a clear error and the user can retry; the query is not executed with a partially provisioned user.
+- What happens when the identity provider rotates its signing keys? The system fetches the latest keys dynamically rather than caching them indefinitely.
+- What happens when the identity provider's key endpoint is temporarily unreachable? The system fails closed (denies access) with a clear error message; it does not fall back to accepting unverified tokens.
+- What happens when a token is structurally valid but was issued by a different environment (e.g., staging key used against production)? The system rejects it.
+- What happens when provisioning partially fails (e.g., user created but team creation fails)? The system returns a clear error and does not cache the partial state; the next query retries the full provisioning.
+- What happens when two concurrent requests for the same unprovisioned user arrive simultaneously? The system handles race conditions gracefully using idempotent operations (e.g., upserts with on-conflict handling) so both requests succeed.
+- What happens when a SQL API connection provides a JWT-shaped password that fails verification? The system fails closed and rejects the connection — it does not fall through to legacy credential lookup, preventing an expired/invalid JWT from accidentally matching a stored credential.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Token Verification**
+
+- **FR-001**: The analytics service MUST accept identity-provider-issued tokens as bearer tokens for query authentication on all REST API endpoints.
+- **FR-002**: The analytics service MUST continue to accept the existing intermediary tokens for backward compatibility.
+- **FR-003**: The system MUST determine which token type was provided and apply the correct verification method for each.
+- **FR-004**: The system MUST dynamically fetch and cache the identity provider's signing keys, refreshing them when key rotation occurs. ~~Token verification MUST validate the audience claim matches the expected client ID~~ **NOTE**: WorkOS access tokens do not include an `aud` claim — audience validation is omitted. Issuer validation (`iss: https://api.workos.com/user_management/{CLIENT_ID}`) provides equivalent app-scoping since the issuer contains the client ID.
+
+**JIT User Provisioning**
+
+- **FR-005**: When an identity-provider token is provided and no corresponding platform user exists, the system MUST first attempt to match by subject identifier, then fall back to matching by email (fetched from the identity provider's user management API). If an email match is found with a missing subject identifier, the system MUST backfill the subject identifier on the existing account. If no match is found at all, the system MUST provision the user (account, profile, team, and team membership) before executing the query. This three-step resolution (subject → email → provision) ensures pre-existing users who registered before the identity provider migration are not duplicated.
+- **FR-006**: If the identity provider returns no display name (first/last name both absent), the system MUST use the user's email address as the display name.
+- **FR-007**: The identity provider API call MUST only occur when provisioning a new user (no existing account match). For all subsequent queries, the cached subject-to-user mapping eliminates any external API calls.
+- **FR-008**: Team assignment during provisioning MUST use the token's partition claim to derive the team name. The partition claim is expected to always be present (via JWT template configuration), but the implementation SHOULD include an email-domain fallback for defensive resilience, consistent with the existing `deriveTeamName()` logic in the Actions service.
+- **FR-009**: Provisioning MUST use idempotent operations (upserts, on-conflict handling) so that concurrent requests for the same user or team do not cause errors or duplicate records.
+- **FR-010**: When an identity-provider token is provided and the platform user already exists, the system MUST resolve the token's subject identifier to the corresponding platform user to enforce datasource permissions and access controls.
+
+**Caching**
+
+- **FR-011**: The system MUST cache the mapping from identity-provider subject identifier to platform user ID, so that subsequent queries from the same user skip both the database lookup and any identity provider API calls.
+- **FR-012**: The system MUST cache the resolved user scope (team memberships, datasource access, permissions) with a bounded time-to-live, consistent with the existing user cache behavior.
+- **FR-013**: The cache MUST NOT store partial provisioning results; only fully provisioned users are cached.
+- **FR-014**: The cache MUST have a maximum size with eviction of oldest entries to prevent unbounded memory growth.
+- **FR-015**: On the happy path (cached user), resolving an identity-provider token to a fully authorized user MUST require zero database queries and zero external API calls — only in-memory cache lookups.
+
+**Database Performance**
+
+- **FR-016**: The database MUST have indexes on all columns used in the identity resolution and provisioning lookup paths to ensure identity resolution queries complete in under 10ms at 100K+ accounts. At minimum: unique index on the identity-provider user ID column in the accounts table, composite index on user-team membership, and unique index on team name.
+
+**SQL API & Frontend**
+
+- **FR-017**: The SQL API MUST accept identity-provider tokens as passwords for authentication, using the username field as the datasource identifier, in addition to the existing credential method. When a JWT-shaped password is detected (contains two dots and decodes as RS256), verification failure MUST fail closed — the system MUST NOT fall through to legacy credential lookup.
+- **FR-018**: The system MUST return clear, distinguishable error messages for: expired token, invalid signature, provisioning failure, and service unavailable scenarios. HTTP status codes MUST match the error type (400 for bad request, 403 for auth failures, 404 for not found, 503 for upstream service unavailable) — errors MUST NOT bubble up as generic 500s.
+- **FR-019**: The frontend MUST send the identity-provider token directly to the analytics service for REST API queries, eliminating the need to mint an intermediary token for this path.
+
+### Key Entities
+
+- **User Session**: Represents an authenticated user's session; contains the identity-provider token, the platform user identifier, and associated team/datasource permissions.
+- **Access Token**: A credential used to authenticate analytics queries; can be either an identity-provider-issued token (asymmetric signature, contains subject claim) or an existing intermediary token (symmetric signature, contains platform-specific claims).
+- **Signing Key Set**: The set of public keys published by the identity provider used to verify tokens; must be fetched dynamically and cached with appropriate refresh logic.
+- **Identity Mapping**: The association between an identity-provider subject identifier and a platform user ID; established during provisioning and cached for fast resolution on the query hot path.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can run analytics queries using their session token with no additional authentication steps, and queries return results within the same time as the current flow (no measurable latency increase on cached/happy path).
+- **SC-002**: 100% of existing query paths (internal service-to-service calls, GraphQL action forwarding) continue to work without modification after the change is deployed.
+- **SC-003**: On the happy path (cached user), token verification and user resolution add less than 5ms of overhead compared to the current verification method (JWKS key is cached in-memory, identity and scope caches hit).
+- **SC-004**: A brand-new user's first query completes successfully (including automatic provisioning) without the user needing to visit the web UI first or take any additional steps.
+- **SC-005**: A user's second and subsequent queries (within the cache window) resolve with zero database lookups for identity mapping or provisioning checks.
+- **SC-006**: The system correctly rejects expired, invalid, or wrong-environment tokens in 100% of cases, with user-friendly error messages.
+
+**Implementation Note**: In this implementation, the identity provider is **WorkOS**. References to "identity-provider" throughout this spec map to WorkOS AuthKit (JWT issuance), WorkOS JWKS (key verification), and WorkOS User Management API (profile fetching).
+
+## Assumptions
+
+- The identity-provider token contains a `sub` claim (unique user identifier). Email is not present in the token. The `partition` claim (team identifier) is included via a **JWT template** configured in the identity provider — this is a deployment prerequisite, not a default token claim.
+- The identity provider publishes a standard key-set endpoint for token verification and a user management API for fetching user profiles (email, display name) by subject identifier.
+- The identity provider API is only called once per user lifetime *in the CubeJS query path*: when a brand-new user (no matching account) sends their first query. The login flow (Actions service) independently reconciles user data on every login. After CubeJS provisioning, the subject-to-user mapping is cached and no further CubeJS-initiated API calls are needed.
+- The existing intermediary token format and signing key will remain unchanged and continue to be used for service-to-service calls.
+- The backend session (Redis) already stores the identity-provider token from the login flow. The `/auth/token` endpoint must be updated to return it to the frontend (see FR-019 and the corresponding tasks). No new login flow changes are needed.
+- **Security tradeoff**: The identity-provider token is returned to the frontend and stored in JavaScript application state (Zustand store). The identity provider's documentation recommends httpOnly cookie storage. This is an accepted tradeoff: the existing intermediary token already uses the same client-side storage pattern, so this does not expand the attack surface. The token grants no more access than the existing intermediary token it replaces for CubeJS calls.
+- Key caching with automatic refresh on verification failure is sufficient; proactive key polling is not required.
+- Team derivation uses the token's partition claim as the primary source. The same `deriveTeamName()` logic from the login-time provisioning is reused: partition (when present) takes priority, email-domain is the fallback for tokens without partition. Both provisioning paths (Actions login-time and CubeJS query-time) use this same function to ensure consistency.
+- Idempotent database operations (upserts, on-conflict) are available and reliable for handling concurrent provisioning of the same user or team.
+- If the identity provider's issuer changes (e.g., due to custom domain configuration), the JWKS URL and issuer validation must be updated as deployment configuration — not hardcoded.
+
+## Scope Boundaries
+
+### In Scope
+- Analytics service (REST API and SQL API) accepting identity-provider tokens
+- Dual-token verification (identity-provider + existing intermediary)
+- JIT user/team/membership provisioning at the analytics layer for new users
+- Two-layer caching: identity-provider subject → platform user ID mapping, and platform user → scope/permissions (existing cache)
+- User resolution from identity-provider token claims
+- Frontend sending identity-provider token directly to analytics endpoints
+- Signing key caching and refresh
+
+### Out of Scope
+- Changes to the GraphQL API authentication (continues using existing tokens via Hasura)
+- Changes to the login/signup flow
+- Changes to the existing login-time provisioning logic (it remains as-is; the analytics-layer provisioning is additive)
+- Migration away from the intermediary token entirely (it remains for service-to-service use)

--- a/specs/007-workos-jwt-query/tasks.md
+++ b/specs/007-workos-jwt-query/tasks.md
@@ -1,0 +1,223 @@
+# Tasks: Query with WorkOS JWT
+
+**Input**: Design documents from `/specs/007-workos-jwt-query/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/cubejs-auth.md
+**Dependency**: T010 assumes `session.workosAccessToken` is populated by the 002-workos-auth feature (WorkOS login flow stores the access token in the Actions session). Verify this exists before starting Phase 3.
+
+**Organization**: Tasks are grouped by user story. US4 (JIT Provisioning) and US5 (Caching) are prerequisites for US1 (Query with WorkOS JWT), so they are in the Foundational phase. Per Constitution §III, test stubs are written before implementation within each phase.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup
+
+**Purpose**: Add dependencies, environment configuration, and verify prerequisites.
+
+- [x] T001 Add `jose` dependency to `services/cubejs/package.json` and run `npm install`
+- [x] T002 [P] Add `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` environment variables to `docker-compose.dev.yml` for the cubejs service (reference existing values from `.env`)
+- [x] T003 [P] Add `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` to `.env.example` with placeholder values
+- [ ] T003a [P] [FR-016] Verify required database indexes exist by querying `pg_indexes` for: (1) unique index on `auth_accounts.workos_user_id`, (2) composite index on `members(user_id, team_id)`, (3) unique index on `teams.name`. If any are missing, create a Hasura migration to add them.
+- [ ] T003b [P] Verify deployment prerequisites: (1) Confirm WorkOS JWT template is configured to include `partition` claim (check a sample token or WorkOS dashboard). Document the required JWT template configuration in `quickstart.md`. (2) Confirm `WORKOS_ISSUER` is documented as optional env var for custom domain deployments. (3) Verify `session.workosAccessToken` is populated by 002-workos-auth: run `curl /auth/token` with a valid session cookie and confirm `workosAccessToken` is present in the response — if not, the Phase 3 frontend tasks are blocked.
+
+**Checkpoint**: CubeJS service has jose available, WorkOS env vars configured, required indexes verified, and deployment prerequisites documented.
+
+---
+
+## Phase 2: Foundational — Token Verification & Identity Resolution (US4 + US5)
+
+**Purpose**: Core dual-token verification, identity mapping cache, JIT provisioning, and user scope caching. These are blocking prerequisites — US1 and US3 cannot work without them.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+**TDD Approach (Constitution §III)**: For each module, write a StepCI test stub first (expected to fail), then implement until the test passes.
+
+### Step 1: Tests First — Write Failing Test Stubs
+
+- [ ] T004a [P] Create StepCI test for WorkOS JWT verification in `tests/stepci/workos-auth.yml`: send a valid WorkOS JWT to `/api/v1/load` and assert 200 response. Send an expired token and assert 403 with `TokenExpiredError`. Send a token with invalid signature and assert 403. **Expected: FAIL (no WorkOS verification path exists yet).**
+- [ ] T004b [P] Create StepCI test for HS256 backward compatibility in `tests/stepci/hasura-jwt-compat.yml`: mint an HS256 JWT inside the actions container and query `/api/v1/load`, assert 200 response with valid data. **Expected: PASS (existing path unchanged).**
+- [ ] T004c [P] Create StepCI test for JIT provisioning in `tests/stepci/jit-provision.yml`: send a WorkOS JWT for a user with no `auth_accounts` record, assert 200 response, then query Postgres to verify user, account, team, and membership were created. **Expected: FAIL (no provisioning path exists yet).**
+- [ ] T004d [P] Create StepCI test for identity cache behavior in `tests/stepci/workos-cache.yml`: send two identical WorkOS JWT queries in quick succession, assert both return 200, and verify (via logs or timing) that the second query skipped DB lookup. **Expected: FAIL.**
+
+### Step 2: WorkOS Token Verification (make T004a pass)
+
+- [x] T005 Create WorkOS JWKS verifier module in `services/cubejs/src/utils/workosAuth.js`: export a `verifyWorkOSToken(token)` function that uses `jose.createRemoteJWKSet()` with the JWKS URL derived from `WORKOS_CLIENT_ID` (support custom issuer via optional `WORKOS_ISSUER` env var for custom domain deployments), verifies with `algorithms: ["RS256"]`, issuer validation, and `audience: WORKOS_CLIENT_ID` (prevents tokens issued for a different WorkOS application from being accepted), and returns the decoded payload. Also export a `detectTokenType(token)` function that decodes the JWT header (without verification) and returns `"workos"` for RS256 or `"hasura"` for HS256. Include structured error handling: throw errors with a `status` property (403 for expired/invalid signature, 503 for JWKS fetch failure) so the Express error handler returns the correct HTTP status — errors MUST NOT bubble up as generic 500s (FR-018). Log provisioning errors but don't expose internal details to the client.
+
+### Step 3: Identity Mapping Cache (US5) + JIT Provisioning Helpers (US4)
+
+These three tasks modify different functions and can run in parallel:
+
+- [x] T006 [P] [US5] Add identity mapping cache to `services/cubejs/src/utils/dataSourceHelpers.js`: create a new `workosSubCache` Map with 5-minute TTL and 1000 max entries, following the same pattern as the existing `userCache`. Export `getWorkosSubCacheEntry(sub)`, `setWorkosSubCacheEntry(sub, userId)`, and `invalidateWorkosSubCache(sub)` functions.
+
+- [x] T007 [P] [US4] Add identity resolution functions to `services/cubejs/src/utils/dataSourceHelpers.js`: (1) `findAccountByWorkosId(workosUserId)` — GraphQL query to `auth_accounts(where: {workos_user_id: {_eq: $workosUserId}})` returning `{id, user_id, email, workos_user_id}`. (2) `findAccountByEmail(email)` — GraphQL query to `auth_accounts(where: {email: {_eq: $email}})` returning `{id, user_id, email, workos_user_id}`. (3) `backfillWorkosId(accountId, workosUserId)` — GraphQL mutation to set `workos_user_id` on an existing account. **Why all three**: Pre-existing users who logged in before 002-workos-auth may have accounts without `workos_user_id` set. The resolution chain must be: workos_user_id lookup → email lookup → backfill workos_user_id (matching the Actions provisioning pattern in `services/actions/src/auth/provision.js:184-196`). Uses admin-secret auth via the existing `fetchGraphQL` utility.
+
+- [x] T008 [P] [US4] Add `fetchWorkOSUserProfile(workosUserId)` function to `services/cubejs/src/utils/workosAuth.js`: direct HTTP fetch to `https://api.workos.com/user_management/users/${workosUserId}` with `Authorization: Bearer ${WORKOS_API_KEY}`. Returns `{email, firstName, lastName, profilePictureUrl}`. Use email as display name if firstName and lastName are both null. Handle API errors: timeout (5s), 404 (user not found → throw with `status: 404`), 5xx (service unavailable → throw with `status: 503`) per FR-018. All thrown errors must include a `status` property for the error mapper.
+
+### Step 4: JIT Provisioning Orchestrator (US4) — make T004c pass
+
+- [x] T009 [US4] Add `provisionUserFromWorkOS(workosPayload)` function to `services/cubejs/src/utils/dataSourceHelpers.js`: accepts the verified WorkOS JWT payload. **Identity resolution chain** (must match `services/actions/src/auth/provision.js:184-196`): (1) check identity cache for `payload.sub`, (2) call `findAccountByWorkosId(payload.sub)`, (3) if not found, call `fetchWorkOSUserProfile(payload.sub)` to get email, then `findAccountByEmail(email)`, (4) if email match found but `workos_user_id` is null, call `backfillWorkosId(accountId, payload.sub)` and use the existing user, (5) if no account found at all, create user, account, team, membership, and member role. **Team derivation**: reuse the same `deriveTeamName(email, partition)` logic from `services/actions/src/auth/provision.js` (partition takes priority, email-domain is fallback). Add a cross-reference comment in both files: `// NOTE: team derivation logic duplicated in services/{actions,cubejs} — keep in sync`. Replicate the same helper functions (`findTeamByName`, `createTeam`, `createMember`, `createMemberRole`). **Idempotency (FR-009)**: ALL mutations MUST use upsert/on-conflict semantics — `createAccount` with `on_conflict: {constraint: accounts_email_key}`, `createTeam` with `on_conflict: {constraint: teams_name_unique}`, `createMember` with `on_conflict: {constraint: members_user_id_team_id_key}`, `createMemberRole` with `on_conflict: {constraint: member_roles_member_id_team_role_key}`. Note: the Actions provisioning currently only uses `on_conflict` for `createMember` — CubeJS must be more thorough because it handles concurrent first-queries without session serialization. Also: `findTeamByName` MUST use `_eq` (not `_ilike`) with pre-normalized (lowered, trimmed) input so the `teams_name_unique` index is used efficiently. Handle the "account exists but membership missing" case for retry-safety after partial failures. On ANY provisioning failure, do NOT cache the `sub → userId` mapping — throw with appropriate `status` property and let the next request retry the full chain (FR-013). Caches the `sub → userId` mapping ONLY on full success. Returns `userId`. **Rollback**: These functions are inert until imported by `checkAuth.js` (T010). If provisioning creates bad data, clean up via Hasura console; FR-013 prevents caching of partial state so the next request retries.
+
+### Step 5: Dual-Path checkAuth (US1 + US2) — make T004a + T004d pass
+
+- [x] T010 Update `services/cubejs/src/utils/checkAuth.js` to support dual-token verification: import `detectTokenType` and `verifyWorkOSToken` from `workosAuth.js`, import `getWorkosSubCacheEntry`, `setWorkosSubCacheEntry`, `findAccountByWorkosId`, `findAccountByEmail`, `backfillWorkosId`, and `provisionUserFromWorkOS` from `dataSourceHelpers.js`. In the `checkAuth` function, after extracting `authToken`, call `detectTokenType(authToken)`. If `"workos"`: verify with `verifyWorkOSToken()`, resolve `userId` via cache → DB (workos_user_id → email fallback → backfill) → provision chain, then continue to `findUser(userId)` and `defineUserScope()` as before. If `"hasura"`: keep the existing `jwt.verify()` path unchanged. Both paths set `req.securityContext` with the same shape. Update `checkAuthMiddleware` error handler: if `err.status` is set, use it as the HTTP status code; otherwise default to 500. **Also update the global error handler** in `services/cubejs/index.js:104`: change `res.status(500).send(err.message)` to `res.status(err.status || 500).send(err.message)` — the current handler always returns 500 regardless of the error's `status` property, which would defeat all the structured error handling in `workosAuth.js` and `dataSourceHelpers.js` (FR-018). **Rollback**: This is the critical integration point. If issues arise, revert to the pre-change `checkAuth.js` — the HS256-only path is the safe fallback. The `workosAuth.js` and `dataSourceHelpers.js` additions are inert without `checkAuth.js` importing them.
+
+### Step 6: Verify All Phase 2 Tests Pass
+
+- [ ] T010a Run all StepCI tests from Step 1 (T004a-T004d) and confirm they pass. Fix any failures before proceeding.
+
+**Checkpoint**: CubeJS accepts both WorkOS RS256 and Hasura HS256 tokens. New users are provisioned on first query. Cached users resolve with zero DB lookups. All tests green.
+
+---
+
+## Phase 3: User Story 1 — Query Analytics Using WorkOS Session Token (Priority: P1) MVP
+
+**Goal**: Users query the analytics service directly with their WorkOS JWT from the frontend.
+
+**Independent Test**: Sign in via WorkOS, navigate to Explore, run a query — data returns using the WorkOS token.
+
+**Prerequisite**: Verify that `session.workosAccessToken` is populated by the 002-workos-auth feature before starting this phase.
+
+### Backend: Token Endpoint
+
+- [x] T011 [US1] Update `services/actions/src/auth/token.js`: add `workosAccessToken: session.workosAccessToken` to the JSON response object in both the refresh path (line 75) and the default path (line 99). **Note**: The refresh path currently refreshes the WorkOS token and stores it in the session but never returns it to the client — this is a functional gap, not just a new field. **Rollback**: Remove the `workosAccessToken` field from the response — frontend falls back to existing `accessToken`.
+
+### Frontend: Store & Use WorkOS Token
+
+- [x] T012 [US1] Update `../client-v2/src/hooks/useAuth.ts`: extend the `TokenResponse` type to include `workosAccessToken?: string`. Pass it through in `fetchToken()` return value.
+
+- [x] T013 [US1] (depends on T012) Update `../client-v2/src/stores/AuthTokensStore.ts`: add `workosAccessToken: string | null` to the store state, initialize to `null`, set it from `authData.workosAccessToken` in `setAuthData()`, and clear it in `cleanTokens()`.
+
+- [x] T014 [P] [US1] Update `../client-v2/src/components/RestAPI/index.tsx`: import `workosAccessToken` from `AuthTokensStore()` (line 63). Change the `token` default value from `Bearer ${accessToken}` to `Bearer ${workosAccessToken || accessToken}` (line 77). This sends the WorkOS JWT to CubeJS when available, falling back to the Hasura JWT.
+
+- [x] T015 [P] [US1] Update `../client-v2/src/components/SmartGeneration/index.tsx`: wherever `AuthTokensStore.getState().accessToken` is used for CubeJS `/api/v1/*` fetch calls, change to prefer `workosAccessToken` with fallback: `const token = AuthTokensStore.getState().workosAccessToken || AuthTokensStore.getState().accessToken`.
+
+- [x] T015a [US1] [FR-019] Audit all CubeJS API call sites in client-v2: run `grep -rn '/api/v1/\|cubejsApi\|cubejs.*fetch\|cubeApi' ../client-v2/src/` to produce a complete list of call sites. Update any components beyond RestAPI and SmartGeneration to prefer `workosAccessToken` with `accessToken` fallback. **Done when**: every `/api/v1/*` fetch in client-v2 uses `workosAccessToken || accessToken`, and the grep results are documented in the PR description.
+
+**Checkpoint**: User Story 1 complete. Users can query CubeJS with WorkOS JWT from the Explore page. Existing Hasura JWT flow still works as fallback.
+
+---
+
+## Phase 4: User Story 2 — Backward Compatibility (Priority: P1)
+
+**Goal**: Existing intermediary tokens continue to work for Hasura Actions and service-to-service calls.
+
+**Independent Test**: Run a query via GraphQL (`fetch_dataset` mutation) — the Hasura Action path still works.
+
+- [ ] T016 [US2] Verify backward compatibility: no code changes needed (the dual-path in T010 preserves the HS256 path). Create a manual test script or curl command in `tests/test-backward-compat.sh` that mints a Hasura JWT inside the actions container and queries CubeJS to confirm it still works.
+
+**Checkpoint**: Both token paths verified working.
+
+---
+
+## Phase 5: User Story 3 — Query via SQL API Using WorkOS Token (Priority: P2)
+
+**Goal**: SQL API (MySQL/PG wire protocol) accepts WorkOS JWT as password, with datasource specified via username.
+
+**Independent Test**: Connect via `psql` or `mysql` CLI using a datasource ID as username and WorkOS JWT as password, run a SQL query.
+
+### Test First (Constitution §III)
+
+- [ ] T016a [US3] Create StepCI test for SQL API WorkOS auth in `tests/stepci/sql-api-workos.yml`: **Note**: StepCI tests are HTTP-based and cannot directly test MySQL/PG wire protocol authentication. This test covers the `/api/v1/cubesql` HTTP endpoint. Wire protocol auth must be verified manually via `psql`/`mysql` CLI (see quickstart.md). connect to the SQL API (MySQL or PG wire protocol) using a datasource ID as the username and a valid WorkOS JWT as the password, run a simple query, and assert success. Also test: expired JWT as password (assert auth error), valid JWT but unauthorized datasource ID (assert auth error), invalid JWT that looks like a JWT (assert fail-closed — NOT legacy credential fallback). **Expected: FAIL (no SQL API WorkOS path exists yet).**
+
+### Implementation
+
+- [x] T017 [US3] Update `services/cubejs/src/utils/checkSqlAuth.js`: add a WorkOS JWT detection path. The `checkSqlAuth(_, user)` function receives `user` as an object with `username` and `password` properties (or a string depending on the Cube.js SQL API interface — verify the actual signature first). Detect if the password looks like a JWT (contains two dots and header decodes as RS256 via `detectTokenType()`). If JWT detected: verify with `verifyWorkOSToken(password)`. **On verification failure: fail closed** — throw an auth error, do NOT fall through to `findSqlCredentials`. On success: resolve `userId` via the cache → DB → provision chain from `dataSourceHelpers.js`, call `findUser(userId)` to get datasources and members, use `username` as the `datasourceId` to select the specific datasource from the user's accessible datasources, verify the user has access to that datasource (member of the owning team), build the security context via `defineUserScope(dataSources, members, datasourceId)`, and return `{ password, securityContext }`. If the username doesn't match any accessible datasource, throw with `status: 403`. If password is NOT a JWT, fall through to the existing `findSqlCredentials(username)` path unchanged.
+
+**Checkpoint**: SQL API accepts WorkOS tokens as passwords with datasource selection via username. Fail-closed on JWT verification failure. All T016a tests pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Error mapping, cache invalidation integration, environment config, performance verification.
+
+- [ ] T017a [FR-018] Verify error mapping end-to-end: confirm that all auth/provisioning errors from `workosAuth.js` and `dataSourceHelpers.js` include a `status` property, and that `checkAuthMiddleware`, `checkSqlAuth`, and the global error handler (updated in T010) propagate it as the HTTP status code. Extend the StepCI test in `tests/stepci/workos-auth.yml` (from T004a) to assert: expired token → 403 (not 500), JWKS unreachable → 503 (not 500), missing datasource header → 400 (not 500). Also add a `status` property to existing error throws in `checkAuth.js` (e.g., "Provide Hasura Authorization token" → `status: 403`, "No x-hasura-datasource-id" → `status: 400`, user not found → `status: 404`). Fix any errors that bubble as 500.
+
+- [x] T018 Extend the internal cache invalidation endpoint in `services/cubejs/src/routes/index.js`: add support for `type: "workos"` in the `/api/v1/internal/invalidate-cache` handler that calls `invalidateWorkosSubCache()` to clear the identity mapping cache. Also clear the workos sub cache when `type: "all"` is received.
+
+- [x] T019 [P] Add `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` environment variables to `docker-compose.stage.yml` and `docker-compose.test.yml` for the cubejs service (`docker-compose.dev.yml` already handled in T002).
+
+- [ ] T020 [P] [SC-003] Performance verification: run two queries with the same WorkOS JWT in quick succession. Measure that the second (cached) query's auth overhead is <5ms compared to the existing HS256 path (per SC-003). Document results.
+
+- [ ] T021 Run quickstart.md validation: execute all test scenarios from `specs/007-workos-jwt-query/quickstart.md` and verify they pass.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (jose dependency). BLOCKS all user stories. Tests written first per §III.
+- **US1 (Phase 3)**: Depends on Phase 2 (dual-path checkAuth must exist). Verify 002-workos-auth session prerequisite.
+- **US2 (Phase 4)**: Depends on Phase 2 (can run in parallel with US1)
+- **US3 (Phase 5)**: Depends on Phase 2 (can run in parallel with US1 and US2)
+- **Polish (Phase 6)**: Depends on Phases 3-5
+
+### User Story Dependencies
+
+- **US4 + US5 (Provisioning + Caching)**: In Foundational phase — completed first
+- **US1 (Query with WorkOS JWT)**: Depends on Foundational. Backend changes in Phase 2, frontend in Phase 3.
+- **US2 (Backward Compatibility)**: Depends on Foundational. Verification only — no code changes.
+- **US3 (SQL API)**: Depends on Foundational. Independent of US1 frontend changes.
+
+### Within Phase 2 (Foundational)
+
+```
+Step 1: T004a-T004d (test stubs — all parallel, expected to fail)
+Step 2: T005 (JWKS verifier — makes T004a partially pass)
+Step 3: T006, T007, T008 (cache + helpers — all parallel)
+Step 4: T009 (provisioning orchestrator — makes T004c pass)
+Step 5: T010 (checkAuth dual-path — makes T004a + T004d fully pass)
+Step 6: T010a (verify all tests green)
+```
+
+### Parallel Opportunities
+
+```
+Phase 1: T002, T003, T003a, T003b can run in parallel
+Phase 2 Step 1: T004a, T004b, T004c, T004d can run in parallel
+Phase 2 Step 3: T006, T007, T008 can run in parallel (different files/functions)
+Phase 3: T014 and T015 can run in parallel (different frontend components)
+Phase 5: T016a must complete before T017 (TDD)
+Phases 3, 4, 5: US1 frontend, US2 verification, US3 SQL API can run in parallel
+Phase 6: T017a, T018, T019, T020 can run in parallel
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup (T001-T003a) — includes index verification
+2. Complete Phase 2: Foundational (T004a-T010a) — tests first, then implementation, then verify
+3. Complete Phase 3: US1 frontend (T011-T015a)
+4. **STOP and VALIDATE**: Query CubeJS with WorkOS JWT from the Explore page
+5. Deploy if ready — backward compat is inherent in the dual-path design
+
+### Incremental Delivery
+
+1. Setup + Foundational → CubeJS accepts WorkOS JWTs (backend MVP, tests green)
+2. Add US1 frontend → Full end-to-end flow working
+3. Add US2 verification → Confidence in backward compatibility
+4. Add US3 SQL API → Advanced users can connect BI tools
+5. Polish → Cache invalidation, environment config, performance verification
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- US4 (JIT Provisioning) and US5 (Caching) are in Phase 2 because they are prerequisites for US1
+- No new database migrations expected — indexes verified in T003a (create migration if missing)
+- The `workosAuth.js` file is new; all other files are modifications to existing code
+- WorkOS API is only called once per user lifetime *in the CubeJS query path* (during first-ever query provisioning). The Actions login flow independently reconciles user data on every login.
+- CubeJS provisioning duplicates `deriveTeamName()` and helper functions from `services/actions/src/auth/provision.js`. Both implementations must stay in sync — cross-reference comments are required (T009).
+- All errors from auth/provisioning must include a `status` property for correct HTTP status codes (FR-018, T017a).
+- `partition` claim requires a WorkOS JWT template configuration — this is a deployment prerequisite verified in T003b, not an automatic token feature.
+- Commit after each task or logical group
+- Phase 3 depends on 002-workos-auth having populated `session.workosAccessToken` in the Actions service — verified in T003b


### PR DESCRIPTION
## Summary
- **Dual-path JWT auth**: CubeJS now accepts WorkOS RS256 JWTs alongside existing Hasura HS256 tokens, with automatic detection via JWT header `alg` field
- **JIT user provisioning**: Identity resolution chain (cache → workos_user_id → email fallback → backfill → full provision) with team membership reconciliation for existing accounts
- **SQL API support**: WorkOS JWT-as-password with fail-closed verification — JWT failures never fall through to legacy credential lookup
- **Performance**: Singleflight dedup for concurrent provision/refresh calls, 5-min identity cache with membership-verified flag, structured error statuses (no more generic 500s)
- **Frontend**: Auth method selector in REST API tab, WorkOS token flow through URQL auth exchange and stores

## Changes

### Backend (services/cubejs/)
- `workosAuth.js` — JWKS verification via jose, token type detection, WorkOS user profile fetch
- `checkAuth.js` — Dual-path: RS256 → WorkOS JWKS verify + provision, HS256 → existing jwt.verify
- `checkSqlAuth.js` — JWT-as-password detection with fail-closed semantics
- `dataSourceHelpers.js` — Identity cache, provisioning chain, team membership reconciliation, singleflight dedup
- `defineUserScope.js` + `graphql.js` — Structured `.status` on all thrown errors (FR-018)
- `index.js` — Global error handler respects `err.status`

### Backend (services/actions/)
- `token.js` — Returns `workosAccessToken` from session, refresh stampede prevention, clears stale tokens on failure
- `provision.js` — Cross-reference comment for team derivation sync

### Frontend (client-v2, separate PR)
- `AuthTokensStore` — Extended with `workosAccessToken`
- `URQLClient` + `useUserData` — Pass `workosAccessToken` through `setAuthData`
- `RestAPI` — Auth method radio toggle (WorkOS/Hasura)
- `SmartGeneration` — Prefer WorkOS token for SSE

### Config
- `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_ISSUER` added to dev/stage/test compose files
- `jose ^6.2.1` added to cubejs dependencies

## Test plan
- [x] WorkOS JWT → CubeJS REST API → 200 with query data (verified live)
- [x] Hasura JWT → CubeJS REST API → 200 (backward compat verified)
- [x] Token type detection: RS256 → workos path, HS256 → hasura path
- [x] JIT provisioning creates user/account/team/membership/role
- [x] Existing account reconciliation adds missing team membership
- [x] Frontend auth method toggle switches bearer token correctly
- [ ] SQL API with WorkOS JWT-as-password
- [ ] StepCI automated tests (T004a, T016, T016a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)