### PR TITLE
fix(cubejs/meta-all): widen partition match to team.name OR team.settings.partition

### DIFF
--- a/services/cubejs/src/routes/metaAll.js
+++ b/services/cubejs/src/routes/metaAll.js
@@ -11,7 +11,7 @@ import {
   provisionUserFromFraiOS,
 } from "../utils/dataSourceHelpers.js";
 import { compileMetaForBranch } from "../utils/metaForBranch.js";
-import { extractCubes, resolvePartitionTeamIds } from "./discover.js";
+import { extractCubes } from "./discover.js";
 
 function getRequestId(req) {
   return (
@@ -129,11 +129,14 @@ async function metaForDatasource(
 /**
  * GET /api/v1/meta-all
  *
- * Aggregated cube catalog across every datasource the caller can see.
- * One request walks all partition-filtered datasources, resolves their
- * active branch + latest version, compiles each, and returns a summary
- * per cube (name, title, description, measures, dimensions, segments, meta,
- * `dataschema_id`, `file_name`).
+ * Aggregated cube catalog scoped to the JWT's active team (partition).
+ * The caller may be a member of multiple teams across orgs; this endpoint
+ * returns only the datasources of the team that matches the JWT partition,
+ * matched by `team.name === partition` OR `team.settings.partition ===
+ * partition`. The dual match avoids the failure mode where a team's
+ * `settings.partition` drifted from its name (e.g. after a copy/migration)
+ * and the user — though a member of the right-named team — got an empty
+ * catalog because the soft setting didn't agree with the JWT.
  *
  * Auth: WorkOS RS256 or FraiOS HS256 Bearer token (same as /discover).
  *
@@ -189,11 +192,24 @@ export default async function metaAll(req, res, cubejs) {
       return res.json({ datasources: [] });
     }
 
-    const partitionTeamIds = resolvePartitionTeamIds(
-      user.members,
-      payload.partition
+    // Scope to the partition's team. A team matches the JWT partition if
+    // `team.name === partition` (canonical, set at team-creation by
+    // deriveTeamName) OR `team.settings.partition === partition` (soft
+    // setting). Either is sufficient — see route docstring for why both.
+    const partition = payload.partition;
+    const partitionTeamIds = new Set(
+      (user.members || [])
+        .filter((m) => {
+          const t = m?.team;
+          if (!t) return false;
+          if (!partition) return false;
+          return (
+            t.name === partition || t.settings?.partition === partition
+          );
+        })
+        .map((m) => m.team_id)
     );
-    const filtered = partitionTeamIds
+    const filtered = partition
       ? user.dataSources.filter((ds) => partitionTeamIds.has(ds.team_id))
       : user.dataSources;
 

--- a/services/cubejs/src/utils/dataSourceHelpers.js
+++ b/services/cubejs/src/utils/dataSourceHelpers.js
@@ -139,6 +139,7 @@ const userQuery = `
       team_id
       properties
       team {
+        name
         settings
         datasources {
           ${sourceFragment}


### PR DESCRIPTION
## Summary
Keep `/api/v1/meta-all` scoped to the JWT's active team (one team per partition), but make the matching robust against `team.settings.partition` drift.

A team now matches the JWT `partition` claim if **either**:
- `team.name === partition` — canonical, set at team creation by `deriveTeamName(email, partition)`
- `team.settings.partition === partition` — soft, back-compat for teams that set it explicitly without changing the name

Either alone is sufficient. Same scope semantics as before (single partition's team), just no longer brittle on the soft setting.

Also threads `team.name` through the `findUser` GraphQL projection so the match has the canonical field available.

## Why
Real-world failure mode caught while debugging Tychi → cube_list end-to-end:
- A team named `blue.is` had `settings.partition` left at `"bluecar.is"` after a copy/migration.
- The user was a member-owner of `blue.is`. Request-time `defineUserScope` would have accepted any cube on it.
- But `meta-all` returned `{ datasources: [] }` because the soft setting didn't agree with the JWT partition `"blue.is"` — so the catalog was empty, the cube_list MCP tool returned no datasources, and the agent truthfully reported "no cubes" with nothing to query.

Symmetric: any user who can pass runtime auth on their team's cubes should see those cubes in the catalog. The team-name match makes that the case for the typical setup, and the soft-setting match keeps existing explicit configurations working.

## What's not changed
- Still single-team-per-JWT scoping (no cross-team aggregation).
- No change to per-cube visibility (cube `public`, member-role `access_list`).
- Other routes that share `resolvePartitionTeamIds` (deleteDataschema, versionDiff, refreshCompiler, discover) are untouched.

## Test plan
- [ ] Local: stefan@snjallgogn.is JWT (`partition=blue.is`), curl `https://dbx.fraios.dev/api/v1/meta-all` → returns `blue.is`'s 2 datasources (was empty before).
- [ ] Local: a JWT with a partition that matches no team for the user → returns `{ datasources: [] }` as before.
- [ ] Local: a JWT for a team whose `settings.partition` matches but name doesn't → still returns that team's datasources (back-compat).
- [ ] Local: end-to-end Tychi `cube_list` returns the cubes in the active partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)