### PR TITLE
Fix teams_name_unique constraint for Hasura on_conflict

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -103,6 +103,7 @@ services:
     environment:
       ENABLE_TELEMETRY: "false"
       CONSOLE_MODE: cli
+      HASURA_GRAPHQL_MIGRATIONS_SERVER_TIMEOUT: "120"
     volumes:
       - ./services/hasura/migrations:/hasura/migrations
       - ./services/hasura/metadata:/hasura/metadata

--- a/services/hasura/migrations/1741520400001_fix_teams_name_unique_constraint/down.sql
+++ b/services/hasura/migrations/1741520400001_fix_teams_name_unique_constraint/down.sql
@@ -1,0 +1,3 @@
+-- Revert to expression index (note: this will re-break Hasura on_conflict)
+ALTER TABLE public.teams DROP CONSTRAINT IF EXISTS teams_name_unique;
+CREATE UNIQUE INDEX teams_name_unique ON public.teams (lower(trim(name)));

--- a/services/hasura/migrations/1741520400001_fix_teams_name_unique_constraint/up.sql
+++ b/services/hasura/migrations/1741520400001_fix_teams_name_unique_constraint/up.sql
@@ -1,0 +1,15 @@
+-- Fix: expression index cannot be used as Hasura on_conflict constraint target.
+-- The expression index created by 1709836800001 breaks:
+--   on_conflict: { constraint: teams_name_unique, update_columns: [] }
+-- in the team auto-provisioning mutation (dataSourceHelpers.js).
+--
+-- Application code (deriveTeamName, findTeamByName) already normalizes
+-- names to lower(trim(name)) before insert/lookup, so a plain constraint
+-- is sufficient and Hasura-compatible.
+
+-- Normalize any names that slipped through without lowering/trimming
+UPDATE public.teams SET name = lower(trim(name)) WHERE name != lower(trim(name));
+
+-- Drop the expression index and replace with a plain unique constraint
+DROP INDEX IF EXISTS public.teams_name_unique;
+ALTER TABLE public.teams ADD CONSTRAINT teams_name_unique UNIQUE (name);


### PR DESCRIPTION
## Summary

- **Migration `1741520400001`**: Replaces the expression index `lower(trim(name))` on `teams` with a plain `UNIQUE` constraint. The expression index (from migration `1709836800001`) cannot be used as a Hasura `on_conflict` target, which broke team auto-provisioning in `dataSourceHelpers.js`. Application code already normalizes names to `lower(trim())` before insert, so a plain constraint is sufficient.
- **docker-compose.dev.yml**: Increases `hasura_cli` migrations server timeout from 30s → 120s to prevent restart loops when applying large migration sets on cold start.

## Context

This was discovered as a cluster incident requiring manual DDL fixes. The expression index silently broke the `insert_teams_one(..., on_conflict: { constraint: teams_name_unique })` mutation — Hasura requires an actual constraint, not an expression index, for `on_conflict` targets.

### Cluster fixes this prevents from recurring

| Fix | Addressed |
|-----|-----------|
| teams DDL (expression index → constraint) | ✅ Migration |
| hasura_cli restart loop | ✅ Timeout increase |
| Pre-aggregation `external: true` patches | ❌ User-defined schemas in DB, not code |
| Version checksum resets | ❌ Operational, by-design cache behavior |
| Hasura metadata restore after untrack | ❌ One-time incident, metadata in repo is correct |

## Test plan

- [x] Applied migration locally — verified `pg_constraint` shows `teams_name_unique` as type `u` (unique constraint)
- [x] Tested Hasura `insert_teams_one` with `on_conflict: { constraint: teams_name_unique }` — returns `null` (no-op) for existing team, no error
- [x] Verified `hasura_cli` starts and reaches healthy state with the timeout increase

🤖 Generated with [Claude Code](https://claude.com/claude-code)