### PR TITLE
fix(cubejs): direct Arrow passthrough with field mapping header

### DIFF
--- a/docs/plans/009-export-formats.md
+++ b/docs/plans/009-export-formats.md
@@ -1,0 +1,256 @@
+# 009: Export Formats — Efficient Output for Query Results
+
+## Goal
+
+Add less-verbose output formats (CSV, JSON-Stat) to the CubeJS service routes, reducing payload size and enabling bulk/streaming export. When the underlying database natively supports a format (e.g. ClickHouse CSV), stream it directly to the client without intermediate serialization.
+
+## Current State
+
+### How query results flow today
+
+| Path | Entry Point | Data Source | Limit Enforcement | Output |
+|------|-------------|-------------|-------------------|--------|
+| **Cube.js `/load` API** | `@cubejs-backend/api-gateway` | Cube.js query engine | `CUBEJS_DB_QUERY_DEFAULT_LIMIT` (10,000), `CUBEJS_DB_QUERY_LIMIT` (50,000 hard max) | JSON only (`default` or `compact` responseFormat) |
+| **`fetch_dataset` action** | `services/actions/src/rpc/fetchDataset.js` | Cube.js client (`@cubejs-client/core`) → `/load` | Same as above (passes through) | JSON (wraps Cube.js response) |
+| **`run_query` action** | `services/actions/src/rpc/runQuery.js` → `cubejsApi.runSQL()` | `POST /api/v1/run-sql` → raw driver | Caller-provided SQL `LIMIT` clause only | JSON (`res.json(rows)`) |
+| **`/api/v1/run-sql` route** | `services/cubejs/src/routes/runSql.js` | Raw database driver (`driver.query()`) | None (raw SQL) | JSON (`res.json(rows)`) |
+
+### Cube.js built-in formats
+
+The API gateway supports two `responseFormat` values (neither is CSV):
+- **`default`** — `{ data: [{key: value}, ...], annotation: {...} }` (verbose, repeated keys per row)
+- **`compact`** — `{ members: [...], dataset: [[...], ...] }` (columnar, smaller payload)
+
+### Frontend limits
+
+- `ExploreSettingsForm` caps UI input at `MAX_ROWS_LIMIT = 10000` (`client-v2/src/components/ExploreSettingsForm/index.tsx:13`)
+- Default limit in UI: 100 rows
+- SQL Runner default: 1,000 rows
+
+## Semantic Query → Raw SQL → Raw Results (existing pieces)
+
+The building blocks to go from a Cube.js semantic query to raw database output already exist — they're just not chained:
+
+1. **`gen_sql` action** (`services/actions/src/rpc/genSql.js`) — takes an exploration (semantic query), compiles it to raw SQL via `cubejsApi.query(state, "sql")`, substitutes params via `replaceQueryParams()`, returns the final SQL string. This uses the Cube.js schema compiler, not the query engine.
+
+2. **`/api/v1/run-sql` route** (`services/cubejs/src/routes/runSql.js`) — takes a raw SQL string, gets a driver instance via `cubejs.options.driverFactory({ securityContext })`, calls `driver.query(sql)`, returns raw rows as JSON.
+
+3. **`run_query` action** (`services/actions/src/rpc/runQuery.js`) — chains these: wraps caller SQL in `SELECT * FROM (...) LIMIT n`, sends to `run-sql`, returns result.
+
+**Today this requires two round trips** (gen_sql → run_query) or the client must know the raw SQL. A single endpoint that compiles + executes + formats would eliminate this.
+
+**Key insight**: The `run-sql` path bypasses the Cube.js API gateway entirely — no 10k/50k limit enforcement. The only limit is what's in the SQL itself. This makes it the ideal path for bulk export.
+
+## The Problem
+
+1. **JSON is verbose** — repeated key names per row, quoting overhead. For large result sets this is significant.
+2. **No CSV export** — common need for data pipelines, spreadsheets, downstream tools.
+3. **No schema description** — consumers can't programmatically discover the shape of results.
+4. **10k default limit** — `CUBEJS_DB_QUERY_DEFAULT_LIMIT` silently caps results even via API.
+5. **No streaming** — even when the database supports native format output (e.g. ClickHouse `FORMAT CSV`), we deserialize to JS objects and re-serialize to JSON. Wasteful for large exports.
+
+## Candidate Implementation Paths
+
+### Path A: Format param on `/api/v1/run-sql` (lowest effort)
+
+The `run-sql` route already has raw rows from the driver. Add a `format` body param:
+
+```
+POST /api/v1/run-sql
+{ "query": "SELECT ...", "format": "csv" }
+```
+
+- **Pros**: Simplest change (one route, ~20 lines). No Cube.js engine limits apply. Raw driver rows are easy to serialize.
+- **Cons**: Only works for raw SQL path. Bypasses Cube.js security context, access controls, and query rewrite rules (already blocked for teams with rewrite rules). Not usable for Cube.js semantic queries.
+
+### Path B: New `/api/v1/export` route
+
+A dedicated export endpoint that accepts either a Cube.js query or raw SQL, runs it, and returns the result in the requested format:
+
+```
+POST /api/v1/export
+{ "query": {...}, "format": "csv", "limit": 50000 }
+```
+
+- **Pros**: Clean separation. Can support both Cube.js queries and raw SQL. Can set proper `Content-Type` and `Content-Disposition` headers for download.
+- **Cons**: More plumbing. Needs to duplicate some of the Cube.js client flow for semantic queries.
+
+### Path C: Transform layer in Actions service
+
+Add format conversion in `cubejsApi.js` query method before returning to Hasura:
+
+- **Pros**: Works for all existing GraphQL actions without new routes.
+- **Cons**: Hasura actions return typed GraphQL — can't return raw CSV through `FetchDatasetOutput`. Would need a new action or workaround. Adds complexity to the wrong layer.
+
+### Path D: Format param on existing routes (pragmatic middle ground)
+
+Add `format` support to both `/api/v1/run-sql` and a thin wrapper around the Cube.js `/load` call:
+
+- `/api/v1/run-sql` — direct driver, format param
+- `/api/v1/query` (new) — wraps Cube.js load, converts result to requested format
+
+- **Pros**: Covers both raw SQL and semantic query paths. Keeps logic in CubeJS service.
+- **Cons**: Moderate effort. The semantic query path still goes through Cube.js limits.
+
+## Recommendation
+
+**Path A first** (run-sql with format param), then extend to semantic queries.
+
+`/api/v1/run-sql` is the fastest path — the raw rows are already there, no Cube.js engine limits apply, and it's a single-file change. For databases that support native format output (ClickHouse), we can stream the response directly without intermediate deserialization.
+
+### Streaming strategy
+
+For **ClickHouse** (and any driver that supports it): append `FORMAT CSV` (or `FORMAT CSVWithNames`) to the SQL and stream the HTTP response body directly to the client. No row-by-row parsing, no JS object allocation — the database does the serialization.
+
+For **other databases**: fetch rows via the driver as today, serialize to CSV in a streaming fashion (row-by-row write to response).
+
+This two-tier approach means ClickHouse exports can handle arbitrarily large result sets with constant memory, while other databases still get CSV support with reasonable overhead.
+
+## Format Details
+
+### CSV
+- `Content-Type: text/csv`
+- `Content-Disposition: attachment; filename="export.csv"`
+- Header row from column names
+- Standard RFC 4180 quoting
+- **ClickHouse fast path**: Use `FORMAT CSVWithNames` in the SQL query itself; stream the raw HTTP response body from ClickHouse directly to the client. Zero intermediate parsing.
+- **Generic path**: `driver.query()` → iterate rows → write CSV lines to response stream.
+
+### JSON-Stat
+- A compact, metadata-rich format designed for statistical data exchange
+- Research needed — see next section
+
+## JSON-Stat Research
+
+### JSON-Stat 2.0 Format Summary
+
+JSON-Stat is a compact, metadata-rich format for statistical data exchange. A dataset is a single JSON object:
+
+```json
+{
+  "version": "2.0",
+  "class": "dataset",
+  "label": "Population by country and year",
+  "id": ["country", "year"],
+  "size": [3, 2],
+  "dimension": {
+    "country": {
+      "label": "Country",
+      "category": {
+        "index": {"US": 0, "DE": 1, "FR": 2},
+        "label": {"US": "United States", "DE": "Germany", "FR": "France"}
+      }
+    },
+    "year": {
+      "label": "Year",
+      "category": {
+        "index": {"2023": 0, "2024": 1},
+        "label": {"2023": "2023", "2024": "2024"}
+      }
+    }
+  },
+  "value": [331, 333, 83, 84, 67, 68]
+}
+```
+
+**Key properties:**
+- **`id`** + **`size`**: dimension ordering and cardinality (determines value array layout)
+- **`value`**: flat array in row-major order (rightmost dimension iterates fastest). Can be sparse object for nulls.
+- **`status`**: per-observation metadata (array, string, or sparse object)
+- **`role`**: semantic roles — `time`, `geo`, `metric`, `classification`
+- **`dimension.*.category.unit`**: measurement units with `decimals`, `symbol`, `position`, `label`
+- **`note`**: annotations at dataset, dimension, or category level
+- **`link`**: related resources by IANA relation type
+- **`extension`**: provider-specific metadata (open structure)
+
+**Why it's compact:** Values are a flat array — no repeated key names. Dimension metadata is stored once, not per-row. For a 3×2 dataset, JSON-Stat stores 6 values + 2 dimension definitions vs. JSON's 6 objects × 3 keys each.
+
+### Cube.js → JSON-Stat Mapping
+
+| Cube.js Concept | JSON-Stat Equivalent |
+|---|---|
+| Dimensions | `dimension` objects with `category.index` + `category.label` |
+| Measures | Values in `value` array; measure names become a metric-role dimension |
+| Time dimensions | Dimension with `role.time` |
+| Filters | Reduce category set in affected dimensions |
+| `limit` / `offset` | Not native to JSON-Stat (applied before encoding) |
+| Query results (rows × columns) | Flattened to `value[]` in row-major order |
+
+**Multiple measures**: JSON-Stat handles this by creating a "metric" dimension. If a Cube.js query has measures `[count, revenue]` and dimension `[country]`, the JSON-Stat encoding uses `id: ["metric", "country"]` with `size: [2, N]` where the metric dimension has categories `{count: 0, revenue: 1}`.
+
+### jsonstat-toolkit Library (Fork: `smartdataHQ/toolkit`)
+
+**Fork status**: Identical to upstream `jsonstat/toolkit` v2.2.2. No modifications yet. Default branch: `master`.
+
+**What it does**: Parses JSON-Stat responses into a traversable object model with methods for dimension/category navigation and tabular conversion.
+
+**API surface** (1,776 lines, zero dependencies):
+
+| Method | Purpose |
+|---|---|
+| `JSONstat(input)` | Entry point — parses JSON-Stat object or fetches URL |
+| `.Dataset(n\|id)` | Select dataset from bundle/collection |
+| `.Dimension(n\|id)` | Navigate to dimension |
+| `.Category(n\|id)` | Navigate to category within dimension |
+| `.Data(pos\|coords)` | Access individual cell values |
+| `.Dice(filters, opts)` | Subset dataset by category filters |
+| `.Unflatten(callback)` | Iterate all cells with coordinates (efficient core loop) |
+| `.Transform(opts)` | Convert to tabular format (replacement for toTable) |
+| `.toTable(opts)` | Legacy tabular conversion (deprecated, planned removal in 3.0) |
+
+**Build**: Rollup → 4 outputs: IIFE, CJS, ESM (module.mjs), ESM (import.mjs). ~18KB each.
+
+### Performance Bottlenecks in the Toolkit
+
+Key areas where the library is slow for large datasets:
+
+1. **`normalize()` (line 27-58)** — On parse, expands sparse value/status objects into full arrays. For a sparse dataset with 1M positions but 10K values, this allocates a 1M-element array with a push loop. Could use `TypedArray` + index map instead.
+
+2. **`toTable()` (line 904-1355)** — The legacy method is O(n × d) with heavy inner loops:
+   - Lines 1299-1306: **Reverse-lookup of category index** — iterates all categories to find which one has `index===j`. This is O(categories²) per dimension. The index is already an object mapping id→position; it should be inverted once to position→id.
+   - Lines 1312-1335: Pre-expands all dimension labels into full-length arrays (`dimexp`), each of size `total`. For 3 dimensions of size 100, this creates 3 arrays of 1M elements each. Memory-intensive and unnecessary — labels can be computed on-the-fly from position using modular arithmetic.
+   - Lines 1102-1109: Inner loop builds row objects with `j--` reverse iteration. Creates a new object per row.
+
+3. **`Dice()` (line 510-716)** — Filtering calls `Transform({type: "arrobj"})` first (line 623), converting the entire dataset to tabular form just to filter it. The TODO on line 624 acknowledges this: "Remove this extra loop: use Unflatten instead of Transform+forEach". For a 1M-row dataset where you want 1K rows, this materializes all 1M rows as objects first.
+
+4. **`Transform()` (line 1432-1774)** — The newer replacement for toTable. Uses `Unflatten()` internally (good), but:
+   - `content === "label"` path calls `d.Category(coordinates[dimId]).label` per cell (line 1495), which does a full Category lookup including child/unit/note/coordinates resolution for every single cell. Only the label is needed.
+   - The `"arrobj"` + `by` pivot path (line 1660+) uses `Object.values(ret).join('|')` as a Map key (line 1705) — string concatenation per row for deduplication.
+
+5. **`Data()` with object/array coordinates (line 740-897)** — Each call to `Data({country: "US", year: "2023"})` does a linear scan through dimensions and category index lookups. No caching of dimension metadata between calls.
+
+6. **`JSON.parse(JSON.stringify(this))` in `Dice()` clone (line 556)** — Full deep clone via JSON round-trip. For large datasets this is extremely slow.
+
+### Performance Improvement Strategy
+
+**Priority 1 — Hot path optimizations (no API changes):**
+- Fix the O(categories²) reverse-index lookup in `toTable()` — pre-build position→id map once
+- Replace `dimexp` full-expansion with on-the-fly label computation via modular arithmetic
+- In `Transform()`, create a fast label-only lookup cache instead of full `Category()` calls
+- Fix `Dice()` to use `Unflatten()` directly instead of materializing all rows first
+
+**Priority 2 — Structural improvements:**
+- Add streaming/iterator support: `Unflatten()` could yield rows instead of collecting into array
+- Support `TypedArray` throughout (partially started in v1.4.0) — avoid boxing numbers into objects
+- Add a "direct write" path: instead of building JS objects and then serializing, write CSV/JSON lines directly to a stream from the flat value array + dimension metadata
+
+**Priority 3 — Synmetrix-specific additions:**
+- Add a `fromRows(columns, rows)` factory that builds JSON-Stat directly from database result sets without intermediate JSON
+- Add a `toCSV()` method that streams CSV from the flat value array + dimensions (no intermediate tabular conversion)
+- Add a `toCubeResponse()` method that converts JSON-Stat back to Cube.js response format
+
+## Key Files
+
+- `services/cubejs/src/routes/runSql.js` — raw SQL route (primary target)
+- `services/cubejs/src/routes/index.js` — route registration
+- `services/cubejs/index.js` — CubeJS server config + env vars
+- `services/actions/src/utils/cubejsApi.js` — Actions service Cube.js client wrapper
+- `services/actions/src/rpc/runQuery.js` — run_query RPC handler
+- `services/actions/src/rpc/fetchDataset.js` — fetch_dataset RPC handler
+- `@cubejs-backend/shared/dist/src/env.js` — `CUBEJS_DB_QUERY_DEFAULT_LIMIT` (10k), `CUBEJS_DB_QUERY_LIMIT` (50k)
+- `client-v2/src/components/ExploreSettingsForm/index.tsx` — frontend `MAX_ROWS_LIMIT` (10k)
+- `services/actions/src/rpc/genSql.js` — semantic query → raw SQL compilation (existing)
+- `services/actions/src/utils/playgroundState.js` — `replaceQueryParams()` for SQL param substitution
+- `services/cubejs/src/utils/driverFactory.js` — driver creation (25+ databases, ClickHouse via `@cubejs-backend/clickhouse-driver`)
+- `smartdataHQ/toolkit` (GitHub) — forked jsonstat-toolkit v2.2.2, currently identical to upstream
+- `smartdataHQ/toolkit/src/jsonstat.js` — 1,776 lines, core library with performance bottlenecks identified above

--- a/docs/plans/009-load-endpoint-streaming-passthrough.md
+++ b/docs/plans/009-load-endpoint-streaming-passthrough.md
@@ -1,0 +1,204 @@
+# Load Endpoint Streaming Passthrough for CSV/Arrow
+
+**Date:** 2026-03-14
+**Status:** Implementation ready
+**Related:** 009-query-output, OOMKill incident on cubejs pod
+
+## Problem
+
+The `/api/v1/load` endpoint buffers all query result rows in memory when serving CSV and Arrow formats. The Cube.js engine internally calls `driver.query()`, collects all rows into a JavaScript array, then calls `res.json(fullResult)`. Our format middleware intercepts `res.json()` and re-serializes to CSV/Arrow, but by that point the full result set is already in memory.
+
+This caused a production OOMKill (exit code 137) when a 50k-row query across many dimensions exceeded the container memory limit. V8 never triggered GC pressure because `--max-old-space-size` exceeded the container limit — the kernel killed the process directly.
+
+The `/api/v1/run-sql` endpoint already has constant-memory streaming for ClickHouse (Arrow via `driver.client.exec()` with `FORMAT ArrowStream`, CSV via `driver.client.query()` with `FORMAT CSVWithNames`). The `/load` endpoint cannot use these paths because the Cube.js engine controls query execution internally.
+
+## Solution: Compile-Then-Redirect
+
+For `format=csv|arrow` on the `/load` endpoint, **compile** the Cube.js query to raw SQL, then **redirect** to the existing `runSql` handler. This reuses all streaming code (ClickHouse Arrow/CSV fast paths, backpressure, abort handling, safety limits) with zero duplication.
+
+### Flow
+
+```
+Browser POST /api/v1/load { query: { measures, dimensions, ... }, format: "csv" }
+  │
+  ▼
+Format middleware (routes/index.js)
+  - Validates format
+  - format === "json" → next() (unchanged, Cube.js handles it)
+  - format === "jsonstat" → next() (intercept approach, needs annotation metadata)
+  - format === "csv" or "arrow" → SHORT-CIRCUIT:
+    │
+    ▼
+  1. checkAuthMiddleware already ran → req.securityContext populated
+    │
+    ▼
+  2. Compile Cube.js query to SQL via cubejs.apiGateway().sql()
+     → Returns { sql: { sql: [sqlString, paramsArray], ... }, dataSource }
+    │
+    ▼
+  3. Substitute params → executable SQL string
+    │
+    ▼
+  4. HMAC-sign the SQL (so runSql's access-control check passes)
+    │
+    ▼
+  5. Rewrite req.body and call runSql(req, res, cubejs)
+     → runSql handles streaming, abort, safety limits — all existing code
+```
+
+**Memory:** O(chunk_size) for ClickHouse (~128KB). O(rows × columns) for non-ClickHouse (driver limitation, unchanged from today).
+
+### Why This Works
+
+**"Loses Cube.js query metadata"** — not an issue. Annotation and pre-aggregation hints are only needed for JSON-Stat (which keeps the intercept approach). CSV and Arrow just need rows/bytes.
+
+**"Bypasses access control signing"** — not an issue. HMAC signing prevents external clients from injecting arbitrary SQL through the public `run-sql` endpoint. Here the SQL is compiled internally by the Cube.js compiler (which applies `queryRewrite` access control rules during compilation) and never leaves the server. We sign it internally with `JWT_KEY` (already available in scope) so `runSql`'s `isSignedSql` check passes transparently — no flags, no special cases.
+
+**"assertApiScope('sql') might block"** — not an issue. Default API scopes include `['graphql', 'meta', 'data', 'sql']` and we don't override `contextToApiScopesFn`. The `sql` scope is always permitted.
+
+### JSON-Stat: Unchanged
+
+JSON-Stat keeps the existing intercept approach. It requires annotation metadata (measure names, time dimension names) from the Cube.js compilation to correctly assign dataset-level roles. JSON-Stat results are also typically smaller (aggregated data), so buffering is acceptable.
+
+## Implementation
+
+### Changes to `routes/index.js`
+
+The format middleware currently handles all non-JSON formats via the intercept approach (override `res.json`/`res.send`, call `next()`, transform the buffered response). For CSV and Arrow, we replace this with a direct redirect to `runSql`.
+
+```javascript
+import crypto from "crypto";
+import runSql from "./runSql.js";
+
+// Parameter substitution (inlined — trivial function)
+function replaceQueryParams(sql, params) {
+  let index = -1;
+  return sql.replace(/(\$\d+)|\(\?[\w\d ]*\)|\?/g, (match) => {
+    index += 1;
+    return match.replace(/\?|\$\d+/, `'${params[index]}'`);
+  });
+}
+
+// Compile a Cube.js query object to executable SQL
+async function compileCubeQuery(cubejs, query, securityContext) {
+  const gateway = cubejs.apiGateway();
+  let sqlResult;
+
+  await gateway.sql({
+    query,
+    context: {
+      securityContext,
+      requestId: crypto.randomUUID(),
+    },
+    res: (result) => { sqlResult = result; },
+  });
+
+  // result shape: { sql: { sql: [sqlString, paramsArray], ... }, dataSource }
+  const { sql: sqlQuery } = sqlResult;
+  const [sqlString, params] = sqlQuery.sql;
+  return replaceQueryParams(sqlString, params);
+}
+
+// HMAC-sign SQL so runSql's isSignedSql check passes
+function signSql(sql) {
+  return crypto.createHmac("sha256", process.env.JWT_KEY).update(sql).digest("hex");
+}
+```
+
+The middleware itself:
+
+```javascript
+router.use(`${basePath}/v1/load`, checkAuthMiddleware, (req, res, next) => {
+  if (req.method !== "POST" && req.method !== "GET") return next();
+
+  const rawFormat = req.method === "POST" ? req.body?.format : req.query?.format;
+  let format;
+  try {
+    format = validateFormat(rawFormat);
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  // JSON: pass through to Cube.js engine (unchanged)
+  if (format === "json") return next();
+
+  // CSV / Arrow: compile query to SQL, then redirect to runSql for streaming
+  if (format === "csv" || format === "arrow") {
+    const cubeQuery = req.method === "POST" ? req.body?.query : JSON.parse(req.query?.query);
+
+    compileCubeQuery(cubejs, cubeQuery, req.securityContext)
+      .then((executableSql) => {
+        // Rewrite request body for runSql
+        req.body = {
+          query: executableSql,
+          format,
+          sql_signature: signSql(executableSql),
+        };
+        return runSql(req, res, cubejs);
+      })
+      .catch((err) => {
+        console.error("Load streaming passthrough failed, falling back to Cube.js engine:", err.message);
+        // On compilation failure, fall back to the buffered intercept approach
+        setupInterceptTransform(req, res, format);
+        next();
+      });
+    return;
+  }
+
+  // JSON-Stat: use the intercept approach (needs annotation metadata)
+  setupInterceptTransform(req, res, format);
+  next();
+});
+```
+
+The existing intercept logic (limit override, `res.json`/`res.send` override, transform function) gets extracted into a `setupInterceptTransform(req, res, format)` helper so JSON-Stat can still use it, and it serves as the fallback if compilation fails.
+
+### Changes to `routes/runSql.js`
+
+None. The `runSql` handler already handles everything: format validation, HMAC signature check, driver factory, ClickHouse streaming fast paths, generic fallback, abort handling, safety limits. The internal redirect just needs to provide a properly shaped `req.body`.
+
+### `req.body` contract for internal redirect
+
+```javascript
+req.body = {
+  query: "SELECT ... FROM ...",        // executable SQL (params substituted)
+  format: "csv" | "arrow",            // output format
+  sql_signature: "a1b2c3...",          // HMAC-SHA256 of query with JWT_KEY
+  // No measures/timeDimensions needed — those are for JSON-Stat only
+};
+```
+
+### Auth Flow
+
+`checkAuthMiddleware` is added to the middleware chain for `/v1/load`. This means:
+- For JSON (passes through to Cube.js): auth runs twice — once in our middleware, once in Cube.js's own middleware. This is harmless (idempotent, cached).
+- For CSV/Arrow (short-circuits): auth runs once in our middleware, which is sufficient.
+- For JSON-Stat (intercept approach): auth runs twice, same as JSON. Harmless.
+
+### Fallback Strategy
+
+If `compileCubeQuery` fails (e.g., invalid query, compiler error), the middleware falls back to the existing buffered intercept approach by calling `setupInterceptTransform()` and `next()`. This means CSV/Arrow exports still work for edge cases where compilation fails — they just use more memory.
+
+### Files to Modify
+
+1. `services/cubejs/src/routes/index.js` — restructure format middleware: extract intercept logic into helper, add streaming passthrough for csv/arrow
+2. No other files changed — `runSql.js` is reused as-is
+
+### Estimated Impact
+
+| Scenario | Current Memory | After Passthrough |
+|----------|---------------|-------------------|
+| 50k rows × 20 cols, ClickHouse Arrow | ~500MB (4x amplification) | ~128KB (chunk buffer) |
+| 50k rows × 20 cols, ClickHouse CSV | ~200MB | ~128KB (chunk buffer) |
+| 50k rows × 20 cols, PostgreSQL | ~200MB (unchanged) | ~200MB (driver limitation) |
+| 1M rows × 10 cols, ClickHouse Arrow | OOM | ~128KB |
+
+### References
+
+- `services/cubejs/node_modules/@cubejs-backend/api-gateway/dist/src/gateway.js:980` — `sql()` method
+- `services/cubejs/node_modules/@cubejs-backend/api-gateway/dist/src/gateway.js:59` — default API scopes include `'sql'`
+- `services/cubejs/node_modules/@cubejs-backend/server-core/dist/src/core/server.js:323` — `apiGateway()` accessor
+- `services/cubejs/index.js:93` — ServerCore instantiation, `cubejs` object passed to routes
+- `services/cubejs/src/routes/runSql.js` — target handler (streaming, abort, safety limits)
+- `services/cubejs/src/utils/checkAuth.js` — auth middleware (already imported in routes/index.js)
+- `services/actions/src/utils/playgroundState.js:3` — `replaceQueryParams()` original (inlined in our implementation)

--- a/docs/plans/2026-03-12-jsonstat-encoder-optimization-research.md
+++ b/docs/plans/2026-03-12-jsonstat-encoder-optimization-research.md
@@ -1,0 +1,453 @@
+# JSON-Stat Encoder Optimization Research
+
+Date: 2026-03-12
+
+## Scope
+
+This note documents:
+
+- JSON-stat format constraints that matter for encoding performance.
+- Analysis of `services/cubejs/src/utils/jsonstatBuilder.js`.
+- Caller-side constraints from `services/cubejs/src/routes/index.js` and `services/cubejs/src/routes/runSql.js`.
+- All identified correctness risks, performance options, payload-size options, and follow-up suggestions.
+
+The goal is not only to optimize the current encoder, but to identify which changes are actually worth making in this codebase.
+
+## Sources
+
+Primary sources used for the format research:
+
+- JSON-stat full format specification: https://json-stat.org/full/
+- JSON-stat JavaScript toolkit sample page: https://json-stat.org/tools/js
+
+Local code reviewed:
+
+- `services/cubejs/src/utils/jsonstatBuilder.js`
+- `services/cubejs/test/jsonstatBuilder.test.js`
+- `services/cubejs/src/routes/index.js`
+- `services/cubejs/src/routes/runSql.js`
+
+## JSON-stat Format Constraints That Matter
+
+### 1. Dense array output is not mandatory
+
+JSON-stat allows `value` to be encoded either as:
+
+- a dense array, where position is implied by `id` and `size`
+- a sparse object, where populated positions are keyed explicitly
+
+This matters because the current encoder always materializes a dense `value` array filled with `null`, even when the cube is sparse.
+
+### 2. Category metadata has representation choices
+
+For `dimension.*.category.index`, JSON-stat allows:
+
+- an object mapping category id to position
+- an array whose order implies the positions
+
+This matters because the current encoder always emits object form and also duplicates every category id into `category.label`.
+
+### 3. Dimension order defines value order
+
+The current stride math assumes row-major flattening with the rightmost dimension varying fastest. That matches the JSON-stat model and is the correct basis for efficient encoding.
+
+### 4. Metric dimensions are a modeling convention, not a required name
+
+Representing measures as a synthetic metric dimension is valid, but the dimension id does not have to be literally `"metric"`. The current implementation hard-codes that id and can collide with real data.
+
+## Current Implementation Summary
+
+The encoder already does several useful things:
+
+- disambiguates duplicate column names
+- scans rows once to classify columns and collect categories
+- computes flat offsets with precomputed strides
+- merges duplicate tuples before writing the final array
+- emits dataset-level `role.time` and `role.metric`
+
+At a high level, the implementation is already using the right dense-encoding strategy. The main remaining opportunities are:
+
+- reducing memory amplification
+- reducing payload size
+- removing unnecessary work on explicit-metadata paths
+- fixing correctness issues before making deeper optimizations
+
+## Caller Constraints
+
+### `/v1/load` path
+
+`services/cubejs/src/routes/index.js` supplies:
+
+- `rows` from Cube response `data`
+- `columns` from `Object.keys(data[0])`
+- `measures` from `annotation.measures`
+- `timeDimensions` from `annotation.timeDimensions`
+
+Implication:
+
+- this is usually the stronger path because classification hints are available
+- heuristic classification is mostly fallback behavior here
+- empty-result schema is lost because columns are inferred from the first row only
+
+### `/v1/run-sql` path
+
+`services/cubejs/src/routes/runSql.js` supplies:
+
+- `rows` from `driver.query(sql)`
+- `columns` from `Object.keys(rows[0])`
+- `measures` and `timeDimensions` only if the client provides them
+
+Implication:
+
+- correctness depends more heavily on heuristics when clients omit hints
+- empty-result schema is also lost here
+
+### Architectural limit
+
+Both JSON-stat paths fully materialize rows before encoding. That means:
+
+- the encoder cannot be constant-memory today
+- builder-level micro-optimizations will help, but they do not change the fundamental memory profile
+- truly large-result optimization requires caller or driver contract changes
+
+## Findings
+
+## Correctness Risks
+
+### 1. Dimension key collisions from string coercion
+
+The encoder uses `String(v ?? "")` when building category maps and when computing tuple offsets.
+
+Impacts:
+
+- `null` and `""` collapse into the same category
+- `1` and `"1"` collapse into the same category
+- `false` and `"false"` collapse into the same category
+
+This can silently corrupt both:
+
+- category cardinality
+- merged observation placement
+
+This is the most important issue to fix before deeper optimization.
+
+### 2. Synthetic `"metric"` dimension can collide with a real dimension
+
+When measures exist, the encoder always appends a synthetic dimension with id `"metric"`.
+
+If the source data already has a real dimension named `"metric"`:
+
+- `id` can contain duplicate entries
+- `dimension.metric` can be overwritten
+- the output dataset becomes ambiguous or invalid
+
+### 3. Duplicate tuple handling is opinionated and potentially unsafe
+
+If two rows map to the same dimension tuple, the encoder:
+
+- sums numeric measures
+- keeps the last non-numeric value
+
+This may be acceptable for a deliberate rollup mode, but it is not a neutral encoding behavior. It changes the data semantics.
+
+### 4. Duplicate-name hint mapping is incomplete
+
+For repeated columns, explicit hints such as `options.measures` and `options.timeDimensions` map only to the first deduped column name.
+
+In practice, this is not important for current callers because duplicate column names do not realistically survive `Object.keys(row)`, but the logic itself is incomplete.
+
+### 5. Empty results lose schema
+
+If there are no rows, both callers pass no usable column schema into the builder. The builder then returns a 400 error for an otherwise valid empty result shape.
+
+This is mostly a route-level issue, not an encoder issue.
+
+## Test Coverage Gaps
+
+Current tests verify shape and basic invariants, but they do not adequately cover:
+
+- exact row-major `value` placement
+- sparse combinations remaining `null` in the correct slots
+- duplicate tuple behavior
+- type-collision cases such as `null` vs `""`
+- synthetic metric name collision
+- empty-result metadata consistency
+
+The current suite passes, but it would not catch several real regressions.
+
+## Optimization Options
+
+## Highest-Impact Options
+
+### 1. Add sparse `value` object output
+
+Description:
+
+- Add a mode that emits `value` as an object keyed by flat offset, instead of allocating a dense null-filled array.
+
+Why it matters:
+
+- avoids `new Array(totalObs).fill(null)` for sparse cubes
+- avoids serializing huge runs of `null`
+- fits naturally with the current `mergedMap` intermediate representation
+
+Best use:
+
+- large multidimensional cubes with many missing combinations
+- any dataset where `populatedCells << product(size)`
+
+Tradeoffs:
+
+- some consumers may expect dense arrays
+- compatibility should be validated with downstream tools before making it the default
+
+Recommendation:
+
+- implement as an optional mode first
+- auto-enable when density falls below a chosen threshold
+
+### 2. Add a cardinality guard and automatic mode selection
+
+Description:
+
+- before allocating dense output, estimate `product(size) * effectiveMeasureCount`
+- if it exceeds a threshold, either:
+  - switch to sparse-object mode
+  - reject the request
+  - warn and require explicit opt-in
+
+Why it matters:
+
+- prevents pathological memory usage
+- protects `run-sql` especially, since it currently has no JSON-stat safety guard
+
+Recommendation:
+
+- combine this with sparse mode
+- track both total cell count and density
+
+### 3. Split explicit-metadata and heuristic paths
+
+Description:
+
+- when `measures` and `timeDimensions` are explicitly known, skip heuristic-only work
+
+Specific savings:
+
+- do not build category maps for measure columns
+- do not do numeric inference for columns already known to be dimensions or measures
+- reduce unnecessary `Set` and `Map` churn on the common `/v1/load` path
+
+Why it matters:
+
+- `/v1/load` usually already has annotation metadata
+- current code builds `catMaps` and `catOrders` for every column up front, even those later discarded as measures
+
+Recommendation:
+
+- refactor into:
+  - fast path: explicit metadata
+  - fallback path: heuristic inference
+
+### 4. Remove one intermediate structure on dense mode
+
+Description:
+
+- today dense output is built via:
+  - `mergedMap`
+  - then `value[]`
+
+For dense mode, it may be cheaper to:
+
+- allocate `value[]` once
+- write directly by offset
+- keep a separate bitset or set only if duplicate detection is needed
+
+Why it matters:
+
+- reduces peak memory
+- reduces one full pass over populated tuples
+
+Tradeoffs:
+
+- more complicated duplicate-handling logic
+- sparse-object mode still benefits from `mergedMap`
+
+Recommendation:
+
+- do this only after deciding duplicate semantics
+- likely worthwhile for dense mode, not mandatory for sparse mode
+
+## Payload-Size Options
+
+### 5. Support compact category encoding
+
+Description:
+
+- use `category.index` as an array when category ids and order are enough
+- optionally omit `category.label` when it would just duplicate ids
+
+Why it matters:
+
+- current output stores every category id twice
+- category metadata can dominate payload for high-cardinality dimensions
+
+Tradeoffs:
+
+- some consumers are more comfortable with object-form `index`
+- labels may still be required for friendly display in some clients
+
+Recommendation:
+
+- add an encoder option such as:
+  - `categoryIndex: "object" | "array"`
+  - `includeCategoryLabels: boolean`
+
+### 6. Add a single-measure fast path
+
+Description:
+
+- when there is exactly one measure, avoid creating a synthetic per-tuple measure array during merge
+
+Why it matters:
+
+- many queries are single-measure
+- reduces small-array allocation churn
+
+Impact:
+
+- moderate, not transformative
+
+Recommendation:
+
+- good cleanup optimization after correctness fixes
+
+## Lower-Value or Context-Dependent Options
+
+### 7. Remove or isolate duplicate-column remapping
+
+Description:
+
+- duplicate column support is largely dead code under the current caller architecture
+
+Why it matters:
+
+- it adds complexity and object remapping work
+- current callers derive columns from JS object keys, which do not preserve true duplicate names
+
+Recommendation:
+
+- either remove it
+- or keep it behind a dedicated lower-level API that receives explicit column metadata from a driver
+
+This is more about simplifying maintenance than improving runtime significantly.
+
+### 8. Micro-optimize object creation
+
+Examples:
+
+- replace some `Object.keys(role).length > 0` checks with boolean flags
+- avoid `activeCols = activeIndices.map(...)`
+- reduce temporary arrays where possible
+
+Impact:
+
+- minor
+
+Recommendation:
+
+- not worth prioritizing until higher-impact changes are settled
+
+## Suggestions By Priority
+
+## Priority 0: Fix correctness first
+
+1. Replace raw string coercion for dimension keys with a stable typed encoding.
+2. Avoid hard-coding `"metric"` when it collides with real dimensions.
+3. Make duplicate tuple handling explicit:
+   - error
+   - aggregate with defined reducer
+   - last-write-wins
+4. Add tests for all three issues above.
+
+## Priority 1: Add safe scalability controls
+
+1. Add sparse-object `value` output.
+2. Add a cardinality guard for dense mode.
+3. Add route-level protection for `run-sql` JSON-stat responses similar to the existing JSON guard.
+
+## Priority 2: Optimize the common path
+
+1. Split explicit-metadata and heuristic paths.
+2. Skip category collection for known measure columns.
+3. Add a single-measure fast path.
+
+## Priority 3: Reduce payload size
+
+1. Support array-form `category.index`.
+2. Allow omission of redundant category labels.
+3. Consider exposing a compact JSON-stat mode separately from the default compatibility mode.
+
+## Route-Level Suggestions
+
+### 1. Preserve schema for empty results
+
+The current builder can produce a valid empty dataset if it is given column metadata, but both callers lose that metadata on empty results.
+
+Suggestions:
+
+- `/v1/load`: derive columns from Cube annotation instead of only from the first row
+- `/v1/run-sql`: if available, use driver metadata or a schema inspection path for empty results
+
+### 2. Decide whether JSON-stat should be dense or adaptive by default
+
+Reasonable default policy:
+
+- dense output for small or near-dense datasets
+- sparse-object output for large sparse datasets
+
+This should be a product decision because compatibility expectations vary by consumer.
+
+### 3. Consider a streaming-oriented lower-level API for raw SQL exports
+
+The current route contracts materialize all rows in memory before encoding. If very large JSON-stat exports become important, the bigger change is not inside the builder. It is in the route and driver layer:
+
+- iterate rows as a stream
+- collect only dimension/category state that is actually needed
+- write output incrementally where format permits
+
+This is much harder than CSV streaming, but it is where the real architectural headroom sits.
+
+## Recommended Next Implementation Slice
+
+The most defensible next slice is:
+
+1. Fix typed category identity and metric-name collision.
+2. Add tests for row-major placement, sparse combinations, duplicate tuples, and key-collision cases.
+3. Add sparse `value` object mode behind an option.
+4. Add a dense-mode cell-count guard.
+5. Refactor the builder into explicit-metadata and heuristic paths.
+
+This sequence improves correctness first, then adds the highest-value scalability feature, then trims avoidable work.
+
+## Proposed Test Additions
+
+- `null` and `""` remain distinct dimension categories
+- `1` and `"1"` remain distinct dimension categories
+- a real dimension named `metric` does not collide with the synthetic metric dimension
+- row-major flattening produces the expected offsets
+- missing combinations remain `null` in dense mode
+- sparse mode emits only populated offsets
+- duplicate tuples follow the chosen policy exactly
+- empty-result datasets preserve `id`, `size`, `dimension`, and `role` consistently
+
+## Bottom Line
+
+The current encoder already has the correct dense flattening model. The biggest remaining opportunities are not low-level arithmetic tricks. They are:
+
+- fixing correctness traps
+- avoiding dense null-filled arrays for sparse cubes
+- avoiding work that is unnecessary when metadata is already known
+- reducing payload duplication in category metadata
+
+If only one optimization is implemented, it should be sparse `value` object support plus a cardinality guard. That is the clearest performance win with the best leverage against large-result failure modes.

--- a/docs/plans/2026-03-14-load-semantic-streaming-design.md
+++ b/docs/plans/2026-03-14-load-semantic-streaming-design.md
@@ -1,0 +1,579 @@
+# Semantic `/load` Streaming Design
+
+**Date:** 2026-03-14  
+**Status:** Proposed  
+**Related:** `009-export-formats.md`, `009-load-endpoint-streaming-passthrough.md`
+
+## Goal
+
+Design a `/load` implementation that:
+
+1. Supports normal Cube query objects and request semantics.
+2. Preserves Synmetrix and Cube security, datasource, branch, version, and query parameter handling.
+3. Uses true streaming when the underlying execution stack supports it, especially for ClickHouse CSV and Arrow.
+
+## Requirements
+
+### Functional
+
+- The external request contract remains the Cube `/load` contract:
+  - semantic query object
+  - same auth headers
+  - same datasource / branch / version scoping
+  - same cache and query parameters
+- `format=json` must keep current behavior.
+- `format=csv|arrow` must use streaming when available.
+- `format=csv|arrow` must preserve semantic query behavior:
+  - query normalization
+  - `queryRewrite`
+  - row-level security
+  - member expressions
+  - pre-aggregation selection/loading
+  - alias/member mapping
+
+### Non-Functional
+
+- Do not buffer full result sets in CubeJS for streaming-capable paths.
+- Preserve backpressure and client abort handling.
+- Do not turn `/load` into a raw-SQL endpoint.
+
+## Current Problem
+
+Today Synmetrix handles `/load?format=csv|arrow` by intercepting the final JSON response after CubeJS has already executed and materialized the result set.
+
+That means:
+
+- CubeJS `/load` executes via the normal non-streaming `executeQuery()` path.
+- ClickHouse `driver.query()` uses `format: JSON` and `resultSet.json()`.
+- Synmetrix only transforms the already-buffered `cubeResponse.data` into CSV or Arrow.
+
+Result:
+
+- CSV is only streamed from app memory to the client, not from the database through Cube.
+- Arrow is fully buffered and serialized in process.
+- ClickHouse native CSV and Arrow streaming are not used on `/load`.
+
+## Decision
+
+Do **not** make `/load` streaming a post-processing optimization on top of the existing buffered `/load` response.
+
+Do **not** use compile-to-SQL then call `/run-sql` as the primary semantic export engine.
+
+Instead:
+
+- Keep `/load` as the public semantic query interface.
+- Add a dedicated **semantic export execution path** for `format=csv|arrow`.
+- Use Cube's semantic normalization and execution pipeline first.
+- Use a streaming backend under that semantic pipeline.
+- Add native database passthrough only as an optimization under the semantic execution layer, not as the semantic execution layer itself.
+
+## Why This Is Better
+
+### Why not keep the current intercept approach
+
+Because interception happens too late. By the time Synmetrix sees the response:
+
+- query execution is done
+- results are materialized
+- memory has already been spent
+
+No downstream response transform can recover true streaming from that.
+
+### Why not use compile -> `run-sql` as the main solution
+
+Compiling semantic queries to SQL preserves part of the semantic layer, but it is not the same as executing through Cube's normal `/load` path.
+
+The main gap is execution semantics:
+
+- `/load` goes through the orchestrator and pre-aggregation loading path
+- `/run-sql` goes directly to `driverFactory(...).query()` or driver-native APIs
+
+That means compile -> `run-sql` is useful as a fallback or optimization path, but not as the canonical implementation for semantic exports.
+
+## Proposed Architecture
+
+### External API
+
+Keep the existing endpoint:
+
+- `POST /api/v1/load`
+- `GET /api/v1/load`
+
+Supported formats:
+
+- `json`
+- `csv`
+- `arrow`
+- `jsonstat`
+
+Behavior split:
+
+- `json` -> current Cube `/load` path
+- `jsonstat` -> current buffered transform path for now
+- `csv|arrow` -> new semantic export path
+
+### Internal Execution Modes
+
+#### Mode 1: Standard semantic load
+
+Used for:
+
+- `format=json`
+- existing dashboard / API consumers
+
+Implementation:
+
+- current `ApiGateway.load()` path
+
+#### Mode 2: Semantic export load
+
+Used for:
+
+- `format=csv`
+- `format=arrow`
+
+Implementation:
+
+- same semantic query parsing and security handling as `/load`
+- different execution backend chosen before normal buffered response generation
+
+## Semantic Export Pipeline
+
+For `format=csv|arrow`, the pipeline should be:
+
+1. Validate format and parse query.
+2. Authenticate and build `securityContext`.
+3. Run the same Cube normalization pipeline:
+   - query type detection
+   - row-level security
+   - `queryRewrite`
+   - member expression parsing/evaluation
+   - datasource resolution
+4. Build semantic execution metadata:
+   - normalized query
+   - annotation
+   - SQL query object
+   - alias-to-member mapping
+   - pre-aggregation metadata
+5. Choose best available stream source.
+6. Stream encoded output to the client.
+
+## Stream Source Hierarchy
+
+The semantic export path should choose among these backends.
+
+### Backend A: Semantic row stream
+
+This should be the canonical streaming abstraction.
+
+Source:
+
+- Cube semantic streaming path via internal `stream()` / `sqlApiLoad(..., streaming: true)` behavior
+
+Properties:
+
+- preserves semantic aliases
+- preserves Cube normalization/security behavior
+- preserves pre-aggregation loading
+- streams row objects rather than raw bytes
+
+Usage:
+
+- always acceptable for CSV
+- acceptable for Arrow via incremental Arrow IPC writer
+
+### Backend B: Native database format passthrough
+
+This is an optimization, not the main abstraction.
+
+Use only when all of the following are true:
+
+- the semantic execution plan has already been resolved
+- column names and order match semantic output exactly
+- pre-aggregation selection/loading has already been honored
+- the native stream can be returned without breaking semantic behavior
+
+Examples:
+
+- ClickHouse CSV native stream
+- ClickHouse ArrowStream native stream
+
+This backend can eventually deliver the lowest memory and CPU cost, but it must sit under semantic planning, not replace it.
+
+### Backend C: Buffered fallback
+
+Use only when no stream path exists.
+
+Examples:
+
+- drivers without stream support
+- formats whose encoder is not yet incremental
+- complex query types unsupported by the export stream path
+
+This fallback should reuse the current buffered transform behavior.
+
+## Capability Model
+
+The implementation should make capability decisions explicitly rather than hardcoding ClickHouse checks in route logic.
+
+Suggested capability dimensions:
+
+- `semanticRowStream`
+- `nativeCsvPassthrough`
+- `nativeArrowPassthrough`
+- `incrementalArrowEncode`
+
+Suggested output of a capability resolver:
+
+```js
+{
+  semanticRowStream: true,
+  nativeCsvPassthrough: true,
+  nativeArrowPassthrough: true,
+  incrementalArrowEncode: true
+}
+```
+
+Initial expectation:
+
+- ClickHouse:
+  - `semanticRowStream: true`
+  - `nativeCsvPassthrough: true`
+  - `nativeArrowPassthrough: true`
+- most other drivers:
+  - `semanticRowStream: false` or unknown
+  - native passthrough: false
+
+## Security and Parameter Invariants
+
+The semantic export path must preserve all of the following:
+
+- `Authorization`
+- `x-hasura-datasource-id`
+- `x-hasura-branch-id`
+- `x-hasura-branch-version-id`
+- query `timezone`
+- query filters, order, limit, offset, segments, member expressions
+- team/member access control
+- query rewrite rules
+
+This means the route must not invent a separate security model for exports.
+
+## Pre-Aggregations and Cache Semantics
+
+This is the main reason not to make compile -> `run-sql` the primary design.
+
+The semantic export path must preserve:
+
+- pre-aggregation resolution
+- loading of required rollups
+- staging / queue / wait behavior
+- transformed query usage where applicable
+
+The ideal design is:
+
+- semantic export executes through the same orchestrator-backed semantic path as `/load`
+- export backends only change how rows are emitted, not how the semantic plan is executed
+
+## Continue Wait and Retry Behavior
+
+The export path must explicitly define how it behaves when the semantic query cannot stream immediately because:
+
+- the query is still queued
+- pre-aggregations are building
+- Cube would normally return `Continue wait`
+
+Recommended behavior:
+
+- Preserve Cube's `Continue wait` JSON contract until the stream is actually ready.
+- Only switch to file streaming once execution has started.
+
+Why:
+
+- this keeps semantic behavior aligned with Cube
+- it avoids inventing a second queue model for exports
+- it keeps pre-aggregation build behavior consistent
+
+This does mean clients exporting CSV/Arrow need retry handling before the file stream starts. That is acceptable and matches existing Cube behavior more closely than bypassing the execution path.
+
+## Query Type Policy
+
+The first version should explicitly support:
+
+- regular single-result semantic queries
+
+The first version should reject or defer:
+
+- blending queries
+- multi-result queries
+- subscribe semantics
+
+Reason:
+
+- current Synmetrix export logic already effectively assumes a single result
+- streaming multi-result CSV/Arrow needs a clear envelope format
+- forcing explicit handling is safer than silently exporting only `results[0]`
+
+## Route Design
+
+### Keep `routes/index.js` as the dispatcher
+
+Recommended high-level behavior:
+
+```text
+/api/v1/load
+  -> validate format
+  -> if json: next() to normal Cube load
+  -> if jsonstat: current buffered transform path
+  -> if csv|arrow:
+       semantic export executor
+         -> if stream available: stream response
+         -> else: buffered fallback
+```
+
+### New internal module
+
+Add a new internal module rather than expanding `index.js` further.
+
+Suggested names:
+
+- `services/cubejs/src/routes/loadExport.js`
+- `services/cubejs/src/utils/semanticExport.js`
+
+The route file should remain a thin dispatcher.
+
+## Recommended Implementation Strategy
+
+### Phase 1
+
+Build semantic CSV streaming using Cube semantic row streams.
+
+This is the safest first target because:
+
+- CSV row encoding is straightforward
+- row stream preserves semantic aliases naturally
+- it validates the semantic streaming architecture before adding native passthrough
+
+### Phase 2
+
+Build semantic Arrow streaming using incremental Arrow IPC output.
+
+Important detail:
+
+- do not use the current `serializeRowsToArrow(rows)` path for streaming
+- it is intentionally full-buffer and column-materializing
+
+Implementation note:
+
+- use an incremental RecordBatch / IPC writer if the library supports it
+- otherwise emit Arrow in bounded record batches while preserving a valid Arrow stream
+
+### Phase 3
+
+Add capability-aware ClickHouse native passthrough for semantic exports.
+
+Do this only after:
+
+- semantic stream path is working
+- invariants around aliases and pre-aggregations are proven
+- fallback path exists
+
+### Phase 4
+
+Optionally factor `/run-sql` and semantic export backends to share:
+
+- abort handling
+- backpressure helpers
+- CSV chunk writing
+- ClickHouse native format helpers
+
+## Detailed Plan
+
+### Workstream 1: Extract shared stream helpers
+
+Create shared utilities for:
+
+- abort-controller lifecycle
+- response close / finish tracking
+- binary chunk writes
+- text chunk writes
+- consistent CSV headers
+- consistent Arrow headers
+
+Target files:
+
+- new `services/cubejs/src/utils/streamResponse.js`
+- refactor `runSql.js` to use it
+
+### Workstream 2: Build semantic export planner
+
+Create an internal planner that:
+
+- takes the raw Cube query + request context
+- runs Cube normalization / query rewrite / security flow
+- returns:
+  - normalized query
+  - query type
+  - annotation
+  - sql query object
+  - alias mapping
+  - execution capability metadata
+
+Target files:
+
+- new `services/cubejs/src/utils/semanticExportPlan.js`
+
+### Workstream 3: Build semantic row stream executor
+
+Create an executor that:
+
+- obtains a semantic stream from Cube internals
+- preserves pre-aggregation/orchestrator behavior
+- exposes:
+  - stream
+  - metadata
+  - cleanup / release
+
+Target files:
+
+- new `services/cubejs/src/utils/semanticRowStream.js`
+
+### Workstream 4: Build CSV export backend
+
+Implement:
+
+- `streamSemanticCsv(plan, req, res)`
+
+Behavior:
+
+- semantic row stream -> CSV encoder -> HTTP response
+- preserve backpressure
+- preserve abort behavior
+- preserve `Continue wait` before stream start
+
+Target files:
+
+- new `services/cubejs/src/utils/semanticCsvExport.js`
+
+### Workstream 5: Build Arrow export backend
+
+Implement:
+
+- `streamSemanticArrow(plan, req, res)`
+
+Behavior:
+
+- semantic row stream -> incremental Arrow IPC writer -> HTTP response
+- bounded batching only
+- no full row array materialization
+
+Target files:
+
+- new `services/cubejs/src/utils/semanticArrowExport.js`
+
+### Workstream 6: Add route dispatcher
+
+Update `/load` route behavior:
+
+- `json` -> current behavior
+- `jsonstat` -> current buffered path
+- `csv|arrow` -> semantic export dispatcher
+
+Target files:
+
+- `services/cubejs/src/routes/index.js`
+
+### Workstream 7: Add native passthrough optimization
+
+After semantic row streaming works:
+
+- add capability resolver
+- implement ClickHouse native CSV passthrough when semantic fidelity is guaranteed
+- implement ClickHouse native Arrow passthrough when semantic fidelity is guaranteed
+
+This should be a second pass, not part of the initial architecture landing.
+
+Target files:
+
+- new `services/cubejs/src/utils/exportCapabilities.js`
+- reuse helper logic from `runSql.js`
+
+## File-Level Plan
+
+### Files to modify
+
+- `services/cubejs/src/routes/index.js`
+- `services/cubejs/src/routes/runSql.js`
+
+### Files to add
+
+- `services/cubejs/src/utils/streamResponse.js`
+- `services/cubejs/src/utils/semanticExportPlan.js`
+- `services/cubejs/src/utils/semanticRowStream.js`
+- `services/cubejs/src/utils/semanticCsvExport.js`
+- `services/cubejs/src/utils/semanticArrowExport.js`
+- `services/cubejs/src/utils/exportCapabilities.js`
+
+## Testing Plan
+
+### Unit tests
+
+- format dispatch behavior
+- capability selection
+- CSV row-stream encoding
+- Arrow batch-stream encoding
+- abort handling
+- backpressure handling
+
+### Integration tests
+
+- `/load?format=csv` on ClickHouse returns streaming CSV
+- `/load?format=arrow` on ClickHouse returns streaming Arrow
+- `/load?format=csv` preserves semantic aliases and filters
+- `/load?format=csv` honors branch/version/datasource headers
+- `/load?format=csv` returns `Continue wait` when semantic execution is not ready
+- `/load?format=csv` uses buffered fallback on non-streaming drivers
+
+### Regression tests
+
+- `format=json` unchanged
+- `format=jsonstat` unchanged
+- `/run-sql` unchanged
+
+## Risks
+
+### Risk 1: Cube internal streaming APIs are not designed for direct Express reuse
+
+Mitigation:
+
+- wrap them behind a Synmetrix-local executor abstraction
+- do not couple route logic directly to internal package shapes
+
+### Risk 2: Arrow incremental encoding may be harder than CSV
+
+Mitigation:
+
+- land CSV semantic streaming first
+- keep current Arrow buffered fallback until incremental Arrow writer is ready
+
+### Risk 3: Native passthrough may drift from semantic aliases
+
+Mitigation:
+
+- native passthrough is phase 2 optimization only
+- row-stream path remains canonical and always correct
+
+## Recommendation Summary
+
+The right architecture is:
+
+- preserve `/load` as the external semantic interface
+- add a separate internal semantic export execution path for `csv|arrow`
+- use Cube semantic streaming as the primary execution model
+- use native ClickHouse passthrough only as an optimization under that model
+
+This satisfies all three user constraints:
+
+- supports Cube query objects
+- preserves Synmetrix and Cube security/parameter behavior
+- supports full streaming when the stack can actually provide it

--- a/services/cubejs/src/routes/index.js
+++ b/services/cubejs/src/routes/index.js
@@ -11,8 +11,15 @@ import { serializeRowsToArrow } from "../utils/arrowSerializer.js";
 import { validateFormat } from "../utils/formatValidator.js";
 import { writeRowsAsCSV } from "../utils/csvSerializer.js";
 import { buildJSONStat } from "../utils/jsonstatBuilder.js";
+import {
+  applyLoadExportQueryLimit,
+  deriveExportColumnsFromLoad,
+  getLoadRequestFormat,
+  getLoadRequestQuery,
+} from "../utils/loadExportUtils.js";
 import generateDataSchema from "./generateDataSchema.js";
 import getSchema from "./getSchema.js";
+import maybeHandleLoadExport from "./loadExport.js";
 import preAggregationPreview from "./preAggregationPreview.js";
 import preAggregations from "./preAggregations.js";
 import profileTable from "./profileTable.js";
@@ -24,60 +31,14 @@ import version from "./version.js";
 
 const router = express.Router();
 
-function addUniqueColumns(target, names) {
-  if (!Array.isArray(names)) return;
-  for (let i = 0; i < names.length; i++) {
-    const name = names[i];
-    if (typeof name === "string" && !target.includes(name)) {
-      target.push(name);
-    }
-  }
-}
-
-function normalizeLoadQuery(rawQuery) {
-  if (!rawQuery) return null;
-  if (typeof rawQuery === "string") {
-    try {
-      return JSON.parse(rawQuery);
-    } catch {
-      return null;
-    }
-  }
-  return rawQuery;
-}
-
-function deriveExportColumnsFromLoad(req, annotation, data) {
-  if (data.length > 0) {
-    return Object.keys(data[0]);
-  }
-
-  const columns = [];
-  const query = req.method === "POST"
-    ? normalizeLoadQuery(req.body?.query)
-    : normalizeLoadQuery(req.query?.query);
-  const primaryQuery = Array.isArray(query) ? query[0] : query;
-
-  if (primaryQuery) {
-    addUniqueColumns(columns, primaryQuery.dimensions);
-    addUniqueColumns(
-      columns,
-      Array.isArray(primaryQuery.timeDimensions)
-        ? primaryQuery.timeDimensions.map((item) => typeof item === "string" ? item : item?.dimension)
-        : []
-    );
-    addUniqueColumns(columns, primaryQuery.measures);
-  }
-
-  if (columns.length === 0) {
-    addUniqueColumns(columns, Object.keys(annotation.dimensions || {}));
-    addUniqueColumns(columns, Object.keys(annotation.timeDimensions || {}));
-    addUniqueColumns(columns, Object.keys(annotation.measures || {}));
-  }
-
-  return columns;
-}
-
 export default ({ basePath, cubejs }) => {
+  router.get(`${basePath}/v1/load`, (req, res, next) =>
+    maybeHandleLoadExport(req, res, next, cubejs)
+  );
+  router.post(`${basePath}/v1/load`, (req, res, next) =>
+    maybeHandleLoadExport(req, res, next, cubejs)
+  );
+
   // Format-aware middleware for the load endpoint.
   // When format=csv, format=jsonstat, or format=arrow, Cube.js processes the query as normal
   // but the response is intercepted and re-serialized in the requested format.
@@ -85,12 +46,9 @@ export default ({ basePath, cubejs }) => {
   router.use(`${basePath}/v1/load`, (req, res, next) => {
     if (req.method !== "POST" && req.method !== "GET") return next();
 
-    const rawFormat =
-      req.method === "POST" ? req.body?.format : req.query?.format;
-
     let format;
     try {
-      format = validateFormat(rawFormat);
+      format = validateFormat(getLoadRequestFormat(req));
     } catch (err) {
       return res.status(400).json({ error: err.message });
     }
@@ -111,22 +69,7 @@ export default ({ basePath, cubejs }) => {
     // For CSV/JSON-Stat/Arrow, override the query limit to CUBEJS_DB_QUERY_LIMIT so
     // exports are not capped by CUBEJS_DB_QUERY_DEFAULT_LIMIT (10k).
     // The user can still set an explicit limit in the query body to cap results.
-    const queryLimit = parseInt(process.env.CUBEJS_DB_QUERY_LIMIT, 10) || 1000000;
-    if (req.method === "POST" && req.body?.query) {
-      if (!req.body.query.limit) {
-        req.body.query.limit = queryLimit;
-      }
-    } else if (req.method === "GET" && req.query?.query) {
-      try {
-        const q = typeof req.query.query === "string"
-          ? JSON.parse(req.query.query)
-          : req.query.query;
-        if (!q.limit) {
-          q.limit = queryLimit;
-          req.query.query = JSON.stringify(q);
-        }
-      } catch { /* leave as-is if unparseable */ }
-    }
+    applyLoadExportQueryLimit(req);
 
     // Wrap response methods to intercept Cube.js output
     const originalSend = res.send.bind(res);
@@ -168,7 +111,11 @@ export default ({ basePath, cubejs }) => {
         }
 
         if (format === "jsonstat") {
-          const columns = deriveExportColumnsFromLoad(req, annotation, data);
+          const columns = deriveExportColumnsFromLoad(
+            getLoadRequestQuery(req),
+            annotation,
+            data
+          );
           const measures = Object.keys(annotation.measures || {});
           const timeDimensions = Object.keys(annotation.timeDimensions || {});
           const dataset = buildJSONStat(data, columns, { measures, timeDimensions });
@@ -192,7 +139,11 @@ export default ({ basePath, cubejs }) => {
             console.warn(`Arrow /load response truncated: ${data.length} rows exceeded safety limit of ${ARROW_SAFETY_LIMIT}`);
             data.length = ARROW_SAFETY_LIMIT;
           }
-          const columns = deriveExportColumnsFromLoad(req, annotation, data);
+          const columns = deriveExportColumnsFromLoad(
+            getLoadRequestQuery(req),
+            annotation,
+            data
+          );
           res.set("Content-Type", "application/vnd.apache.arrow.stream");
           res.set("Content-Disposition", 'attachment; filename="query-result.arrow"');
           originalSend(serializeRowsToArrow(data, { columns }));

--- a/services/cubejs/src/routes/loadExport.js
+++ b/services/cubejs/src/routes/loadExport.js
@@ -40,6 +40,10 @@ const ARROW_HEADERS = {
   "Content-Type": "application/vnd.apache.arrow.stream",
   "Content-Disposition": 'attachment; filename="query-result.arrow"',
 };
+const ARROW_FIELD_MAPPING_HEADER = "X-Synmetrix-Arrow-Field-Mapping";
+const ARROW_FIELD_MAPPING_ENCODING_HEADER =
+  "X-Synmetrix-Arrow-Field-Mapping-Encoding";
+const ARROW_FIELD_MAPPING_ENCODING = "base64url-json";
 const CSV_STREAM_CHUNK_SIZE = 128 * 1024;
 const CLICKHOUSE_NULL_TOKEN_RE = /(?<=,|^)\\N(?=,|\r?\n|$)/g;
 
@@ -167,15 +171,71 @@ function getAliasNameToMember(plan) {
   return plan?.streamingQuery?.aliasNameToMember || null;
 }
 
-function canUseNativeArrowPassthrough(plan) {
+function getChangedAliasNameToMember(plan) {
   const aliasNameToMember = getAliasNameToMember(plan);
-  if (!aliasNameToMember || Object.keys(aliasNameToMember).length === 0) {
-    return true;
+  if (!aliasNameToMember) return null;
+
+  const changedAliasNameToMember = Object.fromEntries(
+    Object.entries(aliasNameToMember).filter(([alias, member]) => alias !== member)
+  );
+
+  return Object.keys(changedAliasNameToMember).length > 0
+    ? changedAliasNameToMember
+    : null;
+}
+
+function getResponseHeader(res, name) {
+  if (typeof res.getHeader === "function") {
+    const value = res.getHeader(name);
+    if (value != null) return value;
   }
 
-  return Object.entries(aliasNameToMember).every(
-    ([alias, member]) => alias === member
+  if (typeof res.get === "function") {
+    const value = res.get(name);
+    if (value != null) return value;
+  }
+
+  return res.headers?.[name] ?? res.headers?.[name.toLowerCase()];
+}
+
+function appendResponseHeaderValues(res, name, values) {
+  const existing = getResponseHeader(res, name);
+  const currentValues = Array.isArray(existing)
+    ? existing.flatMap((value) => String(value).split(","))
+    : typeof existing === "string"
+      ? existing.split(",")
+      : [];
+  const normalized = new Set(
+    currentValues.map((value) => value.trim()).filter(Boolean).map((value) => value.toLowerCase())
   );
+  const mergedValues = currentValues.map((value) => value.trim()).filter(Boolean);
+
+  for (const value of values) {
+    const normalizedValue = value.toLowerCase();
+    if (!normalized.has(normalizedValue)) {
+      normalized.add(normalizedValue);
+      mergedValues.push(value);
+    }
+  }
+
+  res.set(name, mergedValues.join(", "));
+}
+
+function setNativeArrowFieldMappingHeaders(res, plan) {
+  const aliasNameToMember = getChangedAliasNameToMember(plan);
+  if (!aliasNameToMember) return;
+
+  const encodedMapping = Buffer.from(
+    JSON.stringify(aliasNameToMember),
+    "utf8"
+  ).toString("base64url");
+
+  res.set(ARROW_FIELD_MAPPING_HEADER, encodedMapping);
+  res.set(ARROW_FIELD_MAPPING_ENCODING_HEADER, ARROW_FIELD_MAPPING_ENCODING);
+  appendResponseHeaderValues(res, "Access-Control-Expose-Headers", [
+    ARROW_FIELD_MAPPING_HEADER,
+    ARROW_FIELD_MAPPING_ENCODING_HEADER,
+  ]);
 }
 
 function rewriteNativeCsvHeader(line, aliasNameToMember) {
@@ -416,7 +476,6 @@ async function tryHandleLoadExport(req, res, cubejs, query, format) {
     if (
       format === "arrow"
       && plan.capabilities.nativeArrowPassthrough
-      && canUseNativeArrowPassthrough(plan)
       && isClickHouseContext(plan.context.securityContext)
     ) {
       const nativeQuery = await prepareNativeClickHouseExport(plan);
@@ -425,6 +484,7 @@ async function tryHandleLoadExport(req, res, cubejs, query, format) {
           securityContext: plan.context.securityContext,
         });
         res.set(ARROW_HEADERS);
+        setNativeArrowFieldMappingHeaders(res, plan);
         await executeNativeClickHouseArrow(
           res,
           nativeQuery.query,

--- a/services/cubejs/src/routes/loadExport.js
+++ b/services/cubejs/src/routes/loadExport.js
@@ -1,0 +1,526 @@
+import { randomUUID } from "crypto";
+
+import sqlstring from "sqlstring";
+import * as prepareAnnotationModule from "@cubejs-backend/api-gateway/dist/src/helpers/prepare-annotation.js";
+import { QueryType } from "@cubejs-backend/api-gateway/dist/src/types/enums.js";
+import * as QueryCacheModule from "@cubejs-backend/query-orchestrator/dist/src/orchestrator/QueryCache.js";
+
+import {
+  deriveExportColumnsFromLoad,
+  getLoadRequestFormat,
+  getLoadRequestQuery,
+  applyLoadExportQueryLimit,
+} from "../utils/loadExportUtils.js";
+import {
+  canSemanticStreamLoadExport,
+  resolveLoadExportCapabilities,
+} from "../utils/loadExportCapabilities.js";
+import { validateFormat } from "../utils/formatValidator.js";
+import {
+  escapeCSVField,
+  writeRowStreamAsCSV,
+  writeTextChunk,
+} from "../utils/csvSerializer.js";
+import {
+  writeBinaryChunk,
+  writeRowStreamAsArrow,
+} from "../utils/arrowSerializer.js";
+
+const prepareAnnotation =
+  typeof prepareAnnotationModule.prepareAnnotation === "function"
+    ? prepareAnnotationModule.prepareAnnotation
+    : prepareAnnotationModule.default;
+const QueryCache = QueryCacheModule.QueryCache;
+
+const CSV_HEADERS = {
+  "Content-Type": "text/csv",
+  "Content-Disposition": 'attachment; filename="query-result.csv"',
+};
+const ARROW_HEADERS = {
+  "Content-Type": "application/vnd.apache.arrow.stream",
+  "Content-Disposition": 'attachment; filename="query-result.arrow"',
+};
+const CSV_STREAM_CHUNK_SIZE = 128 * 1024;
+const CLICKHOUSE_NULL_TOKEN_RE = /(?<=,|^)\\N(?=,|\r?\n|$)/g;
+
+function getRequestId(req) {
+  return req.get?.("x-request-id")
+    || req.get?.("traceparent")
+    || `${randomUUID()}-span-1`;
+}
+
+function isClickHouseContext(securityContext) {
+  const dbType = securityContext?.userScope?.dataSource?.dbType;
+  return typeof dbType === "string" && dbType.toLowerCase() === "clickhouse";
+}
+
+function removeTrailingSemicolon(query) {
+  const trimmed = String(query ?? "").trimEnd();
+  let lastNonSemiIdx = trimmed.length;
+  for (let i = lastNonSemiIdx; i > 0; i--) {
+    if (trimmed[i - 1] !== ";") {
+      lastNonSemiIdx = i;
+      break;
+    }
+  }
+  return lastNonSemiIdx !== trimmed.length
+    ? trimmed.slice(0, lastNonSemiIdx)
+    : trimmed;
+}
+
+function normalizeClickHouseCSVLine(line) {
+  const normalized = line.replace(CLICKHOUSE_NULL_TOKEN_RE, "");
+  if (normalized.endsWith("\r\n")) return normalized;
+  if (normalized.endsWith("\n")) return normalized.slice(0, -1) + "\r\n";
+  return normalized + "\r\n";
+}
+
+function createAbortController(res) {
+  const abortController = new AbortController();
+  let responseFinished = false;
+
+  res.on("finish", () => {
+    responseFinished = true;
+  });
+
+  res.on("close", () => {
+    if (!responseFinished && !abortController.signal.aborted) {
+      abortController.abort();
+    }
+  });
+
+  return abortController;
+}
+
+async function runMiddleware(middleware, req, res) {
+  await new Promise((resolve, reject) => {
+    let settled = false;
+
+    const next = (err) => {
+      if (settled) return;
+      settled = true;
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    };
+
+    Promise.resolve(middleware(req, res, next))
+      .then(() => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      })
+      .catch((err) => {
+        if (settled) return;
+        settled = true;
+        reject(err);
+      });
+  });
+}
+
+function getGatewayErrorStatus(err) {
+  if (err?.error === "Continue wait") return 200;
+  if (err?.type === "UserError") return 400;
+  if (err?.error) return 400;
+  return err?.status || 500;
+}
+
+function sendGatewayError(res, err, statusOverride) {
+  if (res.headersSent) {
+    if (!res.writableEnded) res.end();
+    return;
+  }
+
+  res.status(statusOverride || getGatewayErrorStatus(err)).json(err);
+}
+
+function emitGatewayHandledError(apiGateway, res, context, query, error, requestStarted) {
+  if (typeof apiGateway?.handleError !== "function") {
+    sendGatewayError(res, {
+      error: error?.message || error?.error || String(error),
+    });
+    return;
+  }
+
+  let payload = null;
+  let status;
+
+  apiGateway.handleError({
+    e: error,
+    context,
+    query,
+    requestStarted,
+    res: (message, options = {}) => {
+      payload = message;
+      status = options.status;
+    },
+  });
+
+  if (payload) {
+    sendGatewayError(res, payload, status);
+  }
+}
+
+function getAliasNameToMember(plan) {
+  return plan?.streamingQuery?.aliasNameToMember || null;
+}
+
+function canUseNativeArrowPassthrough(plan) {
+  const aliasNameToMember = getAliasNameToMember(plan);
+  if (!aliasNameToMember || Object.keys(aliasNameToMember).length === 0) {
+    return true;
+  }
+
+  return Object.entries(aliasNameToMember).every(
+    ([alias, member]) => alias === member
+  );
+}
+
+function rewriteNativeCsvHeader(line, aliasNameToMember) {
+  const stripped = line.replace(/\r?\n$/, "");
+  const aliases = stripped.length > 0 ? stripped.split(",") : [];
+  const members = aliases.map((alias) => {
+    const unquoted = alias.startsWith('"') && alias.endsWith('"')
+      ? alias.slice(1, -1).replace(/""/g, '"')
+      : alias;
+    return escapeCSVField(aliasNameToMember?.[unquoted] || unquoted);
+  });
+  return members.join(",") + "\r\n";
+}
+
+async function prepareLoadContext(req, res, cubejs) {
+  const apiGateway = cubejs.apiGateway();
+
+  await runMiddleware(apiGateway.checkAuth, req, res);
+  if (res.headersSent) return null;
+
+  await runMiddleware(apiGateway.requestContextMiddleware, req, res);
+  if (res.headersSent) return null;
+
+  await cubejs.contextRejectionMiddleware(req, res);
+  if (res.headersSent) return null;
+
+  if (!req.context) {
+    req.context = await apiGateway.contextByReq(
+      req,
+      req.securityContext,
+      getRequestId(req)
+    );
+  }
+
+  return { apiGateway, context: req.context };
+}
+
+async function buildLoadExportPlan(req, res, cubejs, query) {
+  const requestStarted = new Date();
+  const prepared = await prepareLoadContext(req, res, cubejs);
+  if (!prepared) return { handled: true };
+
+  const { apiGateway, context } = prepared;
+
+  try {
+    await apiGateway.assertApiScope("data", context.securityContext);
+
+    const [queryType, normalizedQueries] = await apiGateway.getNormalizedQueries(
+      query,
+      context,
+      true
+    );
+
+    if (
+      queryType !== QueryType.REGULAR_QUERY
+      || !Array.isArray(normalizedQueries)
+      || normalizedQueries.length !== 1
+    ) {
+      return { handled: false, unsupported: true };
+    }
+
+    const normalizedQuery = normalizedQueries[0];
+    const capabilities = resolveLoadExportCapabilities(context.securityContext);
+    const compilerApi = await apiGateway.getCompilerApi(context);
+    let metaConfig = await compilerApi.metaConfig(context, {
+      requestId: context.requestId,
+    });
+    metaConfig = apiGateway.filterVisibleItemsInMeta(context, metaConfig);
+
+    const annotation = prepareAnnotation(metaConfig, normalizedQuery);
+    const sqlQuery = (await apiGateway.getSqlQueriesInternal(
+      context,
+      normalizedQueries
+    ))[0];
+    const streamingQuery = {
+      ...sqlQuery,
+      query: sqlQuery.sql[0],
+      values: sqlQuery.sql[1],
+      cacheMode: "stale-if-slow",
+      requestId: context.requestId,
+      context,
+      persistent: true,
+      forceNoCache: true,
+    };
+
+    return {
+      handled: false,
+      requestStarted,
+      apiGateway,
+      context,
+      capabilities,
+      normalizedQuery,
+      annotation,
+      columns: deriveExportColumnsFromLoad(normalizedQuery, annotation),
+      streamingQuery,
+    };
+  } catch (err) {
+    emitGatewayHandledError(
+      apiGateway,
+      res,
+      context,
+      query,
+      err,
+      requestStarted
+    );
+    return { handled: true };
+  }
+}
+
+async function prepareNativeClickHouseExport(plan) {
+  if (!isClickHouseContext(plan.context.securityContext)) {
+    return null;
+  }
+
+  const adapterApi = await plan.apiGateway.getAdapterApi(plan.context);
+  const queryOrchestrator = adapterApi.getQueryOrchestrator?.();
+  const preAggregations = queryOrchestrator?.getPreAggregations?.();
+  if (!preAggregations?.loadAllPreAggregationsIfNeeded) {
+    return null;
+  }
+
+  const {
+    preAggregationsTablesToTempTables,
+    values,
+  } = await preAggregations.loadAllPreAggregationsIfNeeded(plan.streamingQuery);
+
+  const inlineTables = preAggregationsTablesToTempTables.flatMap(
+    ([, preAggregation]) => (preAggregation.lambdaTable ? [preAggregation.lambdaTable] : [])
+  );
+
+  if (inlineTables.length > 0) {
+    return null;
+  }
+
+  return {
+    query: QueryCache.replacePreAggregationTableNames(
+      plan.streamingQuery.query,
+      preAggregationsTablesToTempTables
+    ),
+    values: values || plan.streamingQuery.values,
+  };
+}
+
+async function executeNativeClickHouseCsv(
+  res,
+  query,
+  values,
+  driver,
+  signal,
+  aliasNameToMember
+) {
+  const resultSet = await driver.client.query({
+    query: sqlstring.format(query, values || []),
+    format: "CSVWithNames",
+    clickhouse_settings: driver.config?.clickhouseSettings,
+    abort_signal: signal,
+  });
+
+  let chunk = "";
+  let wroteHeader = false;
+  for await (const rows of resultSet.stream()) {
+    for (const row of rows) {
+      if (!wroteHeader) {
+        chunk += rewriteNativeCsvHeader(row.text, aliasNameToMember);
+        wroteHeader = true;
+        continue;
+      }
+
+      chunk += normalizeClickHouseCSVLine(row.text);
+      if (chunk.length >= CSV_STREAM_CHUNK_SIZE) {
+        await writeTextChunk(res, chunk, signal);
+        chunk = "";
+      }
+    }
+  }
+
+  if (chunk.length > 0) {
+    await writeTextChunk(res, chunk, signal);
+  }
+}
+
+async function executeNativeClickHouseArrow(res, query, values, driver, signal) {
+  const result = await driver.client.exec({
+    query: `${removeTrailingSemicolon(sqlstring.format(query, values || []))}\nFORMAT ArrowStream`,
+    clickhouse_settings: {
+      ...driver.config?.clickhouseSettings,
+      output_format_arrow_compression_method: "none",
+    },
+    abort_signal: signal,
+  });
+
+  const stream = typeof result.stream === "function"
+    ? result.stream()
+    : result.stream;
+
+  for await (const chunk of stream) {
+    await writeBinaryChunk(res, chunk, signal);
+  }
+}
+
+async function streamSemanticRows(plan) {
+  const adapterApi = await plan.apiGateway.getAdapterApi(plan.context);
+  return adapterApi.streamQuery(plan.streamingQuery);
+}
+
+async function tryHandleLoadExport(req, res, cubejs, query, format) {
+  const plan = await buildLoadExportPlan(req, res, cubejs, query);
+  if (!plan || plan.handled) return true;
+  if (plan.unsupported) return false;
+
+  const abortController = createAbortController(res);
+
+  try {
+    if (
+      format === "csv"
+      && plan.capabilities.nativeCsvPassthrough
+      && isClickHouseContext(plan.context.securityContext)
+    ) {
+      const nativeQuery = await prepareNativeClickHouseExport(plan);
+      if (nativeQuery) {
+        const driver = await cubejs.options.driverFactory({
+          securityContext: plan.context.securityContext,
+        });
+        res.set(CSV_HEADERS);
+        await executeNativeClickHouseCsv(
+          res,
+          nativeQuery.query,
+          nativeQuery.values,
+          driver,
+          abortController.signal,
+          getAliasNameToMember(plan)
+        );
+        res.end();
+        return true;
+      }
+    }
+
+    if (
+      format === "arrow"
+      && plan.capabilities.nativeArrowPassthrough
+      && canUseNativeArrowPassthrough(plan)
+      && isClickHouseContext(plan.context.securityContext)
+    ) {
+      const nativeQuery = await prepareNativeClickHouseExport(plan);
+      if (nativeQuery) {
+        const driver = await cubejs.options.driverFactory({
+          securityContext: plan.context.securityContext,
+        });
+        res.set(ARROW_HEADERS);
+        await executeNativeClickHouseArrow(
+          res,
+          nativeQuery.query,
+          nativeQuery.values,
+          driver,
+          abortController.signal
+        );
+        res.end();
+        return true;
+      }
+    }
+
+    if (!canSemanticStreamLoadExport(format, plan.capabilities)) {
+      return false;
+    }
+
+    const stream = await streamSemanticRows(plan);
+
+    if (format === "csv") {
+      res.set(CSV_HEADERS);
+      await writeRowStreamAsCSV(res, stream, {
+        columns: plan.columns,
+        signal: abortController.signal,
+      });
+      res.end();
+      return true;
+    }
+
+    res.set(ARROW_HEADERS);
+    await writeRowStreamAsArrow(res, stream, {
+      columns: plan.columns,
+      annotation: plan.annotation,
+      signal: abortController.signal,
+    });
+    res.end();
+    return true;
+  } catch (err) {
+    if (abortController.signal.aborted) return true;
+
+    emitGatewayHandledError(
+      plan.apiGateway,
+      res,
+      plan.context,
+      query,
+      err,
+      plan.requestStarted
+    );
+    return true;
+  }
+}
+
+export async function maybeHandleLoadExport(req, res, next, cubejs) {
+  if (req.method !== "POST" && req.method !== "GET") {
+    next();
+    return;
+  }
+
+  let format;
+  try {
+    format = validateFormat(getLoadRequestFormat(req));
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+    return;
+  }
+
+  if (format !== "csv" && format !== "arrow") {
+    next();
+    return;
+  }
+
+  applyLoadExportQueryLimit(req);
+
+  const query = getLoadRequestQuery(req);
+  if (!query || Array.isArray(query)) {
+    next();
+    return;
+  }
+
+  try {
+    const handled = await tryHandleLoadExport(req, res, cubejs, query, format);
+
+    if (!handled) {
+      next();
+    }
+  } catch (err) {
+    console.error("Semantic load export failed:", err);
+
+    if (res.headersSent) {
+      if (!res.writableEnded) res.end();
+      return;
+    }
+
+    res.status(err.status || 500).json({
+      error: err.message || String(err),
+    });
+  }
+}
+
+export default maybeHandleLoadExport;

--- a/services/cubejs/src/utils/arrowSerializer.js
+++ b/services/cubejs/src/utils/arrowSerializer.js
@@ -1,6 +1,28 @@
-import { tableFromArrays, tableToIPC } from "apache-arrow";
+import {
+  Bool,
+  Float64,
+  RecordBatch,
+  RecordBatchStreamWriter,
+  TimestampMillisecond,
+  Utf8,
+  tableFromArrays,
+  tableToIPC,
+  vectorFromArray,
+} from "apache-arrow";
 
 const ARROW_IPC_KIND = "stream";
+const DEFAULT_ARROW_BATCH_SIZE = 4096;
+const NUMERIC_CUBE_TYPES = new Set([
+  "number",
+  "count",
+  "sum",
+  "avg",
+  "min",
+  "max",
+  "runningtotal",
+  "countdistinct",
+  "countdistinctapprox",
+]);
 
 function isArrayBufferLike(value) {
   return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
@@ -75,4 +97,262 @@ export function serializeRowsToArrow(rows, options = {}) {
   const table = tableFromArrays(rowsToArrowColumns(safeRows, { columns }));
   const bytes = tableToIPC(table, ARROW_IPC_KIND);
   return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function getAnnotationEntry(annotation = {}, column) {
+  return annotation.measures?.[column]
+    || annotation.dimensions?.[column]
+    || annotation.timeDimensions?.[column]
+    || null;
+}
+
+function inferArrowKindFromValue(value) {
+  if (value == null) return null;
+  if (value instanceof Date) return "time";
+
+  const type = typeof value;
+  if (type === "boolean") return "boolean";
+  if (type === "number" || type === "bigint") return "number";
+
+  if (type === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return "string";
+    if (trimmed === "true" || trimmed === "false") return "boolean";
+    if (Number.isFinite(Number(trimmed))) return "number";
+    if (!Number.isNaN(Date.parse(trimmed))) return "time";
+  }
+
+  return "string";
+}
+
+function inferArrowKind(column, annotation = {}, sampleRows = []) {
+  const annotatedType = String(getAnnotationEntry(annotation, column)?.type || "")
+    .toLowerCase();
+
+  if (annotatedType === "time") return "time";
+  if (annotatedType === "boolean") return "boolean";
+  if (NUMERIC_CUBE_TYPES.has(annotatedType)) return "number";
+  if (annotatedType) return "string";
+
+  for (let i = 0; i < sampleRows.length; i++) {
+    const inferred = inferArrowKindFromValue(sampleRows[i]?.[column]);
+    if (inferred) return inferred;
+  }
+
+  return "string";
+}
+
+function createArrowType(kind) {
+  if (kind === "time") return new TimestampMillisecond();
+  if (kind === "boolean") return new Bool();
+  if (kind === "number") return new Float64();
+  return new Utf8();
+}
+
+function normalizeUtf8ArrowValue(value) {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+
+  if (Buffer.isBuffer(value)) {
+    return value.toString("base64");
+  }
+
+  if (isArrayBufferLike(value)) {
+    return Buffer.from(
+      value instanceof ArrayBuffer
+        ? value
+        : value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength)
+    ).toString("base64");
+  }
+
+  if (Array.isArray(value) || typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
+function coerceArrowValue(value, kind) {
+  if (value == null) return null;
+
+  if (kind === "number") {
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value === "bigint") {
+      return Number(value);
+    }
+    if (typeof value === "boolean") {
+      return value ? 1 : 0;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  if (kind === "boolean") {
+    if (typeof value === "boolean") return value;
+    if (typeof value === "number") return value !== 0;
+    if (typeof value === "bigint") return value !== 0n;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true" || normalized === "1") return true;
+      if (normalized === "false" || normalized === "0") return false;
+    }
+    return null;
+  }
+
+  if (kind === "time") {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    if (typeof value === "string") {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    return null;
+  }
+
+  return normalizeUtf8ArrowValue(value);
+}
+
+function deriveArrowColumnSpecs(columns, annotation = {}, sampleRows = []) {
+  return columns.map((column) => {
+    const kind = inferArrowKind(column, annotation, sampleRows);
+    return {
+      name: column,
+      kind,
+      arrowType: createArrowType(kind),
+    };
+  });
+}
+
+function createArrowRecordBatch(rows, columnSpecs) {
+  const vectors = Object.create(null);
+
+  for (let c = 0; c < columnSpecs.length; c++) {
+    const spec = columnSpecs[c];
+    const values = new Array(rows.length);
+
+    for (let r = 0; r < rows.length; r++) {
+      values[r] = coerceArrowValue(rows[r]?.[spec.name], spec.kind);
+    }
+
+    vectors[spec.name] = vectorFromArray(values, spec.arrowType);
+  }
+
+  return new RecordBatch(vectors);
+}
+
+export async function writeBinaryChunk(writable, chunk, signal) {
+  if (!chunk || chunk.length === 0) return;
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("Arrow output aborted.");
+  }
+  if (writable.destroyed || writable.writableEnded) {
+    throw new Error("Arrow output stream is not writable.");
+  }
+  if (writable.write(chunk)) return;
+
+  await new Promise((resolve, reject) => {
+    const cleanup = () => {
+      writable.off("drain", onDrain);
+      writable.off("close", onClose);
+      writable.off("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onDrain = () => {
+      cleanup();
+      resolve();
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error("Arrow output stream closed before it drained."));
+    };
+    const onError = (err) => {
+      cleanup();
+      reject(err);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(signal.reason ?? new Error("Arrow output aborted."));
+    };
+
+    writable.once("drain", onDrain);
+    writable.once("close", onClose);
+    writable.once("error", onError);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function writeRowStreamAsArrow(writable, rows, options = {}) {
+  let columns = Array.isArray(options.columns) ? options.columns.slice() : [];
+  const annotation = options.annotation || {};
+  const batchSize = options.batchSize ?? DEFAULT_ARROW_BATCH_SIZE;
+  const writer = new RecordBatchStreamWriter();
+  const pumpChunks = (async () => {
+    for await (const chunk of writer) {
+      await writeBinaryChunk(
+        writable,
+        Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+        options.signal
+      );
+    }
+  })();
+
+  let currentRows = [];
+  let columnSpecs = null;
+  let wroteBatch = false;
+
+  const flush = async () => {
+    if (currentRows.length === 0) return;
+    if (columns.length === 0) {
+      columns = Object.keys(currentRows[0] || {});
+    }
+    if (!columnSpecs) {
+      columnSpecs = deriveArrowColumnSpecs(columns, annotation, currentRows);
+    }
+    writer.write(createArrowRecordBatch(currentRows, columnSpecs));
+    wroteBatch = true;
+    currentRows = [];
+  };
+
+  try {
+    for await (const row of rows) {
+      currentRows.push(row);
+      if (currentRows.length >= batchSize) {
+        await flush();
+      }
+    }
+
+    if (!columnSpecs) {
+      columnSpecs = deriveArrowColumnSpecs(columns, annotation, currentRows);
+    }
+
+    if (currentRows.length > 0 || (!wroteBatch && columnSpecs.length > 0)) {
+      if (currentRows.length === 0) {
+        writer.write(createArrowRecordBatch([], columnSpecs));
+      } else {
+        await flush();
+      }
+    }
+
+    writer.finish();
+    await pumpChunks;
+  } catch (err) {
+    try {
+      writer.abort(err);
+    } catch {
+      // Ignore secondary abort failures while preserving the original error.
+    }
+    await pumpChunks.catch(() => {});
+    throw err;
+  }
 }

--- a/services/cubejs/src/utils/csvSerializer.js
+++ b/services/cubejs/src/utils/csvSerializer.js
@@ -171,3 +171,56 @@ export async function writeRowsAsCSV(writable, rows, options = {}) {
     await writeTextChunk(writable, chunkParts.join(""), options.signal);
   }
 }
+
+/**
+ * Write an async iterable of row objects as CSV to a writable stream.
+ *
+ * The header is emitted lazily when the first row arrives so empty result
+ * sets keep the current export behavior of returning an empty body.
+ *
+ * @param {{ write(chunk: string): boolean }} writable
+ * @param {AsyncIterable<Record<string, *>>} rows
+ * @param {Object} [options]
+ * @param {string[]} [options.columns]
+ * @param {number} [options.chunkSize]
+ * @param {AbortSignal} [options.signal]
+ * @returns {Promise<void>}
+ */
+export async function writeRowStreamAsCSV(writable, rows, options = {}) {
+  const chunkSize = options.chunkSize ?? DEFAULT_CSV_CHUNK_SIZE;
+  let columns = Array.isArray(options.columns) && options.columns.length > 0
+    ? options.columns
+    : null;
+  let wroteHeader = false;
+  let chunkParts = [];
+  let chunkLength = 0;
+
+  const flush = async () => {
+    if (chunkLength === 0) return;
+    await writeTextChunk(writable, chunkParts.join(""), options.signal);
+    chunkParts = [];
+    chunkLength = 0;
+  };
+
+  for await (const row of rows) {
+    if (!wroteHeader) {
+      if (!columns) {
+        columns = Object.keys(row);
+      }
+
+      chunkParts.push(headerToCSV(columns), "\r\n");
+      chunkLength += chunkParts[0].length + 2;
+      wroteHeader = true;
+    }
+
+    const line = rowToCSV(row, columns);
+    chunkParts.push(line, "\r\n");
+    chunkLength += line.length + 2;
+
+    if (chunkLength >= chunkSize) {
+      await flush();
+    }
+  }
+
+  await flush();
+}

--- a/services/cubejs/src/utils/loadExportCapabilities.js
+++ b/services/cubejs/src/utils/loadExportCapabilities.js
@@ -1,0 +1,38 @@
+function getNormalizedDbType(securityContext) {
+  const dbType = securityContext?.userScope?.dataSource?.dbType;
+  return typeof dbType === "string" ? dbType.toLowerCase() : null;
+}
+
+export function resolveLoadExportCapabilities(securityContext) {
+  const dbType = getNormalizedDbType(securityContext);
+
+  if (dbType === "clickhouse") {
+    return {
+      semanticRowStream: true,
+      nativeCsvPassthrough: true,
+      nativeArrowPassthrough: true,
+      incrementalArrowEncode: true,
+    };
+  }
+
+  return {
+    semanticRowStream: false,
+    nativeCsvPassthrough: false,
+    nativeArrowPassthrough: false,
+    incrementalArrowEncode: false,
+  };
+}
+
+export function canSemanticStreamLoadExport(format, capabilities) {
+  if (format === "csv") {
+    return Boolean(capabilities?.semanticRowStream);
+  }
+
+  if (format === "arrow") {
+    return Boolean(
+      capabilities?.semanticRowStream && capabilities?.incrementalArrowEncode
+    );
+  }
+
+  return false;
+}

--- a/services/cubejs/src/utils/loadExportUtils.js
+++ b/services/cubejs/src/utils/loadExportUtils.js
@@ -1,0 +1,87 @@
+export function addUniqueColumns(target, names) {
+  if (!Array.isArray(names)) return;
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    if (typeof name === "string" && !target.includes(name)) {
+      target.push(name);
+    }
+  }
+}
+
+export function normalizeLoadQuery(rawQuery) {
+  if (!rawQuery) return null;
+  if (typeof rawQuery === "string") {
+    try {
+      return JSON.parse(rawQuery);
+    } catch {
+      return null;
+    }
+  }
+  return rawQuery;
+}
+
+export function getLoadRequestFormat(req) {
+  return req.method === "POST" ? req.body?.format : req.query?.format;
+}
+
+export function getLoadRequestQuery(req) {
+  return normalizeLoadQuery(
+    req.method === "POST" ? req.body?.query : req.query?.query
+  );
+}
+
+export function applyLoadExportQueryLimit(req, queryLimit) {
+  const limit =
+    queryLimit ?? (parseInt(process.env.CUBEJS_DB_QUERY_LIMIT, 10) || 1000000);
+
+  if (req.method === "POST" && req.body?.query && !req.body.query.limit) {
+    req.body.query.limit = limit;
+    return;
+  }
+
+  if (req.method === "GET" && req.query?.query) {
+    const query = getLoadRequestQuery(req);
+    if (query && !query.limit) {
+      query.limit = limit;
+      req.query.query = JSON.stringify(query);
+    }
+  }
+}
+
+export function deriveExportColumnsFromLoad(query, annotation = {}, data = []) {
+  if (data.length > 0) {
+    return Object.keys(data[0]);
+  }
+
+  const columns = [];
+  const primaryQuery = Array.isArray(query) ? query[0] : query;
+
+  if (primaryQuery) {
+    addUniqueColumns(columns, primaryQuery.dimensions);
+    addUniqueColumns(
+      columns,
+      Array.isArray(primaryQuery.timeDimensions)
+        ? primaryQuery.timeDimensions.map((item) => {
+            if (typeof item === "string") {
+              return item;
+            }
+
+            if (item?.dimension && item?.granularity) {
+              return `${item.dimension}.${item.granularity}`;
+            }
+
+            return item?.dimension;
+          })
+        : []
+    );
+    addUniqueColumns(columns, primaryQuery.measures);
+  }
+
+  if (columns.length === 0) {
+    addUniqueColumns(columns, Object.keys(annotation.dimensions || {}));
+    addUniqueColumns(columns, Object.keys(annotation.timeDimensions || {}));
+    addUniqueColumns(columns, Object.keys(annotation.measures || {}));
+  }
+
+  return columns;
+}

--- a/services/cubejs/test/arrowSerializer.test.js
+++ b/services/cubejs/test/arrowSerializer.test.js
@@ -5,6 +5,7 @@ import { tableFromIPC } from "apache-arrow";
 import {
   rowsToArrowColumns,
   serializeRowsToArrow,
+  writeRowStreamAsArrow,
 } from "../src/utils/arrowSerializer.js";
 
 describe("arrowSerializer", () => {
@@ -49,4 +50,114 @@ describe("arrowSerializer", () => {
     assert.deepStrictEqual(columns.meta, ['{"a":1}', null]);
     assert.deepStrictEqual(columns.values, [[1, 2, null], null]);
   });
+
+  it("streams semantic rows as Arrow IPC batches", async () => {
+    const writable = new MockBinaryWritable();
+
+    await writeRowStreamAsArrow(
+      writable,
+      createRowStream([
+        {
+          city: "Reykjavik",
+          count: "2",
+          active: "true",
+          ts: "2024-01-01T00:00:00.000Z",
+        },
+        {
+          city: "Akureyri",
+          count: 1,
+          active: false,
+          ts: new Date("2024-01-02T00:00:00.000Z"),
+        },
+      ]),
+      {
+        columns: ["city", "count", "active", "ts"],
+        annotation: {
+          dimensions: {
+            city: { type: "string" },
+            active: { type: "boolean" },
+          },
+          measures: {
+            count: { type: "count" },
+          },
+          timeDimensions: {
+            ts: { type: "time" },
+          },
+        },
+      }
+    );
+
+    const table = tableFromIPC(writable.output);
+
+    assert.deepStrictEqual(
+      table.schema.fields.map((field) => field.type.toString()),
+      ["Utf8", "Float64", "Bool", "Timestamp<MILLISECOND>"]
+    );
+    assert.deepStrictEqual(table.toArray().map((row) => row.toJSON()), [
+      {
+        city: "Reykjavik",
+        count: 2,
+        active: true,
+        ts: Date.parse("2024-01-01T00:00:00.000Z"),
+      },
+      {
+        city: "Akureyri",
+        count: 1,
+        active: false,
+        ts: Date.parse("2024-01-02T00:00:00.000Z"),
+      },
+    ]);
+  });
+
+  it("emits a valid empty Arrow stream when columns are known", async () => {
+    const writable = new MockBinaryWritable();
+
+    await writeRowStreamAsArrow(writable, createRowStream([]), {
+      columns: ["city", "count"],
+      annotation: {
+        dimensions: {
+          city: { type: "string" },
+        },
+        measures: {
+          count: { type: "count" },
+        },
+      },
+    });
+
+    const table = tableFromIPC(writable.output);
+    assert.equal(table.numRows, 0);
+    assert.deepStrictEqual(
+      table.schema.fields.map((field) => [field.name, field.type.toString()]),
+      [
+        ["city", "Utf8"],
+        ["count", "Float64"],
+      ]
+    );
+  });
 });
+
+async function* createRowStream(rows) {
+  for (const row of rows) {
+    yield row;
+  }
+}
+
+class MockBinaryWritable {
+  constructor() {
+    this.output = Buffer.alloc(0);
+    this.destroyed = false;
+    this.writableEnded = false;
+  }
+
+  write(chunk) {
+    this.output = Buffer.concat([
+      this.output,
+      Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+    ]);
+    return true;
+  }
+
+  once() {}
+
+  off() {}
+}

--- a/services/cubejs/test/loadExport.test.js
+++ b/services/cubejs/test/loadExport.test.js
@@ -5,6 +5,10 @@ import { tableFromIPC } from "apache-arrow";
 
 import { maybeHandleLoadExport } from "../src/routes/loadExport.js";
 
+function decodeArrowFieldMappingHeader(value) {
+  return JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+}
+
 describe("maybeHandleLoadExport", () => {
   it("streams CSV through the semantic export path when native passthrough is unavailable", async () => {
     const req = createRequest({
@@ -99,7 +103,7 @@ describe("maybeHandleLoadExport", () => {
     );
   });
 
-  it("streams Arrow through the semantic export path when native passthrough is unsafe", async () => {
+  it("streams Arrow through the native ClickHouse path even when aliases are not semantic member names", async () => {
     const req = createRequest({
       format: "arrow",
       query: {
@@ -145,7 +149,7 @@ describe("maybeHandleLoadExport", () => {
         values: [],
       },
       driver: createClickHouseDriver({
-        arrowChunks: [Buffer.from("native-arrow-should-not-be-used")],
+        arrowChunks: [Buffer.from("native-arrow-stream-binary")],
       }),
     });
 
@@ -157,15 +161,25 @@ describe("maybeHandleLoadExport", () => {
       res.headers["Content-Type"],
       "application/vnd.apache.arrow.stream"
     );
-
-    const parsed = tableFromIPC(res.binaryOutput);
-    assert.deepEqual(parsed.toArray().map((row) => row.toJSON()), [
+    assert.deepEqual(
+      decodeArrowFieldMappingHeader(
+        res.headers["X-Synmetrix-Arrow-Field-Mapping"]
+      ),
       {
-        "Orders.city": "Reykjavik",
-        "Orders.count": 2,
-        "Orders.createdAt.day": Date.parse("2024-01-01T00:00:00.000Z"),
-      },
-    ]);
+        city_alias: "Orders.city",
+        count_alias: "Orders.count",
+        created_day_alias: "Orders.createdAt.day",
+      }
+    );
+    assert.equal(
+      res.headers["X-Synmetrix-Arrow-Field-Mapping-Encoding"],
+      "base64url-json"
+    );
+    assert.match(
+      res.headers["Access-Control-Expose-Headers"],
+      /X-Synmetrix-Arrow-Field-Mapping/
+    );
+    assert.deepEqual(res.binaryOutput, Buffer.from("native-arrow-stream-binary"));
   });
 
   it("streams Arrow through the native ClickHouse path when aliases are already semantic", async () => {
@@ -208,7 +222,85 @@ describe("maybeHandleLoadExport", () => {
       res.headers["Content-Type"],
       "application/vnd.apache.arrow.stream"
     );
+    assert.equal(res.headers["X-Synmetrix-Arrow-Field-Mapping"], undefined);
     assert.deepEqual(res.binaryOutput, nativeArrowBuffer);
+  });
+
+  it("streams Arrow through the semantic export path when native ClickHouse export is unavailable", async () => {
+    const req = createRequest({
+      format: "arrow",
+      query: {
+        dimensions: ["Orders.city"],
+        measures: ["Orders.count"],
+        timeDimensions: [{ dimension: "Orders.createdAt", granularity: "day" }],
+      },
+    });
+    const res = new MockResponse();
+
+    const cubejs = createMockCube({
+      dbType: "clickhouse",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city_alias, count_alias, created_day_alias FROM orders", []],
+        aliasNameToMember: {
+          city_alias: "Orders.city",
+          count_alias: "Orders.count",
+          created_day_alias: "Orders.createdAt.day",
+        },
+      },
+      metaConfig: createMetaConfig({
+        measures: [{ name: "Orders.count", type: "count" }],
+        dimensions: [
+          { name: "Orders.city", type: "string" },
+          {
+            name: "Orders.createdAt",
+            type: "time",
+            granularities: [{ name: "day", title: "day", interval: "1 day" }],
+          },
+          { name: "Orders.createdAt.day", type: "time" },
+        ],
+      }),
+      streamRows: [
+        {
+          "Orders.city": "Reykjavik",
+          "Orders.count": "2",
+          "Orders.createdAt.day": "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      nativePreAggs: {
+        preAggregationsTablesToTempTables: [
+          [
+            "orders_rollup",
+            {
+              lambdaTable: { name: "orders_lambda" },
+            },
+          ],
+        ],
+        values: [],
+      },
+      driver: createClickHouseDriver({
+        arrowChunks: [Buffer.from("native-arrow-should-not-be-used")],
+      }),
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      throw new Error("next should not be called");
+    }, cubejs);
+
+    assert.equal(
+      res.headers["Content-Type"],
+      "application/vnd.apache.arrow.stream"
+    );
+    assert.equal(res.headers["X-Synmetrix-Arrow-Field-Mapping"], undefined);
+
+    const parsed = tableFromIPC(res.binaryOutput);
+    assert.deepEqual(parsed.toArray().map((row) => row.toJSON()), [
+      {
+        "Orders.city": "Reykjavik",
+        "Orders.count": 2,
+        "Orders.createdAt.day": Date.parse("2024-01-01T00:00:00.000Z"),
+      },
+    ]);
   });
 
   it("falls through to the buffered path when semantic streaming is unavailable", async () => {

--- a/services/cubejs/test/loadExport.test.js
+++ b/services/cubejs/test/loadExport.test.js
@@ -1,0 +1,466 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { tableFromIPC } from "apache-arrow";
+
+import { maybeHandleLoadExport } from "../src/routes/loadExport.js";
+
+describe("maybeHandleLoadExport", () => {
+  it("streams CSV through the semantic export path when native passthrough is unavailable", async () => {
+    const req = createRequest({
+      format: "csv",
+      query: {
+        dimensions: ["Orders.city"],
+        measures: ["Orders.count"],
+      },
+    });
+    const res = new MockResponse();
+    let nextCalls = 0;
+
+    const cubejs = createMockCube({
+      dbType: "clickhouse",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city AS city, count AS count FROM orders", []],
+        aliasNameToMember: {
+          city: "Orders.city",
+          count: "Orders.count",
+        },
+      },
+      metaConfig: createMetaConfig({
+        measures: [{ name: "Orders.count", type: "count" }],
+        dimensions: [{ name: "Orders.city", type: "string" }],
+      }),
+      streamRows: [
+        { "Orders.city": "Reykjavik", "Orders.count": 2 },
+        { "Orders.city": "Akureyri", "Orders.count": 1 },
+      ],
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      nextCalls++;
+    }, cubejs);
+
+    assert.equal(nextCalls, 0);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["Content-Type"], "text/csv");
+    assert.equal(
+      res.textOutput,
+      "Orders.city,Orders.count\r\nReykjavik,2\r\nAkureyri,1\r\n"
+    );
+  });
+
+  it("streams CSV through the native ClickHouse path and rewrites the header to semantic names", async () => {
+    const req = createRequest({
+      format: "csv",
+      query: {
+        dimensions: ["Orders.city"],
+        measures: ["Orders.count"],
+      },
+    });
+    const res = new MockResponse();
+
+    const cubejs = createMockCube({
+      dbType: "clickhouse",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city AS city_alias, count AS count_alias FROM orders", []],
+        aliasNameToMember: {
+          city_alias: "Orders.city",
+          count_alias: "Orders.count",
+        },
+      },
+      metaConfig: createMetaConfig({
+        measures: [{ name: "Orders.count", type: "count" }],
+        dimensions: [{ name: "Orders.city", type: "string" }],
+      }),
+      nativePreAggs: {
+        preAggregationsTablesToTempTables: [],
+        values: [],
+      },
+      driver: createClickHouseDriver({
+        csvLines: [
+          "city_alias,count_alias\n",
+          "Reykjavik,2\n",
+          "Akureyri,1\n",
+        ],
+      }),
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      throw new Error("next should not be called");
+    }, cubejs);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["Content-Type"], "text/csv");
+    assert.equal(
+      res.textOutput,
+      "Orders.city,Orders.count\r\nReykjavik,2\r\nAkureyri,1\r\n"
+    );
+  });
+
+  it("streams Arrow through the semantic export path when native passthrough is unsafe", async () => {
+    const req = createRequest({
+      format: "arrow",
+      query: {
+        dimensions: ["Orders.city"],
+        measures: ["Orders.count"],
+        timeDimensions: [{ dimension: "Orders.createdAt", granularity: "day" }],
+      },
+    });
+    const res = new MockResponse();
+
+    const cubejs = createMockCube({
+      dbType: "clickhouse",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city_alias, count_alias, created_day_alias FROM orders", []],
+        aliasNameToMember: {
+          city_alias: "Orders.city",
+          count_alias: "Orders.count",
+          created_day_alias: "Orders.createdAt.day",
+        },
+      },
+      metaConfig: createMetaConfig({
+        measures: [{ name: "Orders.count", type: "count" }],
+        dimensions: [
+          { name: "Orders.city", type: "string" },
+          {
+            name: "Orders.createdAt",
+            type: "time",
+            granularities: [{ name: "day", title: "day", interval: "1 day" }],
+          },
+          { name: "Orders.createdAt.day", type: "time" },
+        ],
+      }),
+      streamRows: [
+        {
+          "Orders.city": "Reykjavik",
+          "Orders.count": "2",
+          "Orders.createdAt.day": "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      nativePreAggs: {
+        preAggregationsTablesToTempTables: [],
+        values: [],
+      },
+      driver: createClickHouseDriver({
+        arrowChunks: [Buffer.from("native-arrow-should-not-be-used")],
+      }),
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      throw new Error("next should not be called");
+    }, cubejs);
+
+    assert.equal(
+      res.headers["Content-Type"],
+      "application/vnd.apache.arrow.stream"
+    );
+
+    const parsed = tableFromIPC(res.binaryOutput);
+    assert.deepEqual(parsed.toArray().map((row) => row.toJSON()), [
+      {
+        "Orders.city": "Reykjavik",
+        "Orders.count": 2,
+        "Orders.createdAt.day": Date.parse("2024-01-01T00:00:00.000Z"),
+      },
+    ]);
+  });
+
+  it("streams Arrow through the native ClickHouse path when aliases are already semantic", async () => {
+    const req = createRequest({
+      format: "arrow",
+      query: {
+        dimensions: ["Orders.city"],
+      },
+    });
+    const res = new MockResponse();
+
+    const nativeArrowBuffer = Buffer.from("arrow-stream-binary");
+
+    const cubejs = createMockCube({
+      dbType: "clickhouse",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city FROM orders", []],
+        aliasNameToMember: {
+          "Orders.city": "Orders.city",
+        },
+      },
+      metaConfig: createMetaConfig({
+        dimensions: [{ name: "Orders.city", type: "string" }],
+      }),
+      nativePreAggs: {
+        preAggregationsTablesToTempTables: [],
+        values: [],
+      },
+      driver: createClickHouseDriver({
+        arrowChunks: [nativeArrowBuffer],
+      }),
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      throw new Error("next should not be called");
+    }, cubejs);
+
+    assert.equal(
+      res.headers["Content-Type"],
+      "application/vnd.apache.arrow.stream"
+    );
+    assert.deepEqual(res.binaryOutput, nativeArrowBuffer);
+  });
+
+  it("falls through to the buffered path when semantic streaming is unavailable", async () => {
+    const req = createRequest({
+      format: "csv",
+      query: {
+        dimensions: ["Orders.city"],
+      },
+    });
+    const res = new MockResponse();
+    let nextCalls = 0;
+
+    const cubejs = createMockCube({
+      dbType: "postgres",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city FROM orders", []],
+      },
+      metaConfig: createMetaConfig({
+        dimensions: [{ name: "Orders.city", type: "string" }],
+      }),
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      nextCalls++;
+    }, cubejs);
+
+    assert.equal(nextCalls, 1);
+    assert.equal(res.textOutput, "");
+    assert.equal(res.headersSent, false);
+  });
+
+  it("falls through to the buffered path for non-regular query shapes", async () => {
+    const req = createRequest({
+      format: "csv",
+      query: {
+        dimensions: ["Orders.city"],
+      },
+    });
+    const res = new MockResponse();
+    let nextCalls = 0;
+
+    const cubejs = createMockCube({
+      dbType: "clickhouse",
+      queryType: "compareDateRangeQuery",
+      normalizedQuery: req.body.query,
+      sqlQuery: {
+        sql: ["SELECT city FROM orders", []],
+      },
+      metaConfig: createMetaConfig({
+        dimensions: [{ name: "Orders.city", type: "string" }],
+      }),
+    });
+
+    await maybeHandleLoadExport(req, res, () => {
+      nextCalls++;
+    }, cubejs);
+
+    assert.equal(nextCalls, 1);
+    assert.equal(res.headersSent, false);
+  });
+});
+
+function createRequest({ format, query }) {
+  return {
+    method: "POST",
+    body: { format, query },
+    headers: {},
+    get(name) {
+      return this.headers[name.toLowerCase()];
+    },
+  };
+}
+
+function createMetaConfig({ measures = [], dimensions = [], segments = [] }) {
+  return [
+    {
+      config: {
+        measures: measures.map((measure) => ({
+          title: measure.name,
+          shortTitle: measure.name,
+          description: "",
+          isVisible: true,
+          ...measure,
+        })),
+        dimensions: dimensions.map((dimension) => ({
+          title: dimension.name,
+          shortTitle: dimension.name,
+          description: "",
+          isVisible: true,
+          ...dimension,
+        })),
+        segments: segments.map((segment) => ({
+          title: segment.name,
+          shortTitle: segment.name,
+          description: "",
+          isVisible: true,
+          ...segment,
+        })),
+      },
+    },
+  ];
+}
+
+function createMockCube(options) {
+  const {
+    dbType,
+    queryType = "regularQuery",
+    normalizedQuery,
+    sqlQuery,
+    metaConfig,
+    streamRows = [],
+    nativePreAggs = null,
+    driver = null,
+  } = options;
+
+  return {
+    options: {
+      driverFactory: async () => {
+        if (!driver) {
+          throw new Error("driverFactory should not be called in this test");
+        }
+        return driver;
+      },
+    },
+    apiGateway() {
+      return {
+        checkAuth: async (request, response, next) => {
+          request.securityContext = {
+            userScope: {
+              dataSource: {
+                dbType,
+              },
+            },
+          };
+          next();
+        },
+        requestContextMiddleware: async (request, response, next) => {
+          request.context = {
+            securityContext: request.securityContext,
+            requestId: "req-1",
+          };
+          next();
+        },
+        assertApiScope: async () => {},
+        getNormalizedQueries: async () => [queryType, [normalizedQuery]],
+        getCompilerApi: async () => ({
+          metaConfig: async () => metaConfig,
+        }),
+        filterVisibleItemsInMeta: (context, cubes) => cubes,
+        getSqlQueriesInternal: async () => [sqlQuery],
+        getAdapterApi: async () => ({
+          streamQuery: async () => createRowStream(streamRows),
+          getQueryOrchestrator: nativePreAggs
+            ? () => ({
+                getPreAggregations: () => ({
+                  loadAllPreAggregationsIfNeeded: async () => nativePreAggs,
+                }),
+              })
+            : undefined,
+        }),
+      };
+    },
+    async contextRejectionMiddleware() {},
+  };
+}
+
+function createClickHouseDriver({ csvLines = [], arrowChunks = [] }) {
+  return {
+    config: {
+      clickhouseSettings: {},
+    },
+    client: {
+      query: async () => ({
+        async *stream() {
+          for (const line of csvLines) {
+            yield [{ text: line }];
+          }
+        },
+      }),
+      exec: async () => ({
+        async *stream() {
+          for (const chunk of arrowChunks) {
+            yield chunk;
+          }
+        },
+      }),
+    },
+  };
+}
+
+async function* createRowStream(rows) {
+  for (const row of rows) {
+    yield row;
+  }
+}
+
+class MockResponse extends EventEmitter {
+  constructor() {
+    super();
+    this.headers = {};
+    this.textOutput = "";
+    this.binaryOutput = Buffer.alloc(0);
+    this.statusCode = 200;
+    this.headersSent = false;
+    this.writableEnded = false;
+    this.destroyed = false;
+  }
+
+  set(nameOrHeaders, value) {
+    if (typeof nameOrHeaders === "string") {
+      this.headers[nameOrHeaders] = value;
+      return this;
+    }
+
+    Object.assign(this.headers, nameOrHeaders);
+    return this;
+  }
+
+  status(code) {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(obj) {
+    this.headersSent = true;
+    this.textOutput = JSON.stringify(obj);
+    this.writableEnded = true;
+    this.emit("finish");
+    return this;
+  }
+
+  write(chunk) {
+    this.headersSent = true;
+
+    if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      this.binaryOutput = Buffer.concat([this.binaryOutput, buffer]);
+      return true;
+    }
+
+    this.textOutput += chunk;
+    return true;
+  }
+
+  end(chunk = "") {
+    if (chunk) {
+      this.write(chunk);
+    }
+    this.headersSent = true;
+    this.writableEnded = true;
+    this.emit("finish");
+    return this;
+  }
+}

--- a/services/cubejs/test/loadExportCapabilities.test.js
+++ b/services/cubejs/test/loadExportCapabilities.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  canSemanticStreamLoadExport,
+  resolveLoadExportCapabilities,
+} from "../src/utils/loadExportCapabilities.js";
+
+describe("resolveLoadExportCapabilities", () => {
+  it("enables semantic row streaming for ClickHouse", () => {
+    const capabilities = resolveLoadExportCapabilities({
+      userScope: {
+        dataSource: {
+          dbType: "clickhouse",
+        },
+      },
+    });
+
+    assert.deepEqual(capabilities, {
+      semanticRowStream: true,
+      nativeCsvPassthrough: true,
+      nativeArrowPassthrough: true,
+      incrementalArrowEncode: true,
+    });
+  });
+
+  it("falls back to buffered capabilities for other databases", () => {
+    const capabilities = resolveLoadExportCapabilities({
+      userScope: {
+        dataSource: {
+          dbType: "postgres",
+        },
+      },
+    });
+
+    assert.deepEqual(capabilities, {
+      semanticRowStream: false,
+      nativeCsvPassthrough: false,
+      nativeArrowPassthrough: false,
+      incrementalArrowEncode: false,
+    });
+  });
+});
+
+describe("canSemanticStreamLoadExport", () => {
+  it("allows CSV when semantic row streaming is available", () => {
+    assert.equal(
+      canSemanticStreamLoadExport("csv", {
+        semanticRowStream: true,
+        incrementalArrowEncode: false,
+      }),
+      true
+    );
+  });
+
+  it("allows Arrow when an incremental encoder exists", () => {
+    assert.equal(
+      canSemanticStreamLoadExport("arrow", {
+        semanticRowStream: true,
+        incrementalArrowEncode: true,
+      }),
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep native ClickHouse Arrow passthrough enabled for /load exports even when Cube aliases differ from semantic member names
- attach a base64url JSON response header that maps Arrow field names back to semantic member names
- expose the mapping headers to browser clients

## Validation
- `node --test test/loadExport.test.js test/arrowSerializer.test.js test/csvSerializer.test.js test/loadExportCapabilities.test.js`

## Notes
- this is the follow-up needed to make native Arrow passthrough viable without rewriting Arrow schema bytes