### PR TITLE
009: Optimized JSON-Stat builder + limit override for exports

### DIFF
--- a/services/cubejs/src/routes/index.js
+++ b/services/cubejs/src/routes/index.js
@@ -23,6 +23,59 @@ import version from "./version.js";
 
 const router = express.Router();
 
+function addUniqueColumns(target, names) {
+  if (!Array.isArray(names)) return;
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    if (typeof name === "string" && !target.includes(name)) {
+      target.push(name);
+    }
+  }
+}
+
+function normalizeLoadQuery(rawQuery) {
+  if (!rawQuery) return null;
+  if (typeof rawQuery === "string") {
+    try {
+      return JSON.parse(rawQuery);
+    } catch {
+      return null;
+    }
+  }
+  return rawQuery;
+}
+
+function deriveJSONStatColumnsFromLoad(req, annotation, data) {
+  if (data.length > 0) {
+    return Object.keys(data[0]);
+  }
+
+  const columns = [];
+  const query = req.method === "POST"
+    ? normalizeLoadQuery(req.body?.query)
+    : normalizeLoadQuery(req.query?.query);
+  const primaryQuery = Array.isArray(query) ? query[0] : query;
+
+  if (primaryQuery) {
+    addUniqueColumns(columns, primaryQuery.dimensions);
+    addUniqueColumns(
+      columns,
+      Array.isArray(primaryQuery.timeDimensions)
+        ? primaryQuery.timeDimensions.map((item) => typeof item === "string" ? item : item?.dimension)
+        : []
+    );
+    addUniqueColumns(columns, primaryQuery.measures);
+  }
+
+  if (columns.length === 0) {
+    addUniqueColumns(columns, Object.keys(annotation.dimensions || {}));
+    addUniqueColumns(columns, Object.keys(annotation.timeDimensions || {}));
+    addUniqueColumns(columns, Object.keys(annotation.measures || {}));
+  }
+
+  return columns;
+}
+
 export default ({ basePath, cubejs }) => {
   // Format-aware middleware for the load endpoint.
   // When format=csv or format=jsonstat, Cube.js processes the query as normal
@@ -114,7 +167,7 @@ export default ({ basePath, cubejs }) => {
         }
 
         if (format === "jsonstat") {
-          const columns = data.length > 0 ? Object.keys(data[0]) : [];
+          const columns = deriveJSONStatColumnsFromLoad(req, annotation, data);
           const measures = Object.keys(annotation.measures || {});
           const timeDimensions = Object.keys(annotation.timeDimensions || {});
           const dataset = buildJSONStat(data, columns, { measures, timeDimensions });

--- a/services/cubejs/src/routes/runSql.js
+++ b/services/cubejs/src/routes/runSql.js
@@ -47,6 +47,29 @@ function normalizeClickHouseCSVLine(line) {
   return normalized + "\r\n";
 }
 
+function addUniqueColumns(target, names) {
+  if (!Array.isArray(names)) return;
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    if (typeof name === "string" && !target.includes(name)) {
+      target.push(name);
+    }
+  }
+}
+
+function deriveJSONStatColumnsFromRunSql(body, rows) {
+  if (rows.length > 0) {
+    return Object.keys(rows[0]);
+  }
+
+  const columns = [];
+  addUniqueColumns(columns, body?.columns);
+  addUniqueColumns(columns, body?.dimensions);
+  addUniqueColumns(columns, body?.timeDimensions);
+  addUniqueColumns(columns, body?.measures);
+  return columns.length > 0 ? columns : null;
+}
+
 /**
  * Asynchronous function to run a SQL query using Cube.js.
  * Blocks access for teams with active query rewrite rules (prevents queryRewrite bypass).
@@ -104,7 +127,7 @@ export default async (req, res, cubejs) => {
     if (format === "jsonstat") {
       const { measures, timeDimensions } = req.body;
       const rows = await driver.query(sql);
-      const columns = rows.length > 0 ? Object.keys(rows[0]) : null;
+      const columns = deriveJSONStatColumnsFromRunSql(req.body, rows);
       const dataset = buildJSONStat(rows, columns, { measures, timeDimensions });
 
       if (dataset.error) {

--- a/services/cubejs/src/utils/jsonstatBuilder.js
+++ b/services/cubejs/src/utils/jsonstatBuilder.js
@@ -1,351 +1,250 @@
+const TIME_COLUMN_RE = /^(year|date|month|quarter|period|time|day|week)/i;
+const DEFAULT_VALUE_FORMAT = "auto";
+const DEFAULT_SPARSE_THRESHOLD = 0.5;
+const DEFAULT_MIN_SPARSE_CELLS = 256;
+const DEFAULT_MAX_DENSE_CELLS = 1_000_000;
+const DEFAULT_DUPLICATE_POLICY = "aggregate";
+const DEFAULT_CATEGORY_INDEX_FORMAT = "object";
+
 /**
  * Builds a JSON-Stat 2.0 dataset object from tabular query results.
  *
- * Optimized single-pass encoder: classifies columns, extracts categories,
- * and merges duplicate tuples in one iteration over rows. Uses stride-based
- * offset computation for O(n*m) value placement instead of O(product(sizes)).
+ * Optimizations:
+ * - typed category identity to avoid value-collision bugs
+ * - explicit-measure fast path to skip heuristic-only work
+ * - adaptive dense/sparse value encoding
+ * - dense-cell guard for pathological cubes
+ * - compact metadata options for category index/labels
  *
  * @param {Array<Object>} rows - Array of row objects
  * @param {string[]} columns - Column names (may contain duplicates)
- * @param {Object} [options] - Classification hints
+ * @param {Object} [options] - Classification and encoding hints
  * @param {string[]} [options.measures] - Columns to treat as measures
  * @param {string[]} [options.timeDimensions] - Columns to treat as time dimensions
+ * @param {string[]} [options.dimensions] - Optional explicit dimension order
+ * @param {"auto"|"dense"|"sparse"} [options.valueFormat]
+ * @param {number} [options.sparseThreshold]
+ * @param {number} [options.minSparseCells]
+ * @param {number} [options.maxDenseCells]
+ * @param {"aggregate"|"last"|"error"} [options.duplicatePolicy]
+ * @param {"object"|"array"} [options.categoryIndexFormat]
+ * @param {boolean} [options.includeCategoryLabels]
+ * @param {string} [options.metricDimensionId]
  * @returns {Object} JSON-Stat 2.0 dataset or error object
  */
-
 export function buildJSONStat(rows, columns, options) {
-  const cols = columns ?? [];
   const opts = options ?? {};
+  const cols = columns ?? [];
+  const workSourceRows = rows ?? [];
 
-  // --- Edge: no rows AND no columns ---
-  if ((!rows || rows.length === 0) && cols.length === 0) {
+  if (workSourceRows.length === 0 && cols.length === 0) {
     return { error: "Cannot produce JSON-Stat from empty result with no columns.", status: 400 };
   }
 
-  // --- Disambiguate duplicate column names ---
-  const dedupedCols = new Array(cols.length);
-  let needsRemap = false;
-  {
-    const seen = Object.create(null);
-    for (let i = 0; i < cols.length; i++) {
-      const col = cols[i];
-      if (seen[col] == null) {
-        seen[col] = 1;
-        dedupedCols[i] = col;
-      } else {
-        seen[col]++;
-        dedupedCols[i] = `${col}_${seen[col]}`;
-        needsRemap = true;
-      }
-    }
+  const valueFormat = opts.valueFormat ?? DEFAULT_VALUE_FORMAT;
+  const sparseThreshold = normalizeFiniteNumber(opts.sparseThreshold, DEFAULT_SPARSE_THRESHOLD);
+  const minSparseCells = Math.max(0, normalizeFiniteInteger(opts.minSparseCells, DEFAULT_MIN_SPARSE_CELLS));
+  const maxDenseCells = Math.max(1, normalizeFiniteInteger(opts.maxDenseCells, DEFAULT_MAX_DENSE_CELLS));
+  const duplicatePolicy = opts.duplicatePolicy ?? DEFAULT_DUPLICATE_POLICY;
+  const categoryIndexFormat = opts.categoryIndexFormat ?? DEFAULT_CATEGORY_INDEX_FORMAT;
+  const includeCategoryLabels = opts.includeCategoryLabels !== false;
+
+  const {
+    dedupedCols,
+    needsRemap,
+    originalToDeduped,
+  } = dedupeColumns(cols);
+
+  let workRows = workSourceRows;
+  if (needsRemap && workSourceRows.length > 0) {
+    workRows = remapRows(workSourceRows, cols, dedupedCols);
   }
 
-  // Remap row data only when duplicate columns exist
-  let workRows = rows;
-  if (needsRemap && rows && rows.length > 0) {
-    workRows = new Array(rows.length);
-    for (let r = 0; r < rows.length; r++) {
-      const row = rows[r];
-      const out = Object.create(null);
-      for (let i = 0; i < cols.length; i++) {
-        const origKey = cols[i];
-        const newKey = dedupedCols[i];
-        if (newKey === origKey) {
-          out[newKey] = row[origKey];
-        } else {
-          out[newKey] = row[newKey] !== undefined ? row[newKey] : row[origKey];
-        }
-      }
-      workRows[r] = out;
-    }
-  }
-
-  const numRows = workRows ? workRows.length : 0;
+  const numRows = workRows.length;
   const numCols = dedupedCols.length;
-
-  // --- Resolve explicit classification hints (map original names to deduped) ---
-  let explicitMeasures = null;
-  let explicitTime = null;
-  if (opts.measures) {
-    const colToDeduped = Object.create(null);
-    for (let i = 0; i < cols.length; i++) {
-      if (!(cols[i] in colToDeduped)) colToDeduped[cols[i]] = dedupedCols[i];
-    }
-    explicitMeasures = new Set();
-    for (const name of opts.measures) {
-      explicitMeasures.add(colToDeduped[name] ?? name);
-    }
-  }
-  if (opts.timeDimensions) {
-    const colToDeduped = Object.create(null);
-    for (let i = 0; i < cols.length; i++) {
-      if (!(cols[i] in colToDeduped)) colToDeduped[cols[i]] = dedupedCols[i];
-    }
-    explicitTime = new Set();
-    for (const name of opts.timeDimensions) {
-      explicitTime.add(colToDeduped[name] ?? name);
-    }
-  }
-
-  // --- Single pass: detect binary, track numeric, build category maps, merge tuples ---
   const warnings = [];
-  const isBinary = new Uint8Array(numCols);   // 1 = binary detected
-  const isNumeric = new Uint8Array(numCols);   // 1 = all-numeric so far
-  const hasSample = new Uint8Array(numCols);   // 1 = at least one non-null value
-  // Per-column category maps: Map<string, int> (only for dimension candidates)
-  // We'll build these for ALL columns initially, then discard for measures.
-  const catMaps = new Array(numCols);
-  const catOrders = new Array(numCols); // ordered category arrays
-  for (let i = 0; i < numCols; i++) {
-    isNumeric[i] = 1; // assume numeric until proven otherwise
-    catMaps[i] = new Map();
-    catOrders[i] = [];
-  }
 
-  // For duplicate tuple merging, we use stride-based integer offsets as dedup keys.
-  // But we don't know dimension columns yet during the scan (for heuristic mode).
-  // So we collect rows and defer merging until after classification.
-  // However, we CAN do the binary/numeric/category detection in one pass.
+  const explicitMeasures = resolveExplicitNames(opts.measures, originalToDeduped);
+  const explicitTime = resolveExplicitNames(opts.timeDimensions, originalToDeduped);
 
-  if (numRows > 0) {
-    for (let r = 0; r < numRows; r++) {
-      const row = workRows[r];
-      for (let c = 0; c < numCols; c++) {
-        if (isBinary[c]) continue; // already known binary, skip
-        const key = dedupedCols[c];
-        const v = row[key];
+  let activeIndices;
+  let measureSet;
+  let timeDimSet;
+  let dimCols;
+  let measureCols;
+  let dimColIndices;
+  let binaryNames;
+  let categoryMapsByColumn = null;
+  let categoryValuesByColumn = null;
 
-        // Binary detection
-        if (Buffer.isBuffer(v)) {
-          isBinary[c] = 1;
-          isNumeric[c] = 0;
-          continue;
-        }
+  if (explicitMeasures) {
+    const scan = scanRowsWithExplicitMeasures(workRows, dedupedCols, explicitMeasures);
+    activeIndices = scan.activeIndices;
+    binaryNames = scan.binaryNames;
+    categoryMapsByColumn = scan.categoryMapsByColumn;
+    categoryValuesByColumn = scan.categoryValuesByColumn;
+    measureSet = filterToActive(explicitMeasures, activeIndices, dedupedCols);
+    timeDimSet = explicitTime
+      ? filterToActive(explicitTime, activeIndices, dedupedCols)
+      : inferTimeDimensions(activeIndices, dedupedCols, measureSet);
 
-        // Numeric tracking
-        if (v != null) {
-          hasSample[c] = 1;
-          if (isNumeric[c] && typeof v !== "number") {
-            isNumeric[c] = 0;
-          }
-        }
-
-        // Category tracking (stringified value)
-        const sv = String(v ?? "");
-        if (!catMaps[c].has(sv)) {
-          catMaps[c].set(sv, catOrders[c].length);
-          catOrders[c].push(sv);
-        }
-      }
+    if (!explicitTime) {
+      warnings.push(
+        "Column classification was inferred heuristically for time dimensions. Supply options.timeDimensions for exact control."
+      );
     }
+
+    ({
+      dimCols,
+      measureCols,
+      dimColIndices,
+    } = splitColumns(activeIndices, dedupedCols, measureSet));
+  } else {
+    const scan = scanRowsForTypeInference(workRows, dedupedCols);
+    activeIndices = scan.activeIndices;
+    binaryNames = scan.binaryNames;
+    measureSet = inferMeasureColumns(activeIndices, dedupedCols, scan.isNumeric, scan.hasSample);
+    timeDimSet = explicitTime
+      ? filterToActive(explicitTime, activeIndices, dedupedCols)
+      : inferTimeDimensions(activeIndices, dedupedCols, measureSet);
+
+    warnings.push(
+      "Column classification was inferred heuristically. Supply options.measures and options.timeDimensions for exact control."
+    );
+
+    ({
+      dimCols,
+      measureCols,
+      dimColIndices,
+    } = splitColumns(activeIndices, dedupedCols, measureSet));
   }
 
-  // --- Build active columns (omit binary) ---
-  const activeIndices = [];
-  const binaryNames = [];
-  for (let c = 0; c < numCols; c++) {
-    if (isBinary[c]) {
-      binaryNames.push(dedupedCols[c]);
-    } else {
-      activeIndices.push(c);
-    }
-  }
   if (binaryNames.length > 0) {
     warnings.push(`Binary columns omitted from JSON-Stat output: ${binaryNames.join(", ")}`);
   }
 
-  const activeCols = activeIndices.map((i) => dedupedCols[i]);
-  const activeSet = new Set(activeCols);
-
-  // --- Classify columns ---
-  let measureSet;
-  let timeDimSet;
-
-  if (explicitMeasures) {
-    measureSet = new Set();
-    for (const m of explicitMeasures) {
-      if (activeSet.has(m)) measureSet.add(m);
-    }
-  }
-  if (explicitTime) {
-    timeDimSet = new Set();
-    for (const t of explicitTime) {
-      if (activeSet.has(t)) timeDimSet.add(t);
-    }
+  const dimOrderOverride = resolveExplicitNames(opts.dimensions, originalToDeduped);
+  if (dimOrderOverride && dimCols.length > 0) {
+    ({ dimCols, dimColIndices } = applyDimensionOrderOverride(dimCols, dimColIndices, dimOrderOverride));
   }
 
-  if (!measureSet || !timeDimSet) {
-    if (!measureSet) {
-      measureSet = new Set();
-      for (const ci of activeIndices) {
-        if (isNumeric[ci] && hasSample[ci]) {
-          measureSet.add(dedupedCols[ci]);
-        }
-      }
-    }
-    if (!timeDimSet) {
-      const timePattern = /^(year|date|month|quarter|period|time|day|week)/i;
-      timeDimSet = new Set();
-      for (const col of activeCols) {
-        if (!measureSet.has(col) && timePattern.test(col)) {
-          timeDimSet.add(col);
-        }
-      }
-    }
-    warnings.push(
-      "Column classification was inferred heuristically. Supply options.measures and options.timeDimensions for exact control."
+  const metricDimensionId = measureCols.length > 0
+    ? makeUniqueMetricDimensionId(dimCols, opts.metricDimensionId)
+    : null;
+
+  if (numRows === 0) {
+    return buildEmptyDataset(
+      dimCols,
+      measureCols,
+      timeDimSet,
+      warnings,
+      metricDimensionId,
+      categoryIndexFormat,
+      includeCategoryLabels
     );
   }
 
-  const dimCols = [];
-  const measureCols = [];
-  // Also track column indices for dims (for fast category lookup)
-  const dimColIndices = [];
-  for (const ci of activeIndices) {
-    const col = dedupedCols[ci];
-    if (measureSet.has(col)) {
-      measureCols.push(col);
-    } else {
-      dimCols.push(col);
-      dimColIndices.push(ci);
-    }
+  let dimensionCategories;
+  if (categoryMapsByColumn) {
+    dimensionCategories = extractCollectedCategories(dimColIndices, categoryMapsByColumn, categoryValuesByColumn);
+  } else {
+    dimensionCategories = collectDimensionCategories(workRows, dimCols);
   }
 
-  // --- Edge: no rows but columns exist ---
-  if (numRows === 0) {
-    return buildEmptyDataset(dimCols, measureCols, timeDimSet, warnings);
-  }
-
-  // --- Build dimension category index maps from pre-built catMaps ---
   const numDims = dimCols.length;
   const numMeasures = measureCols.length;
-  const dimCatMap = new Array(numDims);   // Map<string, int> per dimension
-  const dimCatList = new Array(numDims);  // string[] per dimension
+  const effectiveMeasureCount = numMeasures > 0 ? numMeasures : 1;
   const dimSizes = new Array(numDims);
+  const strides = new Array(numDims);
+  let tupleCount = 1;
 
   for (let d = 0; d < numDims; d++) {
-    const ci = dimColIndices[d];
-    dimCatMap[d] = catMaps[ci];
-    dimCatList[d] = catOrders[ci];
-    dimSizes[d] = catOrders[ci].length;
+    dimSizes[d] = dimensionCategories.values[d].length;
+    tupleCount *= dimSizes[d];
   }
 
-  // --- Compute strides for flat offset (row-major) ---
-  // id order: dim0, dim1, ..., dimN, metric
-  // size order: dimSize0, dimSize1, ..., dimSizeN, numMeasures (if > 0)
-  const effectiveMeasureCount = numMeasures > 0 ? numMeasures : 1;
-  // stride[d] = product of sizes of all dimensions after d, times effectiveMeasureCount
-  const strides = new Array(numDims);
-  {
-    let s = effectiveMeasureCount;
-    for (let d = numDims - 1; d >= 0; d--) {
-      strides[d] = s;
-      s *= dimSizes[d];
-    }
+  let stride = effectiveMeasureCount;
+  for (let d = numDims - 1; d >= 0; d--) {
+    strides[d] = stride;
+    stride *= dimSizes[d];
   }
 
-  const totalObs = dimSizes.length > 0
-    ? dimSizes.reduce((a, b) => a * b, 1) * effectiveMeasureCount
-    : effectiveMeasureCount;
-
-  // --- Merge duplicate tuples using stride-based integer offset as key ---
-  // offset (without measure index) = sum(catIndex[d] * strides[d])
-  // We store merged measure values keyed by this base offset.
-  // Use a Map<int, Array> where the array holds measure values.
-  const mergedMap = new Map(); // baseOffset -> measureValues[]
-  let duplicateCount = 0;
-
-  for (let r = 0; r < numRows; r++) {
-    const row = workRows[r];
-
-    // Compute base offset from dimension category indices
-    let baseOffset = 0;
-    for (let d = 0; d < numDims; d++) {
-      const sv = String(row[dimCols[d]] ?? "");
-      baseOffset += dimCatMap[d].get(sv) * strides[d];
-    }
-
-    if (mergedMap.has(baseOffset)) {
-      duplicateCount++;
-      const existing = mergedMap.get(baseOffset);
-      for (let m = 0; m < numMeasures; m++) {
-        const newVal = row[measureCols[m]];
-        const oldVal = existing[m];
-        if (typeof oldVal === "number" && typeof newVal === "number") {
-          existing[m] = oldVal + newVal;
-        } else if (newVal !== undefined) {
-          existing[m] = newVal;
-        }
-      }
-    } else {
-      const vals = new Array(numMeasures);
-      for (let m = 0; m < numMeasures; m++) {
-        const v = row[measureCols[m]];
-        vals[m] = v !== undefined ? v : null;
-      }
-      mergedMap.set(baseOffset, vals);
-    }
+  const totalCells = tupleCount * effectiveMeasureCount;
+  const mergeResult = mergeRowsToOffsets(
+    workRows,
+    dimCols,
+    measureCols,
+    dimensionCategories.maps,
+    strides,
+    duplicatePolicy
+  );
+  if (mergeResult.error) {
+    return mergeResult.error;
+  }
+  if (mergeResult.duplicateCount > 0) {
+    warnings.push(duplicatePolicyWarning(duplicatePolicy, mergeResult.duplicateCount));
   }
 
-  if (duplicateCount > 0) {
-    warnings.push(
-      `Duplicate dimension tuples detected (${duplicateCount}). Numeric measures were summed; non-numeric used last value.`
-    );
+  const populatedCellCount = numMeasures > 0
+    ? mergeResult.offsetMap.size * numMeasures
+    : mergeResult.offsetMap.size;
+  const density = totalCells > 0 ? populatedCellCount / totalCells : 0;
+  const sparseDecision = resolveValueEncoding(
+    valueFormat,
+    totalCells,
+    density,
+    sparseThreshold,
+    minSparseCells,
+    maxDenseCells
+  );
+  if (sparseDecision.error) {
+    return sparseDecision.error;
+  }
+  if (sparseDecision.warning) {
+    warnings.push(sparseDecision.warning);
   }
 
-  // --- Build value array via sparse placement ---
-  const value = new Array(totalObs).fill(null);
+  const value = sparseDecision.useSparse
+    ? buildSparseValueObject(mergeResult.offsetMap, numMeasures)
+    : buildDenseValueArray(totalCells, mergeResult.offsetMap, numMeasures);
 
-  for (const [baseOffset, measureVals] of mergedMap) {
-    if (numMeasures > 0) {
-      for (let m = 0; m < numMeasures; m++) {
-        value[baseOffset + m] = measureVals[m] ?? null;
-      }
-    }
-    // If no measures, the single observation slot at baseOffset stays null
-    // unless we want to place something — but with 0 measures there's nothing to place.
-    // The slot is already null from fill.
-  }
-
-  // --- Build JSON-Stat 2.0 dataset ---
   const id = new Array(numDims + (numMeasures > 0 ? 1 : 0));
   const size = new Array(id.length);
   const dimension = Object.create(null);
+  const role = Object.create(null);
   const roleTime = [];
-  const roleMetric = [];
 
   for (let d = 0; d < numDims; d++) {
-    const col = dimCols[d];
-    id[d] = col;
+    const dimId = dimCols[d];
+    id[d] = dimId;
     size[d] = dimSizes[d];
-    const idx = Object.create(null);
-    const lbl = Object.create(null);
-    const cats = dimCatList[d];
-    for (let i = 0; i < cats.length; i++) {
-      idx[cats[i]] = i;
-      lbl[cats[i]] = cats[i];
+    dimension[dimId] = {
+      label: dimId,
+      category: buildCategoryMetadata(
+        dimensionCategories.values[d],
+        categoryIndexFormat,
+        includeCategoryLabels
+      ),
+    };
+    if (timeDimSet.has(dimId)) {
+      roleTime.push(dimId);
     }
-    dimension[col] = { label: col, category: { index: idx, label: lbl } };
-    if (timeDimSet.has(col)) roleTime.push(col);
   }
 
   if (numMeasures > 0) {
     const pos = numDims;
-    id[pos] = "metric";
+    id[pos] = metricDimensionId;
     size[pos] = numMeasures;
-    const idx = Object.create(null);
-    const lbl = Object.create(null);
-    for (let i = 0; i < numMeasures; i++) {
-      idx[measureCols[i]] = i;
-      lbl[measureCols[i]] = measureCols[i];
-    }
-    dimension["metric"] = { label: "metric", category: { index: idx, label: lbl } };
-    roleMetric.push("metric");
+    dimension[metricDimensionId] = {
+      label: metricDimensionId,
+      category: buildCategoryMetadata(measureCols, categoryIndexFormat, includeCategoryLabels),
+    };
+    role.metric = [metricDimensionId];
   }
 
-  const role = {};
-  if (roleTime.length > 0) role.time = roleTime;
-  if (roleMetric.length > 0) role.metric = roleMetric;
+  if (roleTime.length > 0) {
+    role.time = roleTime;
+  }
 
   const dataset = {
     version: "2.0",
@@ -356,53 +255,591 @@ export function buildJSONStat(rows, columns, options) {
     value,
   };
 
-  if (Object.keys(role).length > 0) dataset.role = role;
-  if (warnings.length > 0) dataset.extension = { warning: warnings.join(" ") };
+  if (Object.keys(role).length > 0) {
+    dataset.role = role;
+  }
+  if (warnings.length > 0) {
+    dataset.extension = { warning: warnings.join(" ") };
+  }
 
   return dataset;
 }
 
-/**
- * Build a valid but empty JSON-Stat dataset (no rows, but columns known).
- */
-function buildEmptyDataset(dimCols, measureCols, timeDimSet, warnings) {
+function dedupeColumns(cols) {
+  const dedupedCols = new Array(cols.length);
+  const originalToDeduped = Object.create(null);
+  let needsRemap = false;
+  const seen = Object.create(null);
+
+  for (let i = 0; i < cols.length; i++) {
+    const col = cols[i];
+    const count = (seen[col] ?? 0) + 1;
+    seen[col] = count;
+    const deduped = count === 1 ? col : `${col}_${count}`;
+    dedupedCols[i] = deduped;
+    if (count > 1) needsRemap = true;
+    if (!originalToDeduped[col]) {
+      originalToDeduped[col] = [];
+    }
+    originalToDeduped[col].push(deduped);
+  }
+
+  return { dedupedCols, needsRemap, originalToDeduped };
+}
+
+function remapRows(rows, cols, dedupedCols) {
+  const outRows = new Array(rows.length);
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    const out = Object.create(null);
+    for (let i = 0; i < cols.length; i++) {
+      const originalKey = cols[i];
+      const dedupedKey = dedupedCols[i];
+      out[dedupedKey] = dedupedKey === originalKey
+        ? row[originalKey]
+        : row[dedupedKey] !== undefined ? row[dedupedKey] : row[originalKey];
+    }
+    outRows[r] = out;
+  }
+  return outRows;
+}
+
+function resolveExplicitNames(names, originalToDeduped) {
+  if (!Array.isArray(names) || names.length === 0) return null;
+
+  const resolved = new Set();
+  for (const name of names) {
+    const mapped = originalToDeduped[name];
+    if (mapped && mapped.length > 0) {
+      for (const deduped of mapped) {
+        resolved.add(deduped);
+      }
+    } else {
+      resolved.add(name);
+    }
+  }
+  return resolved;
+}
+
+function scanRowsWithExplicitMeasures(rows, dedupedCols, explicitMeasures) {
+  const numCols = dedupedCols.length;
+  const categoryMapsByColumn = new Array(numCols);
+  const categoryValuesByColumn = new Array(numCols);
+  const isBinary = new Uint8Array(numCols);
+  const binaryNames = [];
+  const activeIndices = [];
+
+  for (let c = 0; c < numCols; c++) {
+    if (!explicitMeasures.has(dedupedCols[c])) {
+      categoryMapsByColumn[c] = new Map();
+      categoryValuesByColumn[c] = [];
+    }
+  }
+
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    for (let c = 0; c < numCols; c++) {
+      if (isBinary[c]) continue;
+      const value = row[dedupedCols[c]];
+      if (Buffer.isBuffer(value)) {
+        isBinary[c] = 1;
+        continue;
+      }
+      if (categoryMapsByColumn[c]) {
+        addCategoryValue(categoryMapsByColumn[c], categoryValuesByColumn[c], value);
+      }
+    }
+  }
+
+  for (let c = 0; c < numCols; c++) {
+    if (isBinary[c]) {
+      binaryNames.push(dedupedCols[c]);
+    } else {
+      activeIndices.push(c);
+    }
+  }
+
+  return {
+    activeIndices,
+    binaryNames,
+    categoryMapsByColumn,
+    categoryValuesByColumn,
+  };
+}
+
+function scanRowsForTypeInference(rows, dedupedCols) {
+  const numCols = dedupedCols.length;
+  const isBinary = new Uint8Array(numCols);
+  const isNumeric = new Uint8Array(numCols);
+  const hasSample = new Uint8Array(numCols);
+  const binaryNames = [];
+  const activeIndices = [];
+
+  for (let c = 0; c < numCols; c++) {
+    isNumeric[c] = 1;
+  }
+
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    for (let c = 0; c < numCols; c++) {
+      if (isBinary[c]) continue;
+      const value = row[dedupedCols[c]];
+      if (Buffer.isBuffer(value)) {
+        isBinary[c] = 1;
+        isNumeric[c] = 0;
+        continue;
+      }
+      if (value != null) {
+        hasSample[c] = 1;
+        if (isNumeric[c] && typeof value !== "number") {
+          isNumeric[c] = 0;
+        }
+      }
+    }
+  }
+
+  for (let c = 0; c < numCols; c++) {
+    if (isBinary[c]) {
+      binaryNames.push(dedupedCols[c]);
+    } else {
+      activeIndices.push(c);
+    }
+  }
+
+  return {
+    activeIndices,
+    binaryNames,
+    isNumeric,
+    hasSample,
+  };
+}
+
+function filterToActive(values, activeIndices, dedupedCols) {
+  const activeSet = new Set();
+  for (let i = 0; i < activeIndices.length; i++) {
+    activeSet.add(dedupedCols[activeIndices[i]]);
+  }
+
+  const filtered = new Set();
+  for (const value of values) {
+    if (activeSet.has(value)) {
+      filtered.add(value);
+    }
+  }
+  return filtered;
+}
+
+function inferMeasureColumns(activeIndices, dedupedCols, isNumeric, hasSample) {
+  const measureSet = new Set();
+  for (let i = 0; i < activeIndices.length; i++) {
+    const colIndex = activeIndices[i];
+    if (isNumeric[colIndex] && hasSample[colIndex]) {
+      measureSet.add(dedupedCols[colIndex]);
+    }
+  }
+  return measureSet;
+}
+
+function inferTimeDimensions(activeIndices, dedupedCols, measureSet) {
+  const timeDimSet = new Set();
+  for (let i = 0; i < activeIndices.length; i++) {
+    const name = dedupedCols[activeIndices[i]];
+    if (!measureSet.has(name) && TIME_COLUMN_RE.test(name)) {
+      timeDimSet.add(name);
+    }
+  }
+  return timeDimSet;
+}
+
+function splitColumns(activeIndices, dedupedCols, measureSet) {
+  const dimCols = [];
+  const measureCols = [];
+  const dimColIndices = [];
+
+  for (let i = 0; i < activeIndices.length; i++) {
+    const colIndex = activeIndices[i];
+    const colName = dedupedCols[colIndex];
+    if (measureSet.has(colName)) {
+      measureCols.push(colName);
+    } else {
+      dimCols.push(colName);
+      dimColIndices.push(colIndex);
+    }
+  }
+
+  return { dimCols, measureCols, dimColIndices };
+}
+
+function applyDimensionOrderOverride(dimCols, dimColIndices, requestedDims) {
+  const requested = Array.from(requestedDims);
+  const currentIndexByName = Object.create(null);
+  for (let i = 0; i < dimCols.length; i++) {
+    currentIndexByName[dimCols[i]] = i;
+  }
+
+  const orderedNames = [];
+  const orderedIndices = [];
+  const seen = new Set();
+
+  for (let i = 0; i < requested.length; i++) {
+    const name = requested[i];
+    const existingIndex = currentIndexByName[name];
+    if (existingIndex == null || seen.has(name)) continue;
+    orderedNames.push(dimCols[existingIndex]);
+    orderedIndices.push(dimColIndices[existingIndex]);
+    seen.add(name);
+  }
+
+  for (let i = 0; i < dimCols.length; i++) {
+    const name = dimCols[i];
+    if (seen.has(name)) continue;
+    orderedNames.push(name);
+    orderedIndices.push(dimColIndices[i]);
+  }
+
+  return {
+    dimCols: orderedNames,
+    dimColIndices: orderedIndices,
+  };
+}
+
+function collectDimensionCategories(rows, dimCols) {
+  const maps = new Array(dimCols.length);
+  const values = new Array(dimCols.length);
+
+  for (let d = 0; d < dimCols.length; d++) {
+    maps[d] = new Map();
+    values[d] = [];
+  }
+
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    for (let d = 0; d < dimCols.length; d++) {
+      addCategoryValue(maps[d], values[d], row[dimCols[d]]);
+    }
+  }
+
+  return { maps, values };
+}
+
+function extractCollectedCategories(dimColIndices, categoryMapsByColumn, categoryValuesByColumn) {
+  const maps = new Array(dimColIndices.length);
+  const values = new Array(dimColIndices.length);
+
+  for (let d = 0; d < dimColIndices.length; d++) {
+    const colIndex = dimColIndices[d];
+    maps[d] = categoryMapsByColumn[colIndex] ?? new Map();
+    values[d] = categoryValuesByColumn[colIndex] ?? [];
+  }
+
+  return { maps, values };
+}
+
+function addCategoryValue(categoryMap, categoryValues, rawValue) {
+  const identity = encodeCategoryIdentity(rawValue);
+  if (categoryMap.has(identity)) return;
+  categoryMap.set(identity, categoryValues.length);
+  categoryValues.push(rawValue);
+}
+
+function encodeCategoryIdentity(value) {
+  if (value === null) return "null:";
+  if (value === undefined) return "undefined:";
+
+  const type = typeof value;
+  if (type === "string") return `string:${value}`;
+  if (type === "number") {
+    if (Number.isNaN(value)) return "number:NaN";
+    if (Object.is(value, -0)) return "number:-0";
+    return `number:${value}`;
+  }
+  if (type === "boolean") return `boolean:${value}`;
+  if (type === "bigint") return `bigint:${value.toString()}`;
+  if (type === "symbol") return `symbol:${String(value.description ?? "")}`;
+  if (type === "function") return `function:${value.name || "<anonymous>"}`;
+  if (value instanceof Date) return `date:${value.toISOString()}`;
+  try {
+    return `object:${JSON.stringify(value)}`;
+  } catch {
+    return `object:${String(value)}`;
+  }
+}
+
+function mergeRowsToOffsets(rows, dimCols, measureCols, dimCatMaps, strides, duplicatePolicy) {
+  const offsetMap = new Map();
+  let duplicateCount = 0;
+
+  for (let r = 0; r < rows.length; r++) {
+    const row = rows[r];
+    let baseOffset = 0;
+
+    for (let d = 0; d < dimCols.length; d++) {
+      const categoryIndex = dimCatMaps[d].get(encodeCategoryIdentity(row[dimCols[d]]));
+      baseOffset += categoryIndex * strides[d];
+    }
+
+    if (offsetMap.has(baseOffset)) {
+      duplicateCount++;
+      if (duplicatePolicy === "error") {
+        return {
+          error: {
+            error: "Duplicate dimension tuples detected. Supply pre-aggregated rows or set options.duplicatePolicy.",
+            status: 400,
+          },
+        };
+      }
+      const existing = offsetMap.get(baseOffset);
+      if (measureCols.length > 0) {
+        if (duplicatePolicy === "last") {
+          for (let m = 0; m < measureCols.length; m++) {
+            const nextValue = row[measureCols[m]];
+            if (nextValue !== undefined) {
+              existing[m] = nextValue;
+            }
+          }
+        } else {
+          for (let m = 0; m < measureCols.length; m++) {
+            const nextValue = row[measureCols[m]];
+            const currentValue = existing[m];
+            if (typeof currentValue === "number" && typeof nextValue === "number") {
+              existing[m] = currentValue + nextValue;
+            } else if (nextValue !== undefined) {
+              existing[m] = nextValue;
+            }
+          }
+        }
+      }
+      continue;
+    }
+
+    if (measureCols.length > 0) {
+      const values = new Array(measureCols.length);
+      for (let m = 0; m < measureCols.length; m++) {
+        const value = row[measureCols[m]];
+        values[m] = value !== undefined ? value : null;
+      }
+      offsetMap.set(baseOffset, values);
+    } else {
+      offsetMap.set(baseOffset, null);
+    }
+  }
+
+  return { offsetMap, duplicateCount };
+}
+
+function duplicatePolicyWarning(policy, duplicateCount) {
+  if (policy === "last") {
+    return `Duplicate dimension tuples detected (${duplicateCount}). Last non-undefined values were kept.`;
+  }
+  return `Duplicate dimension tuples detected (${duplicateCount}). Numeric measures were summed; other values used the last non-undefined value.`;
+}
+
+function resolveValueEncoding(
+  valueFormat,
+  totalCells,
+  density,
+  sparseThreshold,
+  minSparseCells,
+  maxDenseCells
+) {
+  if (valueFormat === "sparse") {
+    return { useSparse: true };
+  }
+
+  if (valueFormat === "dense") {
+    if (totalCells > maxDenseCells) {
+      return {
+        error: {
+          error: `Dense JSON-Stat output would require ${totalCells} cells, exceeding the configured maximum of ${maxDenseCells}.`,
+          status: 413,
+        },
+      };
+    }
+    return { useSparse: false };
+  }
+
+  if (totalCells > maxDenseCells && density > sparseThreshold) {
+    return {
+      error: {
+        error: `JSON-Stat output would require ${totalCells} dense cells at ${(density * 100).toFixed(1)}% density, exceeding the configured maximum of ${maxDenseCells}.`,
+        status: 413,
+      },
+    };
+  }
+
+  if (totalCells >= minSparseCells && density <= sparseThreshold) {
+    return {
+      useSparse: true,
+      warning: `Sparse JSON-Stat value encoding was used for a low-density cube (${(density * 100).toFixed(1)}% populated).`,
+    };
+  }
+
+  if (totalCells > maxDenseCells) {
+    return {
+      useSparse: true,
+      warning: `Sparse JSON-Stat value encoding was used because dense output would require ${totalCells} cells.`,
+    };
+  }
+
+  return { useSparse: false };
+}
+
+function buildDenseValueArray(totalCells, offsetMap, numMeasures) {
+  const value = new Array(totalCells).fill(null);
+  for (const [baseOffset, measureValues] of offsetMap) {
+    if (numMeasures > 0) {
+      for (let m = 0; m < numMeasures; m++) {
+        value[baseOffset + m] = measureValues[m] ?? null;
+      }
+    } else {
+      value[baseOffset] = null;
+    }
+  }
+  return value;
+}
+
+function buildSparseValueObject(offsetMap, numMeasures) {
+  const value = Object.create(null);
+  for (const [baseOffset, measureValues] of offsetMap) {
+    if (numMeasures > 0) {
+      for (let m = 0; m < numMeasures; m++) {
+        value[baseOffset + m] = measureValues[m] ?? null;
+      }
+    } else {
+      value[baseOffset] = null;
+    }
+  }
+  return value;
+}
+
+function buildCategoryMetadata(rawValues, categoryIndexFormat, includeCategoryLabels) {
+  const categoryIds = buildUniqueCategoryIds(rawValues);
+  const category = {
+    index: categoryIndexFormat === "array"
+      ? categoryIds.slice()
+      : buildCategoryIndexObject(categoryIds),
+  };
+
+  if (includeCategoryLabels) {
+    const labels = Object.create(null);
+    for (let i = 0; i < categoryIds.length; i++) {
+      labels[categoryIds[i]] = renderCategoryLabel(rawValues[i]);
+    }
+    category.label = labels;
+  }
+
+  return category;
+}
+
+function buildCategoryIndexObject(categoryIds) {
+  const index = Object.create(null);
+  for (let i = 0; i < categoryIds.length; i++) {
+    index[categoryIds[i]] = i;
+  }
+  return index;
+}
+
+function buildUniqueCategoryIds(rawValues) {
+  const categoryIds = new Array(rawValues.length);
+  const usedIds = new Set();
+
+  for (let i = 0; i < rawValues.length; i++) {
+    const value = rawValues[i];
+    let candidate = defaultCategoryId(value);
+    if (usedIds.has(candidate)) {
+      const typeSuffix = categoryTypeLabel(value);
+      const base = candidate === ""
+        ? `[${typeSuffix}]`
+        : `${candidate} [${typeSuffix}]`;
+      let suffix = 1;
+      let uniqueCandidate = base;
+      while (usedIds.has(uniqueCandidate)) {
+        suffix++;
+        uniqueCandidate = `${base} ${suffix}`;
+      }
+      candidate = uniqueCandidate;
+    }
+    usedIds.add(candidate);
+    categoryIds[i] = candidate;
+  }
+
+  return categoryIds;
+}
+
+function defaultCategoryId(value) {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" ? value : String(value);
+}
+
+function renderCategoryLabel(value) {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" ? value : String(value);
+}
+
+function categoryTypeLabel(value) {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (value instanceof Date) return "date";
+  return typeof value;
+}
+
+function makeUniqueMetricDimensionId(dimCols, preferredId) {
+  const baseId = preferredId || "metric";
+  if (!dimCols.includes(baseId)) return baseId;
+
+  let suffix = 2;
+  let candidate = `${baseId}_${suffix}`;
+  while (dimCols.includes(candidate)) {
+    suffix++;
+    candidate = `${baseId}_${suffix}`;
+  }
+  return candidate;
+}
+
+function buildEmptyDataset(
+  dimCols,
+  measureCols,
+  timeDimSet,
+  warnings,
+  metricDimensionId,
+  categoryIndexFormat,
+  includeCategoryLabels
+) {
   const id = [];
   const size = [];
-  const dimension = {};
+  const dimension = Object.create(null);
+  const role = Object.create(null);
   const roleTime = [];
-  const roleMetric = [];
 
-  for (const col of dimCols) {
-    id.push(col);
+  for (let i = 0; i < dimCols.length; i++) {
+    const dimId = dimCols[i];
+    id.push(dimId);
     size.push(0);
-    dimension[col] = {
-      label: col,
-      category: { index: {}, label: {} },
+    dimension[dimId] = {
+      label: dimId,
+      category: buildCategoryMetadata([], categoryIndexFormat, includeCategoryLabels),
     };
-    if (timeDimSet.has(col)) {
-      roleTime.push(col);
+    if (timeDimSet.has(dimId)) {
+      roleTime.push(dimId);
     }
   }
 
   if (measureCols.length > 0) {
-    const metricId = "metric";
-    id.push(metricId);
+    id.push(metricDimensionId);
     size.push(measureCols.length);
-    const idx = {};
-    measureCols.forEach((m, i) => { idx[m] = i; });
-    dimension[metricId] = {
-      label: "metric",
-      category: {
-        index: idx,
-        label: Object.fromEntries(measureCols.map((m) => [m, m])),
-      },
+    dimension[metricDimensionId] = {
+      label: metricDimensionId,
+      category: buildCategoryMetadata(measureCols, categoryIndexFormat, includeCategoryLabels),
     };
-    roleMetric.push(metricId);
+    role.metric = [metricDimensionId];
   }
 
-  const role = {};
-  if (roleTime.length > 0) role.time = roleTime;
-  if (roleMetric.length > 0) role.metric = roleMetric;
+  if (roleTime.length > 0) {
+    role.time = roleTime;
+  }
 
   const dataset = {
     version: "2.0",
@@ -413,10 +850,20 @@ function buildEmptyDataset(dimCols, measureCols, timeDimSet, warnings) {
     value: [],
   };
 
-  if (Object.keys(role).length > 0) dataset.role = role;
+  if (Object.keys(role).length > 0) {
+    dataset.role = role;
+  }
   if (warnings.length > 0) {
     dataset.extension = { warning: warnings.join(" ") };
   }
 
   return dataset;
+}
+
+function normalizeFiniteNumber(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeFiniteInteger(value, fallback) {
+  return Number.isInteger(value) ? value : fallback;
 }

--- a/services/cubejs/test/jsonstatBuilder.test.js
+++ b/services/cubejs/test/jsonstatBuilder.test.js
@@ -22,7 +22,7 @@ describe("buildJSONStat", () => {
       assert.ok(Array.isArray(ds.id), "id must be an array");
       assert.ok(Array.isArray(ds.size), "size must be an array");
       assert.ok(typeof ds.dimension === "object" && ds.dimension !== null);
-      assert.ok(Array.isArray(ds.value), "value must be an array");
+      assert.ok(Array.isArray(ds.value), "dense default should produce an array for small cubes");
     });
   });
 
@@ -35,7 +35,6 @@ describe("buildJSONStat", () => {
       assert.ok(ds.role, "role must exist on dataset");
       assert.ok(Array.isArray(ds.role.metric), "role.metric must be an array");
       assert.ok(Array.isArray(ds.role.time), "role.time must be an array");
-      // They should NOT be on individual dimensions
       for (const dimId of ds.id) {
         const dim = ds.dimension[dimId];
         assert.equal(dim.role, undefined, `dimension ${dimId} must not have a role property`);
@@ -43,36 +42,25 @@ describe("buildJSONStat", () => {
     });
   });
 
-  describe("explicit classification", () => {
-    it("with options.measures and options.timeDimensions, no warning in extension", () => {
+  describe("classification", () => {
+    it("uses explicit classification without heuristic warning", () => {
       const ds = buildJSONStat(rows, columns, {
         measures: ["revenue"],
         timeDimensions: ["year"],
       });
-      if (ds.extension) {
-        assert.equal(ds.extension.warning, undefined, "should not have heuristic warning");
-      }
+      assert.equal(ds.extension?.warning, undefined);
     });
-  });
 
-  describe("heuristic inference", () => {
-    it("without hints, numeric columns become measures, year/date patterns become time, includes warning", () => {
+    it("falls back to heuristics when hints are omitted", () => {
       const ds = buildJSONStat(rows, columns);
-      assert.ok(ds.extension, "extension must exist");
-      assert.ok(
-        typeof ds.extension.warning === "string",
-        "extension.warning must be a string"
-      );
-      // revenue should be a measure (part of metric dimension categories)
-      assert.ok(ds.role.metric, "should have metric role");
-      // year should be a time dimension
-      assert.ok(ds.role.time, "should have time role");
-      assert.ok(ds.role.time.length > 0, "should have at least one time dimension");
+      assert.match(ds.extension.warning, /heuristically/i);
+      assert.deepStrictEqual(ds.role.metric, ["metric"]);
+      assert.deepStrictEqual(ds.role.time, ["year"]);
     });
   });
 
-  describe("multiple measures", () => {
-    it("become categories of a metric-role dimension", () => {
+  describe("placement and measures", () => {
+    it("creates a metric dimension for multiple measures", () => {
       const multiRows = [
         { country: "US", revenue: 100, profit: 30 },
         { country: "UK", revenue: 200, profit: 50 },
@@ -80,18 +68,29 @@ describe("buildJSONStat", () => {
       const ds = buildJSONStat(multiRows, ["country", "revenue", "profit"], {
         measures: ["revenue", "profit"],
       });
-      // Find the metric dimension
       const metricDimId = ds.role.metric[0];
-      assert.ok(metricDimId, "must have a metric dimension");
       const metricDim = ds.dimension[metricDimId];
-      const cats = metricDim.category.index;
-      assert.ok("revenue" in cats, "revenue must be a category");
-      assert.ok("profit" in cats, "profit must be a category");
+      assert.ok("revenue" in metricDim.category.index);
+      assert.ok("profit" in metricDim.category.index);
     });
-  });
 
-  describe("null handling", () => {
-    it("null values in rows appear as null in value array", () => {
+    it("uses row-major placement with metric last", () => {
+      const sparseRows = [
+        { country: "US", year: "2025", revenue: 1 },
+        { country: "US", year: "2026", revenue: 2 },
+        { country: "UK", year: "2025", revenue: 3 },
+      ];
+      const ds = buildJSONStat(sparseRows, columns, {
+        measures: ["revenue"],
+        timeDimensions: ["year"],
+      });
+
+      assert.deepStrictEqual(ds.id, ["country", "year", "metric"]);
+      assert.deepStrictEqual(ds.size, [2, 2, 1]);
+      assert.deepStrictEqual(ds.value, [1, 2, 3, null]);
+    });
+
+    it("keeps null measures as null", () => {
       const nullRows = [
         { country: "US", year: "2025", revenue: null },
         { country: "US", year: "2026", revenue: 110 },
@@ -100,79 +99,199 @@ describe("buildJSONStat", () => {
         measures: ["revenue"],
         timeDimensions: ["year"],
       });
-      assert.ok(ds.value.includes(null), "value array must contain null");
+      assert.ok(ds.value.includes(null));
     });
-  });
 
-  describe("duplicate column disambiguation", () => {
-    it("columns with same name get numeric suffix", () => {
-      const dupRows = [{ a: 1, a_2: 2 }];
-      // Simulate duplicate column names in the columns array
-      const ds = buildJSONStat(dupRows, ["a", "a"], {
-        measures: ["a", "a"],
-      });
-      // After disambiguation, should have "a" and "a_2"
-      // The dataset should still be valid
-      assert.equal(ds.version, "2.0");
-      assert.equal(ds.id.length, ds.size.length);
-    });
-  });
-
-  describe("measures-only query", () => {
-    it("no dimensions, just measures produces single metric dimension", () => {
+    it("supports measure-only queries", () => {
       const measRows = [{ revenue: 100, profit: 30 }];
       const ds = buildJSONStat(measRows, ["revenue", "profit"], {
         measures: ["revenue", "profit"],
       });
-      assert.equal(ds.id.length, 1, "should have exactly one dimension (metric)");
-      assert.ok(ds.role.metric, "must have metric role");
+      assert.equal(ds.id.length, 1);
+      assert.deepStrictEqual(ds.role.metric, ["metric"]);
+    });
+  });
+
+  describe("correctness fixes", () => {
+    it("maps duplicate explicit measure hints across deduped columns", () => {
+      const dupRows = [{ a: 1, a_2: 2 }];
+      const ds = buildJSONStat(dupRows, ["a", "a"], {
+        measures: ["a"],
+      });
+      const metricDim = ds.dimension[ds.role.metric[0]];
+      assert.deepStrictEqual(Object.keys(metricDim.category.index), ["a", "a_2"]);
+    });
+
+    it("distinguishes null and empty-string dimension values", () => {
+      const ds = buildJSONStat(
+        [
+          { country: null, revenue: 1 },
+          { country: "", revenue: 2 },
+        ],
+        ["country", "revenue"],
+        { measures: ["revenue"] }
+      );
+      assert.equal(Object.keys(ds.dimension.country.category.index).length, 2);
+      assert.deepStrictEqual(ds.value, [1, 2]);
+    });
+
+    it("distinguishes numeric and string dimension values with the same rendered label", () => {
+      const ds = buildJSONStat(
+        [
+          { country: 1, revenue: 1 },
+          { country: "1", revenue: 2 },
+        ],
+        ["country", "revenue"],
+        { measures: ["revenue"] }
+      );
+      assert.equal(Object.keys(ds.dimension.country.category.index).length, 2);
+      assert.deepStrictEqual(ds.value, [1, 2]);
+    });
+
+    it("avoids colliding with a real metric dimension", () => {
+      const ds = buildJSONStat(
+        [{ metric: "A", revenue: 1 }],
+        ["metric", "revenue"],
+        { measures: ["revenue"] }
+      );
+      assert.deepStrictEqual(ds.id, ["metric", "metric_2"]);
+      assert.deepStrictEqual(ds.role.metric, ["metric_2"]);
+      assert.ok(ds.dimension.metric);
+      assert.ok(ds.dimension.metric_2);
+    });
+
+    it("aggregates duplicate tuples by default and emits a warning", () => {
+      const ds = buildJSONStat(
+        [
+          { country: "US", revenue: 1 },
+          { country: "US", revenue: 2 },
+        ],
+        ["country", "revenue"],
+        { measures: ["revenue"] }
+      );
+      assert.deepStrictEqual(ds.value, [3]);
+      assert.match(ds.extension.warning, /duplicate dimension tuples/i);
+    });
+
+    it("can reject duplicate tuples explicitly", () => {
+      const ds = buildJSONStat(
+        [
+          { country: "US", revenue: 1 },
+          { country: "US", revenue: 2 },
+        ],
+        ["country", "revenue"],
+        { measures: ["revenue"], duplicatePolicy: "error" }
+      );
+      assert.equal(ds.status, 400);
+      assert.match(ds.error, /duplicate dimension tuples/i);
+    });
+  });
+
+  describe("category metadata options", () => {
+    it("supports compact category metadata", () => {
+      const ds = buildJSONStat(rows, columns, {
+        measures: ["revenue"],
+        timeDimensions: ["year"],
+        categoryIndexFormat: "array",
+        includeCategoryLabels: false,
+      });
+
+      assert.deepStrictEqual(ds.dimension.country.category.index, ["US", "UK"]);
+      assert.equal(ds.dimension.country.category.label, undefined);
     });
   });
 
   describe("binary columns", () => {
-    it("omitted with extension warning", () => {
-      const binRows = [
-        { country: "US", data: Buffer.from([0x00, 0xff]) },
-      ];
-      const ds = buildJSONStat(binRows, ["country", "data"]);
-      // data column should be omitted
-      assert.equal(ds.dimension.data, undefined, "binary column should be omitted");
-      assert.ok(ds.extension, "extension must exist");
-      assert.ok(
-        typeof ds.extension.warning === "string" &&
-          ds.extension.warning.toLowerCase().includes("binary"),
-        "warning should mention binary columns"
+    it("omits binary columns with a warning", () => {
+      const ds = buildJSONStat(
+        [{ country: "US", data: Buffer.from([0x00, 0xff]) }],
+        ["country", "data"]
       );
+      assert.equal(ds.dimension.data, undefined);
+      assert.match(ds.extension.warning, /binary/i);
     });
   });
 
-  describe("empty result with columns", () => {
-    it("returns valid dataset with value: []", () => {
+  describe("empty results", () => {
+    it("returns a valid empty dataset when columns are known", () => {
       const ds = buildJSONStat([], ["country", "year", "revenue"], {
         measures: ["revenue"],
         timeDimensions: ["year"],
       });
       assert.equal(ds.version, "2.0");
-      assert.equal(ds.class, "dataset");
+      assert.deepStrictEqual(ds.id, ["country", "year", "metric"]);
+      assert.deepStrictEqual(ds.size, [0, 0, 1]);
       assert.deepStrictEqual(ds.value, []);
+      assert.deepStrictEqual(ds.role.time, ["year"]);
+      assert.deepStrictEqual(ds.role.metric, ["metric"]);
     });
-  });
 
-  describe("empty result without columns", () => {
-    it("returns error object with status 400", () => {
+    it("returns an error for empty results without columns", () => {
       const ds = buildJSONStat([], []);
       assert.equal(ds.status, 400);
       assert.ok(typeof ds.error === "string");
     });
 
-    it("returns error for null/undefined columns", () => {
+    it("returns an error for null columns", () => {
       const ds = buildJSONStat([], null);
       assert.equal(ds.status, 400);
     });
   });
 
+  describe("value encoding", () => {
+    it("supports explicit sparse value encoding", () => {
+      const sparseRows = Array.from({ length: 20 }, (_, i) => ({
+        country: `C${i}`,
+        year: `Y${i}`,
+        revenue: i + 1,
+      }));
+      const ds = buildJSONStat(sparseRows, columns, {
+        measures: ["revenue"],
+        timeDimensions: ["year"],
+        valueFormat: "sparse",
+      });
+
+      assert.equal(Array.isArray(ds.value), false);
+      assert.equal(typeof ds.value, "object");
+      assert.equal(Object.keys(ds.value).length, 20);
+    });
+
+    it("auto-selects sparse value encoding for low-density cubes", () => {
+      const sparseRows = Array.from({ length: 20 }, (_, i) => ({
+        country: `C${i}`,
+        year: `Y${i}`,
+        revenue: i + 1,
+      }));
+      const ds = buildJSONStat(sparseRows, columns, {
+        measures: ["revenue"],
+        timeDimensions: ["year"],
+      });
+
+      assert.equal(Array.isArray(ds.value), false);
+      assert.equal(Object.keys(ds.value).length, 20);
+      assert.match(ds.extension.warning, /sparse json-stat value encoding/i);
+    });
+
+    it("rejects overly large dense output", () => {
+      const sparseRows = Array.from({ length: 20 }, (_, i) => ({
+        country: `C${i}`,
+        year: `Y${i}`,
+        revenue: i + 1,
+      }));
+      const ds = buildJSONStat(sparseRows, columns, {
+        measures: ["revenue"],
+        timeDimensions: ["year"],
+        valueFormat: "dense",
+        maxDenseCells: 100,
+      });
+
+      assert.equal(ds.status, 413);
+      assert.match(ds.error, /dense json-stat output/i);
+    });
+  });
+
   describe("invariants", () => {
-    it("id.length === size.length", () => {
+    it("keeps id and size aligned", () => {
       const ds = buildJSONStat(rows, columns, {
         measures: ["revenue"],
         timeDimensions: ["year"],
@@ -180,31 +299,11 @@ describe("buildJSONStat", () => {
       assert.equal(ds.id.length, ds.size.length);
     });
 
-    it("value.length === product(size)", () => {
+    it("dense value length matches the product of size", () => {
       const ds = buildJSONStat(rows, columns, {
         measures: ["revenue"],
         timeDimensions: ["year"],
       });
-      const product = ds.size.reduce((a, b) => a * b, 1);
-      assert.equal(ds.value.length, product);
-    });
-
-    it("invariants hold for heuristic path too", () => {
-      const ds = buildJSONStat(rows, columns);
-      assert.equal(ds.id.length, ds.size.length);
-      const product = ds.size.reduce((a, b) => a * b, 1);
-      assert.equal(ds.value.length, product);
-    });
-
-    it("invariants hold for multiple measures", () => {
-      const multiRows = [
-        { country: "US", revenue: 100, profit: 30 },
-        { country: "UK", revenue: 200, profit: 50 },
-      ];
-      const ds = buildJSONStat(multiRows, ["country", "revenue", "profit"], {
-        measures: ["revenue", "profit"],
-      });
-      assert.equal(ds.id.length, ds.size.length);
       const product = ds.size.reduce((a, b) => a * b, 1);
       assert.equal(ds.value.length, product);
     });


### PR DESCRIPTION
## Summary
Follow-up to #18 with changes made after the initial merge:

- **Rewritten jsonstatBuilder**: typed category identity, adaptive dense/sparse value encoding, explicit-measure fast path, dense-cell guard, compact metadata options
- **Limit override middleware**: CSV/JSON-Stat queries on `/api/v1/load` inject `CUBEJS_DB_QUERY_LIMIT` (1M) so exports aren't capped by the 10k default
- **Empty result handling**: derive JSON-Stat columns from query annotation when data array is empty
- **docker-compose**: add `CUBEJS_DB_QUERY_LIMIT=1000000` for dev environment
- Updated jsonstatBuilder tests for new features

## Test plan
- [x] All jsonstatBuilder unit tests pass
- [x] End-to-end verified: CSV, JSON-Stat, JSON all return correct results via `/api/v1/load`
- [x] Limit override: CSV/JSON-Stat without explicit limit returns all rows (not capped at 10k)

🤖 Generated with [Claude Code](https://claude.com/claude-code)