### PR TITLE
Fix team settings overwrite and member query access

### DIFF
--- a/services/actions/src/rpc/updateTeamSettings.js
+++ b/services/actions/src/rpc/updateTeamSettings.js
@@ -3,6 +3,14 @@ import { invalidateAllUserCaches } from "../utils/cubeCache.js";
 import { fetchGraphQL } from "../utils/graphql.js";
 import { isPortalAdmin } from "../utils/portalAdmin.js";
 
+const getTeamQuery = `
+  query GetTeamSettings($team_id: uuid!) {
+    teams_by_pk(id: $team_id) {
+      settings
+    }
+  }
+`;
+
 const updateTeamSettingsMutation = `
   mutation ($team_id: uuid!, $settings: jsonb!) {
     update_teams_by_pk(pk_columns: {id: $team_id}, _set: {settings: $settings}) {
@@ -94,10 +102,22 @@ export default async (session, input, headers) => {
       };
     }
 
+    // Read current settings and merge to avoid overwriting existing keys
+    const currentRes = await fetchGraphQL(getTeamQuery, { team_id: teamId });
+    const currentSettings = currentRes?.data?.teams_by_pk?.settings || {};
+    const merged = { ...currentSettings };
+    for (const [key, value] of Object.entries(settings)) {
+      if (value === null) {
+        delete merged[key];
+      } else {
+        merged[key] = value;
+      }
+    }
+
     // Update team settings
     const res = await fetchGraphQL(
       updateTeamSettingsMutation,
-      { team_id: teamId, settings },
+      { team_id: teamId, settings: merged },
       headers?.authorization
     );
 

--- a/services/cubejs/src/utils/defineUserScope.js
+++ b/services/cubejs/src/utils/defineUserScope.js
@@ -16,11 +16,13 @@ export const getDataSourceAccessList = (
   }
 
   const { access_list: accessList } = dataSourceMemberRole;
+  const hasAccessList = accessList != null;
   const dataSourceAccessList =
     accessList?.config?.datasources?.[selectedDataSourceId]?.cubes;
 
   return {
     role: dataSourceMemberRole?.team_role,
+    hasAccessList,
     dataSourceAccessList,
   };
 };

--- a/services/cubejs/src/utils/queryRewrite.js
+++ b/services/cubejs/src/utils/queryRewrite.js
@@ -75,7 +75,7 @@ function extractCubeNames(query) {
  */
 const queryRewrite = async (query, { securityContext }) => {
   const { userScope } = securityContext;
-  const { dataSourceAccessList, role, teamProperties, memberProperties } = userScope;
+  const { dataSourceAccessList, hasAccessList, role, teamProperties, memberProperties } = userScope;
 
   // --- Step 1: Rule-based row filtering (applies to ALL roles) ---
   const rules = await loadRules();
@@ -139,6 +139,14 @@ const queryRewrite = async (query, { securityContext }) => {
     return query;
   }
 
+  // No access list assigned (access_list_id is NULL) → no restrictions configured.
+  // Auto-provisioned members start without an access list and get full access
+  // until an admin explicitly assigns one to scope their permissions.
+  if (!hasAccessList) {
+    return query;
+  }
+
+  // Access list IS assigned but has no entry for this datasource → deny.
   if (!dataSourceAccessList) {
     throw new Error("403: You have no access to the datasource");
   }


### PR DESCRIPTION
## Summary
- **Team settings overwrite bug**: `updateTeamSettings` RPC was replacing the entire `settings` JSONB column instead of merging, wiping keys like `partition`. Now reads existing settings and merges (matching the `updateTeamProperties` pattern).
- **Member query 403 bug**: Auto-provisioned WorkOS members got `team_role=member` with no `access_list` assigned, causing `queryRewrite` to throw 403. Now distinguishes `access_list_id=NULL` (no restrictions → allow) from an assigned access list missing the datasource (explicitly scoped → deny). Write operations remain blocked by Hasura RLS for non-admin roles.

## Test plan
- [ ] Login as a non-admin team member via WorkOS and run a Cube.js query (`/api/v1/load`) — should succeed
- [ ] Assign an access list to that member scoped to specific cubes — queries outside scope should 403
- [ ] Update team settings (e.g. `internal_tables`) as team owner — verify `partition` is preserved
- [ ] Verify admin/owner queries still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)