### PR TITLE
fix(cubejs): match checkSqlAuth signature to Cube.js v1.6

### DIFF
--- a/services/cubejs/src/utils/checkSqlAuth.js
+++ b/services/cubejs/src/utils/checkSqlAuth.js
@@ -36,19 +36,33 @@ const buildSqlSecurityContext = (sqlCredentials) => {
 
 /**
  * Check SQL authentication for a user.
- * Supports two authentication methods:
- * 1. WorkOS JWT as password (new): password is a JWT, username is datasource ID
- * 2. Legacy sql_credentials lookup (existing): username/password from sql_credentials table
  *
- * @param {null} _ - Unused parameter.
- * @param {Object} user - The user object with username and password.
- * @returns {Promise} - Resolves to { password, securityContext }
+ * Cube.js v1.6 invokes this callback as `checkSqlAuth(request, user, password)`
+ * (see @cubejs-backend/api-gateway/dist/src/sql-server.js — the callback is
+ * wrapped with three positional args). Earlier builds passed a single object
+ * `{ username, password }`; the defensive branches below keep backward-
+ * compatibility with that older shape.
+ *
+ * Supports two authentication methods:
+ * 1. WorkOS / FraiOS JWT as password: password is a JWT, username is the datasource ID
+ * 2. Legacy sql_credentials lookup: username/password from the sql_credentials table
+ *
+ * @param {Object} request - Cube.js SQL request metadata (protocol, method, apiType)
+ * @param {string|Object} userArg - Username string (v1.6+) or legacy { username, password } object
+ * @param {string} [passwordArg] - Password string (v1.6+); absent in legacy object-shape calls
+ * @returns {Promise<{ password: string, securityContext: Object }>}
  */
-const checkSqlAuth = async (_, user) => {
-  const password = typeof user === "string" ? user : user?.password;
-  const username = typeof user === "string" ? _ : user?.username;
+const checkSqlAuth = async (request, userArg, passwordArg) => {
+  // Resolve the two shapes Cube has used for this callback:
+  //   new: (request, username: string, password: string)
+  //   legacy: (_req, { username, password })
+  const username =
+    typeof userArg === "string" ? userArg : userArg?.username;
+  const password =
+    passwordArg ??
+    (typeof userArg === "string" ? undefined : userArg?.password);
 
-  // Detect if password looks like a JWT (WorkOS RS256)
+  // Detect if password looks like a JWT (WorkOS RS256 / FraiOS HS256)
   if (password && password.includes(".") && password.split(".").length === 3) {
     const tokenType = detectTokenType(password);
 
@@ -134,8 +148,12 @@ const checkSqlAuth = async (_, user) => {
     }
   }
 
-  // Legacy sql_credentials path (unchanged)
-  const sqlCredentials = await findSqlCredentials(username || user);
+  // Legacy sql_credentials path — lookup by the plaintext username.
+  // Cube.js compares the supplied password against `password` in the return value.
+  if (!username || typeof username !== "string") {
+    throw new Error("Incorrect user name or password");
+  }
+  const sqlCredentials = await findSqlCredentials(username);
 
   return {
     password: sqlCredentials?.password,


### PR DESCRIPTION
## Summary

- Fix `checkSqlAuth` callback signature — Cube.js v1.6 passes `(request, user, password)` as three positional args; our code expected `(_, user)` and treated the username string as the password.
- Unblocks Postgres / MySQL wire auth against the CubeJS SQL API.

## Root cause

`@cubejs-backend/api-gateway/dist/src/sql-server.js:291,105` wraps the callback and always calls it with three positional args. When a Postgres client connects (e.g. `psql -U e0m19ghdz9`), Cube hands us:

```
request  = { protocol: "postgres", method: "password", apiType: "sql" }
user     = "e0m19ghdz9"
password = "<client-supplied>"
```

The existing code:

```js
const checkSqlAuth = async (_, user) => {
  const password = typeof user === "string" ? user : user?.password;
  const username = typeof user === "string" ? _    : user?.username;
  ...
  const sqlCredentials = await findSqlCredentials(username || user);
}
```

With `user` being a string, this assigned the *username string* to `password` and the *request object* to `username`. `findSqlCredentials` then called Hasura with an object variable:

```
parsing Text failed, expected String, but encountered Object
path: $.selectionSet.sql_credentials.args.where.username._eq
```

Every SQL login failed before the password was ever compared. Reproduced with `psql -h <cubejs> -p 15432 -U <valid> -d db` → `28P01 FATAL: password authentication failed`.

## Fix

- Declare the callback with the v1.6 signature: `(request, userArg, passwordArg)`.
- Keep a defensive branch for the legacy object-shape (`{ username, password }`) to not break anyone still on the old path.
- Reject non-string username before the Hasura lookup so a misrouted request surfaces as `Incorrect user name or password` rather than a 503 with a GraphQL parse error.

## Test plan

- [ ] Build new container image; update `data/synmetrix/overlays/dev/kustomization.yaml` to the new tag
- [ ] Deploy and verify `psql -h dbx.fraios.dev -p 15432 -U <valid_sql_user> -d db` authenticates
- [ ] Verify JWT-as-password path still works (`psql -U <datasource_id> -d db` with a FraiOS JWT in `PGPASSWORD`)
- [ ] Verify a bad password still returns `28P01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)