### PR TITLE
010: Filter discover endpoint by JWT partition, remap dev ports

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
     image: redis:7.0.0
     restart: always
     ports:
-      - 6379:6379
+      - 6381:6379
     networks:
       - synmetrix_default
 
@@ -36,7 +36,7 @@ services:
       - ./services/actions/src:/app/src
       - ./services/actions/index.js:/app/index.js
     ports:
-      - 3000:3000
+      - 3001:3000
     env_file:
       - .env
       - .dev.env

--- a/services/cubejs/src/routes/__tests__/discover.test.js
+++ b/services/cubejs/src/routes/__tests__/discover.test.js
@@ -1,7 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { extractCubes, buildDiscoverResponse } from "../discover.js";
+import {
+  extractCubes,
+  buildDiscoverResponse,
+  resolvePartitionTeamIds,
+} from "../discover.js";
 
 // --- Helpers ---
 
@@ -235,5 +239,72 @@ describe("buildDiscoverResponse", () => {
     assert.equal(result[0].branch_id, "br-1");
     assert.equal(result[0].version_id, null);
     assert.deepEqual(result[0].cubes, []);
+  });
+
+  it("filters datasources by partition team IDs", () => {
+    const dataSources = [
+      makeDatasource("ds-a", "match", [yamlSchema("a.yml", [{ name: "A" }])], {
+        team_id: "team-1",
+      }),
+      makeDatasource("ds-b", "other", [yamlSchema("b.yml", [{ name: "B" }])], {
+        team_id: "team-2",
+      }),
+    ];
+    const partitionTeamIds = new Set(["team-1"]);
+    const result = buildDiscoverResponse(dataSources, partitionTeamIds);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "ds-a");
+  });
+
+  it("returns all datasources when no partitionTeamIds provided", () => {
+    const dataSources = [
+      makeDatasource("ds-a", "a", [], { team_id: "team-1" }),
+      makeDatasource("ds-b", "b", [], { team_id: "team-2" }),
+    ];
+    const result = buildDiscoverResponse(dataSources, null);
+    assert.equal(result.length, 2);
+  });
+});
+
+// --- resolvePartitionTeamIds ---
+
+describe("resolvePartitionTeamIds", () => {
+  it("returns team IDs matching the partition", () => {
+    const members = [
+      { team_id: "t1", team: { settings: { partition: "blue.is" } } },
+      { team_id: "t2", team: { settings: { partition: "other.co" } } },
+      { team_id: "t3", team: { settings: { partition: "blue.is" } } },
+    ];
+    const ids = resolvePartitionTeamIds(members, "blue.is");
+    assert.equal(ids.size, 2);
+    assert.ok(ids.has("t1"));
+    assert.ok(ids.has("t3"));
+    assert.ok(!ids.has("t2"));
+  });
+
+  it("returns null when no partition in token", () => {
+    const members = [
+      { team_id: "t1", team: { settings: { partition: "blue.is" } } },
+    ];
+    assert.equal(resolvePartitionTeamIds(members, undefined), null);
+    assert.equal(resolvePartitionTeamIds(members, null), null);
+  });
+
+  it("returns empty set when no teams match", () => {
+    const members = [
+      { team_id: "t1", team: { settings: { partition: "other.co" } } },
+    ];
+    const ids = resolvePartitionTeamIds(members, "blue.is");
+    assert.equal(ids.size, 0);
+  });
+
+  it("handles teams with no settings", () => {
+    const members = [
+      { team_id: "t1", team: { settings: null } },
+      { team_id: "t2", team: {} },
+      { team_id: "t3" },
+    ];
+    const ids = resolvePartitionTeamIds(members, "blue.is");
+    assert.equal(ids.size, 0);
   });
 });

--- a/services/cubejs/src/routes/discover.js
+++ b/services/cubejs/src/routes/discover.js
@@ -37,10 +37,28 @@ export function extractCubes(schema) {
 }
 
 /**
- * Build the datasources response from findUser result.
+ * Build a set of team IDs whose partition matches the JWT partition claim.
  */
-export function buildDiscoverResponse(dataSources) {
-  return dataSources.map((ds) => {
+export function resolvePartitionTeamIds(members, partition) {
+  if (!partition) return null; // no filtering if no partition in token
+  const ids = new Set();
+  for (const member of members) {
+    if (member.team?.settings?.partition === partition) {
+      ids.add(member.team_id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Build the datasources response from findUser result.
+ * When partitionTeamIds is provided, only include datasources from those teams.
+ */
+export function buildDiscoverResponse(dataSources, partitionTeamIds) {
+  const filtered = partitionTeamIds
+    ? dataSources.filter((ds) => partitionTeamIds.has(ds.team_id))
+    : dataSources;
+  return filtered.map((ds) => {
     const activeBranch =
       ds.branches?.find((b) => b.status === "active") || ds.branches?.[0];
     const latestVersion = activeBranch?.versions?.[0] || null;
@@ -103,7 +121,15 @@ export default async function discover(req, res) {
       return res.json({ datasources: [] });
     }
 
-    res.json({ datasources: buildDiscoverResponse(user.dataSources) });
+    // Only return datasources from the team matching the JWT partition claim
+    const partitionTeamIds = resolvePartitionTeamIds(
+      user.members,
+      payload.partition
+    );
+
+    res.json({
+      datasources: buildDiscoverResponse(user.dataSources, partitionTeamIds),
+    });
   } catch (err) {
     const status = err.status || 500;
     if (status >= 500) {


### PR DESCRIPTION
## Summary
- **Discover endpoint partition filtering**: `GET /api/v1/discover` now only returns datasources from the team whose `settings.partition` matches the JWT `partition` claim, instead of all teams the user belongs to
- **Dev port remapping**: Actions 3000→3001, Redis 6379→6381 in docker-compose.dev.yml to avoid conflicts with other local services

## Context
Follow-up to #27 (merged). The discover endpoint was returning datasources across all team memberships. Now it correctly scopes results to the team identified by the WorkOS JWT partition claim.

## Test plan
- [x] 19 unit tests passing (added resolvePartitionTeamIds + partition filtering tests)
- [x] Live-tested with WorkOS token — response filtered from 4 datasources to 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)