### PR TITLE
fix(actions): prevent unhandledRejection crash on WorkOS refresh failure

### DIFF
--- a/services/actions/src/auth/token.js
+++ b/services/actions/src/auth/token.js
@@ -75,7 +75,12 @@ export default async function tokenHandler(req, res) {
           return { accessToken: freshJwt, workosAccessToken: refreshResult.accessToken };
         })();
         inflightRefreshes.set(sessionId, refreshPromise);
-        refreshPromise.finally(() => inflightRefreshes.delete(sessionId));
+        // Swallow the rejection on this branch — `await refreshPromise` below owns the error.
+        // Without the catch, `.finally()` returns an unhandled rejected promise when refresh fails,
+        // which crashes the process via unhandledRejection.
+        refreshPromise
+          .finally(() => inflightRefreshes.delete(sessionId))
+          .catch(() => {});
       }
 
       try {


### PR DESCRIPTION
## Summary
- Attach `.catch(() => {})` to the singleflight `.finally()` chain in `services/actions/src/auth/token.js` so cleanup cannot produce a dangling rejected promise.
- The awaited consumer still owns error handling; this fix only addresses the orphan chain.

## Context
Observed in production (synmetrix k8s ns): both `synmetrix-actions` replicas crashed with exit 1 when WorkOS returned `invalid_grant — Session has already ended` from `authenticateWithRefreshToken`. Stack pointed at `src/auth/token.js:66`.

Root cause: the singleflight pattern stored the refresh promise, then called `refreshPromise.finally(() => inflightRefreshes.delete(sessionId))` on a separate statement. That `.finally()` returns a new promise which re-rejects if the source rejects. No handler was attached to it, so `unhandledRejection` fired even though `await refreshPromise` inside the try/catch handled its own chain.

## Test plan
- [ ] Deploy to staging, force a refresh with an expired WorkOS session (or invalidate a refresh token), confirm process stays up and `/auth/token` returns 200 with cleared `workosAccessToken` (falls through to existing Hasura JWT path).
- [ ] Verify no regression in the happy-path token refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)