### PR TITLE
fix(cubejs): guard express error handler against already-sent responses

### DIFF
--- a/services/cubejs/index.js
+++ b/services/cubejs/index.js
@@ -109,6 +109,10 @@ if (String(CUBEJS_SQL_API) === "true") {
 app.use((err, req, res, next) => {
   console.error(err.stack);
 
+  if (res.headersSent) {
+    return next(err);
+  }
+
   res.status(err.status || 500).send(err.message);
 });
 


### PR DESCRIPTION
## Summary
- Short-circuit the fallback error middleware with `res.headersSent` → `next(err)` in `services/cubejs/index.js`.
- Prevents the handler from calling `res.status().send()` on a response whose headers have already been flushed.

## Context
Observed in production logs on `synmetrix-cubejs`:
```
Error: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader ...
    at ServerResponse.send ...
    at file:///app/index.js:112:33
    at handleErrorMiddleware (/app/node_modules/@cubejs-backend/api-gateway/src/gateway.ts:2287:5)
```

The upstream cube api-gateway error handler already sends its own response, then forwards via `next(err)`. The trailing `app.use((err, req, res, next) => ...)` in `index.js` then tries to write again and throws. This masks the original error (the surfaced message was a hasura auth rejection, not a header issue) and adds log noise.

Not the cause of any crash — cube's orchestrator handles the re-throw — but it's obscuring real errors.

## Test plan
- [ ] Trigger a 401 against `/cubejs-api/v1/load` with no auth, confirm response is still 403/401 (handled upstream) and no `Cannot set headers` line appears in logs.
- [ ] Trigger a generic error from a custom route in `src/routes/`, confirm it still reaches this fallback handler and returns 500 with `err.message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)