### PR TITLE
fix(cubejs): propagate team/member properties into SQL API scope

### DIFF
--- a/services/cubejs/src/utils/checkSqlAuth.js
+++ b/services/cubejs/src/utils/checkSqlAuth.js
@@ -26,11 +26,28 @@ const buildSqlSecurityContext = (sqlCredentials) => {
     teamId
   );
 
-  const dataSourceContext = buildSecurityContext(sqlCredentials?.datasource);
+  // Resolve team settings + per-member properties so queryRewrite rules can
+  // evaluate `property_source: team` / `property_source: member` lookups for
+  // SQL API logins. Without these, every rule blocks and queries get rewritten
+  // to the `__blocked_by_access_control__` sentinel.
+  const teamMember = Array.isArray(allMembers)
+    ? allMembers.find((m) => m.team_id === teamId)
+    : null;
+  const teamSettings = teamMember?.team?.settings || {};
+  const memberProperties = teamMember?.properties || {};
+
+  const dataSourceContext = buildSecurityContext(
+    sqlCredentials?.datasource,
+    undefined,
+    undefined,
+    teamSettings
+  );
 
   return {
     dataSource: dataSourceContext,
     ...dataSourceAccessList,
+    teamProperties: teamSettings,
+    memberProperties,
   };
 };
 

--- a/services/cubejs/src/utils/checkSqlAuth.js
+++ b/services/cubejs/src/utils/checkSqlAuth.js
@@ -36,19 +36,33 @@ const buildSqlSecurityContext = (sqlCredentials) => {
 
 /**
  * Check SQL authentication for a user.
- * Supports two authentication methods:
- * 1. WorkOS JWT as password (new): password is a JWT, username is datasource ID
- * 2. Legacy sql_credentials lookup (existing): username/password from sql_credentials table
  *
- * @param {null} _ - Unused parameter.
- * @param {Object} user - The user object with username and password.
- * @returns {Promise} - Resolves to { password, securityContext }
+ * Cube.js v1.6 invokes this callback as `checkSqlAuth(request, user, password)`
+ * (see @cubejs-backend/api-gateway/dist/src/sql-server.js — the callback is
+ * wrapped with three positional args). Earlier builds passed a single object
+ * `{ username, password }`; the defensive branches below keep backward-
+ * compatibility with that older shape.
+ *
+ * Supports two authentication methods:
+ * 1. WorkOS / FraiOS JWT as password: password is a JWT, username is the datasource ID
+ * 2. Legacy sql_credentials lookup: username/password from the sql_credentials table
+ *
+ * @param {Object} request - Cube.js SQL request metadata (protocol, method, apiType)
+ * @param {string|Object} userArg - Username string (v1.6+) or legacy { username, password } object
+ * @param {string} [passwordArg] - Password string (v1.6+); absent in legacy object-shape calls
+ * @returns {Promise<{ password: string, securityContext: Object }>}
  */
-const checkSqlAuth = async (_, user) => {
-  const password = typeof user === "string" ? user : user?.password;
-  const username = typeof user === "string" ? _ : user?.username;
+const checkSqlAuth = async (request, userArg, passwordArg) => {
+  // Resolve the two shapes Cube has used for this callback:
+  //   new: (request, username: string, password: string)
+  //   legacy: (_req, { username, password })
+  const username =
+    typeof userArg === "string" ? userArg : userArg?.username;
+  const password =
+    passwordArg ??
+    (typeof userArg === "string" ? undefined : userArg?.password);
 
-  // Detect if password looks like a JWT (WorkOS RS256)
+  // Detect if password looks like a JWT (WorkOS RS256 / FraiOS HS256)
   if (password && password.includes(".") && password.split(".").length === 3) {
     const tokenType = detectTokenType(password);
 
@@ -134,8 +148,12 @@ const checkSqlAuth = async (_, user) => {
     }
   }
 
-  // Legacy sql_credentials path (unchanged)
-  const sqlCredentials = await findSqlCredentials(username || user);
+  // Legacy sql_credentials path — lookup by the plaintext username.
+  // Cube.js compares the supplied password against `password` in the return value.
+  if (!username || typeof username !== "string") {
+    throw new Error("Incorrect user name or password");
+  }
+  const sqlCredentials = await findSqlCredentials(username);
 
   return {
     password: sqlCredentials?.password,


### PR DESCRIPTION
## Summary

- Populate \`teamProperties\` and \`memberProperties\` in the security context built for the SQL API (\`checkSqlAuth.js → buildSqlSecurityContext\`).
- Unblocks \`queryRewrite\` rule evaluation on SQL wire logins (Postgres/MySQL). Without this, every rule's property lookup returns \`undefined\`, \`blocked\` fires, and the query is rewritten to the \`__blocked_by_access_control__\` sentinel — which then crashes downstream when the first member is a numeric measure.

## Reproduction

\`\`\`
psql -h dbx.fraios.dev -p 15432 -U <valid-sql-user> -d db -c 'SELECT count(*) FROM stockout_event'
\`\`\`

Failed with:

\`\`\`
ERROR: Cannot parse string '__blocked_by_access_control__' as Float64
  In scope SELECT count(*) AS stockout_event__count FROM (...)
\`\`\`

A rule for \`semantic_events.partition\` with \`property_source: team\` tries to read \`teamProperties.partition\`, which was \`undefined\` because \`buildSqlSecurityContext\` never populated it. \`queryRewrite\` blocks and replaces \`query.filters\` with:

\`\`\`
[{ member: allMembers[0], operator: "equals", values: ["__blocked_by_access_control__"] }]
\`\`\`

\`allMembers[0]\` is \`stockout_event.count\` (numeric) → ClickHouse cast failure.

## Fix

\`buildSqlSecurityContext\` now mirrors \`defineUserScope\`:

- Resolves the member for the datasource's team via \`sqlCredentials.user.members\`.
- Passes \`team.settings\` and \`member.properties\` into the scope.
- Also threads \`teamSettings\` into \`buildSecurityContext\` so the content-hash isolates cache consistently between REST and SQL paths.

## Test plan

- [ ] \`psql -h dbx.fraios.dev -p 15432 -U <valid> -d db -c 'SELECT count(*) FROM stockout_event'\` returns a row count without cast error.
- [ ] Rule-based row filtering still scopes SQL queries to the team's partition (verify via query plan shows \`partition = 'bonus.is'\`).
- [ ] Wrong password still returns 28P01.
- [ ] REST /load path remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)