### PR TITLE
fix(cubejs): include team.settings and member.properties in members fragment

### DIFF
--- a/services/cubejs/src/utils/checkSqlAuth.js
+++ b/services/cubejs/src/utils/checkSqlAuth.js
@@ -26,11 +26,28 @@ const buildSqlSecurityContext = (sqlCredentials) => {
     teamId
   );
 
-  const dataSourceContext = buildSecurityContext(sqlCredentials?.datasource);
+  // Resolve team settings + per-member properties so queryRewrite rules can
+  // evaluate `property_source: team` / `property_source: member` lookups for
+  // SQL API logins. Without these, every rule blocks and queries get rewritten
+  // to the `__blocked_by_access_control__` sentinel.
+  const teamMember = Array.isArray(allMembers)
+    ? allMembers.find((m) => m.team_id === teamId)
+    : null;
+  const teamSettings = teamMember?.team?.settings || {};
+  const memberProperties = teamMember?.properties || {};
+
+  const dataSourceContext = buildSecurityContext(
+    sqlCredentials?.datasource,
+    undefined,
+    undefined,
+    teamSettings
+  );
 
   return {
     dataSource: dataSourceContext,
     ...dataSourceAccessList,
+    teamProperties: teamSettings,
+    memberProperties,
   };
 };
 

--- a/services/cubejs/src/utils/checkSqlAuth.js
+++ b/services/cubejs/src/utils/checkSqlAuth.js
@@ -36,19 +36,33 @@ const buildSqlSecurityContext = (sqlCredentials) => {
 
 /**
  * Check SQL authentication for a user.
- * Supports two authentication methods:
- * 1. WorkOS JWT as password (new): password is a JWT, username is datasource ID
- * 2. Legacy sql_credentials lookup (existing): username/password from sql_credentials table
  *
- * @param {null} _ - Unused parameter.
- * @param {Object} user - The user object with username and password.
- * @returns {Promise} - Resolves to { password, securityContext }
+ * Cube.js v1.6 invokes this callback as `checkSqlAuth(request, user, password)`
+ * (see @cubejs-backend/api-gateway/dist/src/sql-server.js — the callback is
+ * wrapped with three positional args). Earlier builds passed a single object
+ * `{ username, password }`; the defensive branches below keep backward-
+ * compatibility with that older shape.
+ *
+ * Supports two authentication methods:
+ * 1. WorkOS / FraiOS JWT as password: password is a JWT, username is the datasource ID
+ * 2. Legacy sql_credentials lookup: username/password from the sql_credentials table
+ *
+ * @param {Object} request - Cube.js SQL request metadata (protocol, method, apiType)
+ * @param {string|Object} userArg - Username string (v1.6+) or legacy { username, password } object
+ * @param {string} [passwordArg] - Password string (v1.6+); absent in legacy object-shape calls
+ * @returns {Promise<{ password: string, securityContext: Object }>}
  */
-const checkSqlAuth = async (_, user) => {
-  const password = typeof user === "string" ? user : user?.password;
-  const username = typeof user === "string" ? _ : user?.username;
+const checkSqlAuth = async (request, userArg, passwordArg) => {
+  // Resolve the two shapes Cube has used for this callback:
+  //   new: (request, username: string, password: string)
+  //   legacy: (_req, { username, password })
+  const username =
+    typeof userArg === "string" ? userArg : userArg?.username;
+  const password =
+    passwordArg ??
+    (typeof userArg === "string" ? undefined : userArg?.password);
 
-  // Detect if password looks like a JWT (WorkOS RS256)
+  // Detect if password looks like a JWT (WorkOS RS256 / FraiOS HS256)
   if (password && password.includes(".") && password.split(".").length === 3) {
     const tokenType = detectTokenType(password);
 
@@ -134,8 +148,12 @@ const checkSqlAuth = async (_, user) => {
     }
   }
 
-  // Legacy sql_credentials path (unchanged)
-  const sqlCredentials = await findSqlCredentials(username || user);
+  // Legacy sql_credentials path — lookup by the plaintext username.
+  // Cube.js compares the supplied password against `password` in the return value.
+  if (!username || typeof username !== "string") {
+    throw new Error("Incorrect user name or password");
+  }
+  const sqlCredentials = await findSqlCredentials(username);
 
   return {
     password: sqlCredentials?.password,

--- a/services/cubejs/src/utils/dataSourceHelpers.js
+++ b/services/cubejs/src/utils/dataSourceHelpers.js
@@ -92,6 +92,11 @@ const membersFragment = `
   members {
     id
     team_id
+    properties
+    team {
+      id
+      settings
+    }
     member_roles {
       id
       team_role


### PR DESCRIPTION
## Summary

- Follow-up to #42. Makes the SQL API actually receive \`team.settings\` and \`member.properties\` so \`buildSqlSecurityContext\` can populate \`teamProperties\` / \`memberProperties\` in the security context. Without this, queryRewrite rules keep blocking every SQL query.

## Why #42 wasn't enough

#42 taught \`buildSqlSecurityContext\` to forward \`teamMember.team.settings\` and \`teamMember.properties\` into the scope — matching \`defineUserScope\` on the REST path. But the upstream GraphQL \`membersFragment\` consumed by \`sqlCredentialsQuery\` never selected \`team\` or \`properties\`, so at runtime:

\`\`\`js
const teamMember = allMembers.find((m) => m.team_id === teamId); // ← found
teamMember.team      // undefined (not in query)
teamMember.properties // undefined (not in query)
\`\`\`

\`teamProperties\` stayed empty, \`queryRewrite\` couldn't resolve \`partition\` from team settings, \`blocked = true\` fired, and \`SELECT count(*) FROM stockout_event\` got rewritten to:

\`\`\`
HAVING count(*) = toFloat64('__blocked_by_access_control__')
\`\`\`

— same Float64 cast crash we saw before the #42 merge.

## Fix

Add \`team { id settings }\` and \`properties\` to \`membersFragment\`. The REST path already fetches these via the \`currentUser\` query; the SQL path was the odd one out.

## Test plan

- [ ] After rollout, \`psql ... 'SELECT count(*) FROM stockout_event'\` returns a real count (no Float64 sentinel cast).
- [ ] Verify the generated SQL includes \`partition = 'bonus.is'\` from the rewrite rule.
- [ ] REST \`/load\` path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)