### PR TITLE
fix(hasura): make 1741520400001 teams_name_unique migration idempotent

### DIFF
--- a/services/hasura/migrations/1741520400001_fix_teams_name_unique_constraint/up.sql
+++ b/services/hasura/migrations/1741520400001_fix_teams_name_unique_constraint/up.sql
@@ -6,10 +6,59 @@
 -- Application code (deriveTeamName, findTeamByName) already normalizes
 -- names to lower(trim(name)) before insert/lookup, so a plain constraint
 -- is sufficient and Hasura-compatible.
+--
+-- Idempotent across every possible starting state:
+--   (a) expression index teams_name_unique exists          → drop it, add constraint
+--   (b) plain UNIQUE constraint teams_name_unique exists   → no-op
+--   (c) neither exists                                     → add constraint
+-- Required because an earlier version of this migration blindly ran
+-- `DROP INDEX IF EXISTS` followed by `ADD CONSTRAINT`, which fails with
+-- "cannot drop index because constraint requires it" whenever the constraint
+-- had already been created (locally or via partial reruns). The pattern below
+-- lets `hasura-cli migrate apply` succeed on every environment regardless of
+-- prior state, including environments where a human manually added the
+-- constraint after the first attempt failed.
 
--- Normalize any names that slipped through without lowering/trimming
-UPDATE public.teams SET name = lower(trim(name)) WHERE name != lower(trim(name));
+-- Normalize any names that slipped through without lowering/trimming.
+-- Skip rows whose normalized form would collide with an existing row — the
+-- constraint below is case-sensitive on the exact stored string, so leaving
+-- those rows un-normalized is safe: they coexist with the normalized
+-- counterpart and the application only ever writes the normalized form.
+-- Blindly normalising would hit a duplicate-key error on the UPDATE itself.
+UPDATE public.teams t
+   SET name = lower(trim(t.name))
+ WHERE t.name <> lower(trim(t.name))
+   AND NOT EXISTS (
+     SELECT 1
+       FROM public.teams u
+      WHERE u.id <> t.id
+        AND u.name = lower(trim(t.name))
+   );
 
--- Drop the expression index and replace with a plain unique constraint
-DROP INDEX IF EXISTS public.teams_name_unique;
-ALTER TABLE public.teams ADD CONSTRAINT teams_name_unique UNIQUE (name);
+DO $$
+BEGIN
+  -- Case (b): constraint already present, nothing to do.
+  IF EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'teams_name_unique'
+       AND conrelid = 'public.teams'::regclass
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- Case (a): expression index exists without a constraint backing it.
+  -- DROP it so we can cleanly add the constraint below.
+  IF EXISTS (
+    SELECT 1
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND indexname = 'teams_name_unique'
+  ) THEN
+    EXECUTE 'DROP INDEX public.teams_name_unique';
+  END IF;
+
+  -- Cases (a) and (c): add the plain constraint.
+  EXECUTE 'ALTER TABLE public.teams ADD CONSTRAINT teams_name_unique UNIQUE (name)';
+END
+$$;


### PR DESCRIPTION
## Summary

Unblocks the ArgoCD `hasura-migrations-job` PostSync hook, which has been failing on every sync and blocks all future Synmetrix deploys — including the recently merged Model Management API (#45).

The migration was previously:

```sql
DROP INDEX IF EXISTS public.teams_name_unique;
ALTER TABLE public.teams ADD CONSTRAINT teams_name_unique UNIQUE (name);
```

This crashes on any environment where the constraint was already created (locally on retry, or in the intermediate state after a partial apply):

```
cannot drop index teams_name_unique because constraint
teams_name_unique on table teams requires it
```

`DROP INDEX` refuses to drop an index that backs a UNIQUE constraint — the constraint owns the index.

## Fix

Replace the two blind statements with a `DO` block that branches on the current DB state and short-circuits when the desired end state already holds:

| Starting state | Action |
|---|---|
| (a) expression index `teams_name_unique` exists without a constraint | `DROP INDEX` then `ADD CONSTRAINT` |
| (b) plain UNIQUE constraint `teams_name_unique` already present | no-op, return |
| (c) neither exists | `ADD CONSTRAINT` |

Detected via `pg_constraint` + `pg_indexes` lookups rather than bare SQL statements.

## Also guarded

The pre-existing `UPDATE public.teams SET name = lower(trim(name)) …` was itself failing with a duplicate-key violation on environments where two rows normalize to the same value (`"Default team"` + `"default team"` is a real case observed on the dev cluster and locally). The UPDATE now skips rows whose normalized form already exists in another row. The constraint is case-sensitive on the exact stored string, so the two rows coexist under the new constraint and the application (which always writes `lower(trim(…))`) only ever writes the normalized form going forward.

## Test plan

- [x] Applied forward against local dev DB in state (b): success in <1 s, `migrate status` shows every migration Present/Present.
- [x] `node --test` on services/cubejs + services/actions: 475 / 479 pass (the 4 pre-existing unrelated failures unchanged).
- [x] `scripts/lint-error-codes.mjs`: green.

State (c) follows the direct `ADD CONSTRAINT` path — trivially correct.
State (a) reproduces the original forward intent — `DROP INDEX` + `ADD CONSTRAINT` — and was the path the old migration was already trying to run; it just needed to be gated so it doesn't run in state (b).

**Not in scope**: fixing the symmetric bug in `down.sql` (cannot recreate the expression index while duplicate normalized values exist). That path is only hit during intentional rollbacks and is not on the deploy critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)