### PR TITLE
feat(cubejs): smart-gen — YAML default, shorter names, smarter skips, no auto pre-aggs

### DIFF
--- a/services/cubejs/package.json
+++ b/services/cubejs/package.json
@@ -5,7 +5,7 @@
     "start": "node index.js",
     "start.dev": "nodemon --exitcrash --inspect=0.0.0.0  --max-old-space-size=8096 --max-http-header-size=32768 --watch src --watch index.js",
     "jsdoc": "jsdoc index.js -r src -d docs",
-    "test": "node --test 'src/**/__tests__/*.test.js'",
+    "test": "node --experimental-test-module-mocks --test 'src/**/__tests__/*.test.js'",
     "lint:error-codes": "node ../../scripts/lint-error-codes.mjs"
   },
   "dependencies": {

--- a/services/cubejs/src/routes/smartGenerate.js
+++ b/services/cubejs/src/routes/smartGenerate.js
@@ -5,14 +5,18 @@ import {
 import createMd5Hex from '../utils/md5Hex.js';
 import { profileTable } from '../utils/smart-generation/profiler.js';
 import { detectPrimaryKeys } from '../utils/smart-generation/primaryKeyDetector.js';
-import { buildCubes, mergeAIMetrics } from '../utils/smart-generation/cubeBuilder.js';
-import { generateJs, generateFileName } from '../utils/smart-generation/yamlGenerator.js';
+import { buildCubes, mergeAIMetrics, deriveCubeNameFromFlatFilters } from '../utils/smart-generation/cubeBuilder.js';
+import {
+  generateJs,
+  generateYaml,
+  requiresJsOutput,
+} from '../utils/smart-generation/yamlGenerator.js';
 import { enrichWithAIMetrics } from '../utils/smart-generation/llmEnricher.js';
 import { createProgressEmitter } from '../utils/smart-generation/progressEmitter.js';
 import { adviseModel, applyAdvisoryPasses } from '../utils/smart-generation/modelAdvisor.js';
 import { mergeModels, extractAIMetrics } from '../utils/smart-generation/merger.js';
 import { deserializeProfile } from '../utils/smart-generation/profileSerializer.js';
-import { diffModels, parseCubesFromJs } from '../utils/smart-generation/diffModels.js';
+import { diffModels, parseCubeContent } from '../utils/smart-generation/diffModels.js';
 import { loadRules } from '../utils/queryRewrite.js';
 import { validateModelSyntax, smokeTestQuery } from '../utils/smart-generation/modelValidator.js';
 import { fetchClickHouseAliasColumnNames } from '../utils/smart-generation/clickHouseAliasColumns.js';
@@ -101,8 +105,20 @@ export default async (req, res, cubejs) => {
   const fileNameOverride = typeof rawFileName === 'string' && rawFileName.trim() ? rawFileName.trim() : null;
   // Derive cube name from file name if not explicitly set (strip extension)
   const explicitCubeName = typeof rawCubeName === 'string' && rawCubeName.trim() ? rawCubeName.trim() : null;
+  const fileDerivedCubeName = fileNameOverride
+    ? fileNameOverride.replace(/\.(js|yml|yaml)$/, '')
+    : null;
+  // Auto-derive a model name from `=` / `IN` filter values when the user has
+  // not supplied an explicit cube/file name. This produces e.g. `stockout_ended`
+  // for a filter `event = 'Stockout Ended'`, keeping the model semantically
+  // distinct from the source table when filtering rows. Falls back to the table
+  // name (handled in buildRawCube) when no usable filter is present.
+  const filterDerivedCubeName = (!explicitCubeName && !fileDerivedCubeName && filters.length > 0)
+    ? deriveCubeNameFromFlatFilters(filters)
+    : '';
   const cubeNameOverride = explicitCubeName
-    || (fileNameOverride ? fileNameOverride.replace(/\.(js|yml|yaml)$/, '') : null);
+    || fileDerivedCubeName
+    || (filterDerivedCubeName || null);
   // When provided, only these AI metric names are merged into the model (user selection from preview)
   const selectedAIMetrics = Array.isArray(rawSelectedAIMetrics) ? new Set(rawSelectedAIMetrics) : null;
   // When provided, these fully-qualified field names (cube.field) are excluded from the final model
@@ -245,19 +261,51 @@ export default async (req, res, cubejs) => {
     }
 
     // Fetch existing schemas early (needed for AI superset regeneration and merge)
-    // When nested filters produce a different cube name, use that for the file name
-    // so file name matches cube name (required for Cube.js resolution).
     const cubeName = cubeResult.cubes[0]?.name;
-    const effectiveFileNameOverride = (nestedFilters.length > 0 && cubeName)
-      ? `${cubeName}.js`
-      : fileNameOverride;
-    const fileName = effectiveFileNameOverride
-      ? (effectiveFileNameOverride.endsWith('.js') || effectiveFileNameOverride.endsWith('.yml') ? effectiveFileNameOverride : `${effectiveFileNameOverride}.js`)
-      : generateFileName(table, true);
+    // File name follows the cube name when the cube name was derived from
+    // filters (flat or nested) — required so Cube.js can resolve the model
+    // and so re-running the same filter set updates the same file.
+    const fileShouldFollowCube = cubeName && (
+      nestedFilters.length > 0
+      || (filterDerivedCubeName && cubeName === filterDerivedCubeName)
+    );
+    const baseName = fileShouldFollowCube
+      ? cubeName
+      : (fileNameOverride
+          ? fileNameOverride.replace(/\.(js|yml|yaml)$/, '')
+          : table);
+    const explicitFileName = fileNameOverride && /\.(js|yml|yaml)$/.test(fileNameOverride)
+      ? fileNameOverride
+      : null;
+
     emitter.emit('versioning', 'Checking existing schemas...', 0.62);
     // Use admin secret (no authToken) for internal Hasura calls — the user's
     // JWT may expire during the long-running profiling + LLM enrichment flow.
     const existingSchemas = await findDataSchemas({ branchId });
+
+    // Filename + format resolution (YAML-first):
+    //   1. Explicit `file_name` with extension wins.
+    //   2. Otherwise, if a model already exists by base name, reuse its
+    //      extension — preserves continuity for files originally created as JS.
+    //   3. Otherwise, default to .yml.
+    // Safety: if cubes contain non-translatable arrow callbacks
+    // (FILTER_PARAMS lambda forms beyond `(v) => v`), force JS even when YAML
+    // would otherwise be chosen, so the model stays correct.
+    const existingByBase = explicitFileName
+      ? null
+      : existingSchemas.find((f) =>
+          f.name.replace(/\.(js|yml|yaml)$/, '') === baseName
+        ) || null;
+    const cubesNeedJs = requiresJsOutput(cubeResult.cubes);
+    let fileName;
+    if (explicitFileName) {
+      fileName = explicitFileName;
+    } else if (existingByBase) {
+      fileName = existingByBase.name;
+    } else {
+      fileName = `${baseName}.${cubesNeedJs ? 'js' : 'yml'}`;
+    }
+    const useJsOutput = cubesNeedJs || /\.js$/.test(fileName);
     const existingFileIndex = existingSchemas.findIndex((f) => f.name === fileName);
     const existingCode = existingFileIndex >= 0
       ? existingSchemas[existingFileIndex].code
@@ -412,7 +460,9 @@ export default async (req, res, cubejs) => {
     let advisorResult = null;
     if (!dryRun && !skipLlm) {
       emitter.emit('advising', 'Running LLM advisory passes...', 0.65);
-      const generatedPreAdvise = generateJs(cubeResult.cubes);
+      const generatedPreAdvise = useJsOutput
+        ? generateJs(cubeResult.cubes)
+        : generateYaml(cubeResult.cubes);
 
       const profileSummaryForAdvisor = {
         table,
@@ -626,18 +676,22 @@ export default async (req, res, cubejs) => {
       cubeResult.summary.measures_count = totalMeasures;
     }
 
-    // Generate JS model
-    emitter.emit('generating', 'Generating JS model...', 0.7);
-    const yamlContent = generateJs(cubeResult.cubes);
+    // Generate model — YAML by default, JS when FILTER_PARAMS arrow callbacks
+    // require it (YAML can't represent arrow functions).
+    emitter.emit('generating', `Generating ${useJsOutput ? 'JS' : 'YAML'} model...`, 0.7);
+    const yamlContent = useJsOutput
+      ? generateJs(cubeResult.cubes)
+      : generateYaml(cubeResult.cubes);
 
     // Apply merge strategy
     emitter.emit('merging', 'Applying merge strategy...', 0.78);
 
-    // Extract previous generation filters from existing model (if any)
+    // Extract previous generation filters from existing model (if any).
+    // parseCubeContent auto-detects YAML vs JS so this works for both formats.
     let previousFilters = null;
     if (existingCode) {
       try {
-        const existingCubes = parseCubesFromJs(existingCode);
+        const { cubes: existingCubes } = parseCubeContent(existingCode);
         if (existingCubes) {
           for (const cube of existingCubes) {
             if (cube.meta?.generation_filters) {

--- a/services/cubejs/src/utils/smart-generation/__tests__/cubeBuilder.test.js
+++ b/services/cubejs/src/utils/smart-generation/__tests__/cubeBuilder.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { buildCubes } from '../cubeBuilder.js';
+import { buildCubes, deriveCubeNameFromFlatFilters } from '../cubeBuilder.js';
 import { ColumnType, ValueType } from '../typeParser.js';
 
 /**
@@ -100,7 +100,7 @@ describe('cubeBuilder – buildCubes', () => {
   });
 
   describe('Map key expansion', () => {
-    it('should expand Map column into separate fields per unique key', () => {
+    it('expands Map columns and prefers the bare key when no clash', () => {
       const t = makeTable({
         columns: new Map([
           col('props', 'Map(String, String)', ColumnType.MAP, ValueType.OTHER, {
@@ -111,8 +111,32 @@ describe('cubeBuilder – buildCubes', () => {
 
       const { cubes } = buildCubes(t);
       const dimNames = cubes[0].dimensions.map((d) => d.name);
-      assert.ok(dimNames.includes('props_color'));
-      assert.ok(dimNames.includes('props_size'));
+      // Shortest-unique resolver drops the `props_` prefix when nothing else
+      // wants `color` / `size`.
+      assert.ok(dimNames.includes('color'), `expected 'color' in ${JSON.stringify(dimNames)}`);
+      assert.ok(dimNames.includes('size'), `expected 'size' in ${JSON.stringify(dimNames)}`);
+      // Native map accessor keeps its qualified name (already includes the column name).
+      assert.ok(dimNames.includes('props_map'));
+    });
+
+    it('falls back to the qualified name when the bare key clashes', () => {
+      // A basic `color` column already owns the leaf name → map key advances
+      // to `props_color`.
+      const t = makeTable({
+        columns: new Map([
+          col('color', 'String', ColumnType.BASIC, ValueType.STRING, {
+            hasValues: true, uniqueValues: 5,
+          }),
+          col('props', 'Map(String, String)', ColumnType.MAP, ValueType.OTHER, {
+            uniqueKeys: ['color', 'size'],
+          }),
+        ]),
+      });
+      const { cubes } = buildCubes(t);
+      const dimNames = cubes[0].dimensions.map((d) => d.name);
+      assert.ok(dimNames.includes('color'), 'basic column keeps its leaf name');
+      assert.ok(dimNames.includes('props_color'), 'map key falls back to qualified name on clash');
+      assert.ok(dimNames.includes('size'), `'size' should still be unique → bare leaf. Got: ${JSON.stringify(dimNames)}`);
     });
   });
 
@@ -150,6 +174,115 @@ describe('cubeBuilder – buildCubes', () => {
     });
   });
 
+  describe('single empty/zero value exclusion', () => {
+    it('skips numeric columns whose only value is 0', () => {
+      const t = makeTable({
+        columns: new Map([
+          col('amount', 'Float64', ColumnType.BASIC, ValueType.NUMBER, {
+            hasValues: true, uniqueValues: 1, minValue: 0, maxValue: 0,
+          }),
+          col('count', 'Int32', ColumnType.BASIC, ValueType.NUMBER, {
+            hasValues: true, uniqueValues: 5, minValue: 0, maxValue: 42,
+          }),
+        ]),
+      });
+      const { cubes } = buildCubes(t);
+      const names = cubes[0].measures.map((m) => m.name);
+      assert.ok(!names.includes('amount'), 'all-zero numeric should be skipped');
+      assert.ok(names.includes('count'), 'numeric with non-zero values must remain');
+    });
+
+    it('skips string columns whose only LC-probed value is empty / whitespace / "0"', () => {
+      const t = makeTable({
+        columns: new Map([
+          col('blank_text', 'String', ColumnType.BASIC, ValueType.STRING, {
+            hasValues: true, uniqueValues: 1, lcValues: [''],
+          }),
+          col('whitespace', 'String', ColumnType.BASIC, ValueType.STRING, {
+            hasValues: true, uniqueValues: 1, lcValues: ['   '],
+          }),
+          col('zero_text', 'String', ColumnType.BASIC, ValueType.STRING, {
+            hasValues: true, uniqueValues: 1, lcValues: ['0'],
+          }),
+          col('useful', 'String', ColumnType.BASIC, ValueType.STRING, {
+            hasValues: true, uniqueValues: 1, lcValues: ['active'],
+          }),
+        ]),
+      });
+      const { cubes } = buildCubes(t);
+      const names = cubes[0].dimensions.map((d) => d.name);
+      assert.ok(!names.includes('blank_text'));
+      assert.ok(!names.includes('whitespace'));
+      assert.ok(!names.includes('zero_text'));
+      assert.ok(names.includes('useful'), 'meaningful constant string should be kept');
+    });
+
+    it('keeps numeric column when min!==max even if min is 0', () => {
+      const t = makeTable({
+        columns: new Map([
+          col('score', 'Float64', ColumnType.BASIC, ValueType.NUMBER, {
+            hasValues: true, uniqueValues: 10, minValue: 0, maxValue: 100,
+          }),
+        ]),
+      });
+      const { cubes } = buildCubes(t);
+      const names = cubes[0].measures.map((m) => m.name);
+      assert.ok(names.includes('score'));
+    });
+
+    it('skips boolean column with single distinct value (always-true OR always-false)', () => {
+      const t = makeTable({
+        columns: new Map([
+          col('always_false_flag', 'Bool', ColumnType.BASIC, ValueType.BOOLEAN, {
+            hasValues: true, uniqueValues: 1,
+          }),
+          col('always_true_flag', 'Bool', ColumnType.BASIC, ValueType.BOOLEAN, {
+            hasValues: true, uniqueValues: 1,
+          }),
+          col('mixed_flag', 'Bool', ColumnType.BASIC, ValueType.BOOLEAN, {
+            hasValues: true, uniqueValues: 2,
+          }),
+        ]),
+      });
+      const { cubes } = buildCubes(t);
+      const names = [
+        ...cubes[0].dimensions.map((d) => d.name),
+        ...cubes[0].measures.map((m) => m.name),
+      ];
+      assert.ok(!names.includes('always_false_flag'), 'always-same bool should be skipped');
+      assert.ok(!names.includes('always_true_flag'), 'always-same bool should be skipped');
+      assert.ok(names.includes('mixed_flag'), 'genuinely-varying bool should be kept');
+    });
+
+    it('skips Int8/Bool basic columns by min===max (initial profile has no uniqueValues)', () => {
+      // Reproduces the `customer_facing Int8 Min 0 Max 0 Avg 0` case: the
+      // profiler's initial pass writes min/max/avg for BOOLEAN scalars but
+      // doesn't compute uniqueValues — so the skip must be range-based too.
+      const t = makeTable({
+        columns: new Map([
+          col('customer_facing', 'Int8', ColumnType.BASIC, ValueType.BOOLEAN, {
+            hasValues: true, minValue: 0, maxValue: 0, avgValue: 0,
+            // uniqueValues intentionally omitted — matches real profiler output
+          }),
+          col('always_one', 'Int8', ColumnType.BASIC, ValueType.BOOLEAN, {
+            hasValues: true, minValue: 1, maxValue: 1, avgValue: 1,
+          }),
+          col('actually_used', 'Int8', ColumnType.BASIC, ValueType.BOOLEAN, {
+            hasValues: true, minValue: 0, maxValue: 1, avgValue: 0.3,
+          }),
+        ]),
+      });
+      const { cubes } = buildCubes(t);
+      const names = [
+        ...cubes[0].dimensions.map((d) => d.name),
+        ...cubes[0].measures.map((m) => m.name),
+      ];
+      assert.ok(!names.includes('customer_facing'), 'all-zero Int8 should be skipped via min===max');
+      assert.ok(!names.includes('always_one'), 'all-one Int8 should be skipped via min===max');
+      assert.ok(names.includes('actually_used'), 'mixed Int8 should be kept');
+    });
+  });
+
   describe('max Map key limit enforcement', () => {
     it('should truncate Map keys when exceeding maxMapKeys', () => {
       // Create 10 keys but set limit to 3
@@ -165,9 +298,13 @@ describe('cubeBuilder – buildCubes', () => {
       const { cubes } = buildCubes(t, { maxMapKeys: 3 });
       const dimNames = cubes[0].dimensions.map((d) => d.name);
 
-      // Should have exactly 3 expanded fields + 1 native map accessor
-      const mapFields = dimNames.filter((n) => n.startsWith('big_map_'));
-      assert.strictEqual(mapFields.length, 4); // 3 expanded + big_map_map
+      // Resolver shortens unique keys → expanded keys land as their leaf
+      // names. Plus the native `big_map_map` accessor.
+      const allMapFields = cubes[0].dimensions.filter(
+        (d) => d.meta?.source_column === 'big_map'
+      );
+      assert.strictEqual(allMapFields.length, 4); // 3 expanded + big_map_map
+      assert.ok(dimNames.includes('big_map_map'));
     });
 
     it('should keep all keys when under the limit', () => {
@@ -182,8 +319,11 @@ describe('cubeBuilder – buildCubes', () => {
 
       const { cubes } = buildCubes(t, { maxMapKeys: 500 });
       const dimNames = cubes[0].dimensions.map((d) => d.name);
-      const mapFields = dimNames.filter((n) => n.startsWith('small_map_'));
-      assert.strictEqual(mapFields.length, 4); // 3 expanded + small_map_map
+      const allMapFields = cubes[0].dimensions.filter(
+        (d) => d.meta?.source_column === 'small_map'
+      );
+      assert.strictEqual(allMapFields.length, 4); // 3 expanded + small_map_map
+      assert.ok(dimNames.includes('small_map_map'));
     });
   });
 
@@ -261,5 +401,199 @@ describe('cubeBuilder – buildCubes', () => {
       assert.ok(!cubes[0].name.includes('-'));
       assert.ok(!cubes[0].name.includes('.'));
     });
+
+    it('should use the cubeName override when provided', () => {
+      const { cubes } = buildCubes(table, { cubeName: 'stockout_ended' });
+      assert.strictEqual(cubes[0].name, 'stockout_ended');
+    });
+  });
+});
+
+describe('cubeBuilder – shortest-unique field naming', () => {
+  function nestedCol(parent, child, valueType = ValueType.STRING) {
+    const name = `${parent}.${child}`;
+    return [name, {
+      name,
+      rawType: valueType === ValueType.NUMBER ? 'Float64' : 'String',
+      columnType: ColumnType.GROUPED,
+      valueType,
+      parentName: parent,
+      childName: child,
+      isNullable: false,
+      profile: { hasValues: true, uniqueValues: 5 },
+    }];
+  }
+
+  it('drops parent prefix from nested fields when the leaf is unique', () => {
+    const t = {
+      database: 'db',
+      table: 'events',
+      partition: null,
+      columns: new Map([
+        nestedCol('location', 'lat', ValueType.NUMBER),
+        nestedCol('location', 'lng', ValueType.NUMBER),
+      ]),
+    };
+    const { cubes } = buildCubes(t);
+    const all = [
+      ...cubes[0].dimensions.map((d) => d.name),
+      ...cubes[0].measures.map((m) => m.name),
+    ];
+    assert.ok(all.includes('lat'), `expected 'lat'. Got: ${JSON.stringify(all)}`);
+    assert.ok(all.includes('lng'));
+  });
+
+  it('keeps parent prefix on nested field when leaf clashes with a basic column', () => {
+    // `score` (basic NUMBER, doesn't match the coordinate regex) → measure.
+    // `metrics.score` (nested NUMBER) → also a measure. Same leaf → resolver
+    // forces the nested one to advance to `metrics_score`.
+    const t = {
+      database: 'db',
+      table: 'events',
+      partition: null,
+      columns: new Map([
+        ['score', {
+          name: 'score', rawType: 'Float64', columnType: ColumnType.BASIC, valueType: ValueType.NUMBER,
+          isNullable: false,
+          profile: { hasValues: true, minValue: 1, maxValue: 100, avgValue: 50 },
+        }],
+        nestedCol('metrics', 'score', ValueType.NUMBER),
+      ]),
+    };
+    const { cubes } = buildCubes(t);
+    const measureNames = cubes[0].measures.map((m) => m.name);
+    assert.ok(measureNames.includes('score'), `top-level score keeps the bare name. Got: ${JSON.stringify(measureNames)}`);
+    assert.ok(measureNames.includes('metrics_score'), `nested score falls back to metrics_score. Got: ${JSON.stringify(measureNames)}`);
+  });
+
+  it('falls back through deeper levels when multiple nested fields share a leaf and a parent', () => {
+    const t = {
+      database: 'db',
+      table: 'events',
+      partition: null,
+      columns: new Map([
+        nestedCol('commerce.products', 'id', ValueType.STRING),
+        nestedCol('commerce.shipping.products', 'id', ValueType.STRING),
+      ]),
+    };
+    const { cubes } = buildCubes(t);
+    const dimNames = cubes[0].dimensions.map((d) => d.name);
+    assert.ok(
+      dimNames.includes('commerce_products_id') || dimNames.includes('shipping_products_id'),
+      `expected qualified names. Got: ${JSON.stringify(dimNames)}`
+    );
+    // Both must be unique
+    assert.strictEqual(new Set(dimNames).size, dimNames.length, 'all dim names must be unique');
+  });
+
+  it('rebinds FILTER_PARAMS refs when a lookup-key dimension is shortened', () => {
+    // Build a synthetic nested group with a `_type` lookup key + one data sibling.
+    const t = {
+      database: 'db',
+      table: 'events',
+      partition: null,
+      columns: new Map([
+        ['commerce.products.entry_type', {
+          name: 'commerce.products.entry_type',
+          rawType: 'Array(String)',
+          columnType: ColumnType.GROUPED,
+          valueType: ValueType.STRING,
+          parentName: 'commerce.products',
+          childName: 'entry_type',
+          isNullable: false,
+          profile: {
+            hasValues: true, uniqueValues: 3,
+            lcValues: ['Line Item', 'Cart Item', 'Order'],
+          },
+        }],
+        ['commerce.products.value', {
+          name: 'commerce.products.value',
+          rawType: 'Array(String)',
+          columnType: ColumnType.GROUPED,
+          valueType: ValueType.STRING,
+          parentName: 'commerce.products',
+          childName: 'value',
+          isNullable: false,
+          profile: { hasValues: true, uniqueValues: 50 },
+        }],
+      ]),
+    };
+    const { cubes } = buildCubes(t);
+    const dimNames = cubes[0].dimensions.map((d) => d.name);
+    // Lookup-key dim should land on `type` (no clash for that name)
+    assert.ok(dimNames.includes('type'), `expected resolved 'type'. Got: ${JSON.stringify(dimNames)}`);
+    // Every FILTER_PARAMS ref in any dim sql must point at `type`, not the old name
+    for (const d of cubes[0].dimensions) {
+      if (typeof d.sql === 'string' && d.sql.includes('FILTER_PARAMS')) {
+        assert.ok(
+          d.sql.includes(`FILTER_PARAMS.${cubes[0].name}.type.`),
+          `FILTER_PARAMS ref should point at resolved 'type' dim. SQL: ${d.sql}`
+        );
+        assert.ok(
+          !d.sql.includes('commerce_products_type'),
+          `Old qualified ref must be rewritten. SQL: ${d.sql}`
+        );
+      }
+    }
+  });
+});
+
+describe('cubeBuilder – deriveCubeNameFromFlatFilters', () => {
+  it('returns empty for no filters', () => {
+    assert.strictEqual(deriveCubeNameFromFlatFilters([]), '');
+    assert.strictEqual(deriveCubeNameFromFlatFilters(null), '');
+  });
+
+  it('builds an identifier from a single equality filter value', () => {
+    const name = deriveCubeNameFromFlatFilters([
+      { column: 'event', operator: '=', value: 'Stockout Ended' },
+    ]);
+    assert.strictEqual(name, 'stockout_ended');
+  });
+
+  it('joins multiple filter values with underscores', () => {
+    const name = deriveCubeNameFromFlatFilters([
+      { column: 'event', operator: '=', value: 'Stockout Ended' },
+      { column: 'store_id', operator: '=', value: 42 },
+    ]);
+    assert.strictEqual(name, 'stockout_ended_42');
+  });
+
+  it('expands IN values', () => {
+    const name = deriveCubeNameFromFlatFilters([
+      { column: 'event', operator: 'IN', value: ['Order Placed', 'Order Shipped'] },
+    ]);
+    assert.strictEqual(name, 'order_placed_order_shipped');
+  });
+
+  it('ignores non-equality operators', () => {
+    assert.strictEqual(
+      deriveCubeNameFromFlatFilters([{ column: 'event', operator: '!=', value: 'X' }]),
+      ''
+    );
+    assert.strictEqual(
+      deriveCubeNameFromFlatFilters([{ column: 'event', operator: 'LIKE', value: '%foo%' }]),
+      ''
+    );
+    assert.strictEqual(
+      deriveCubeNameFromFlatFilters([{ column: 'event', operator: 'IS NULL', value: null }]),
+      ''
+    );
+  });
+
+  it('prefixes purely numeric names so they are valid identifiers', () => {
+    const name = deriveCubeNameFromFlatFilters([
+      { column: 'store_id', operator: '=', value: 42 },
+    ]);
+    assert.ok(!/^\d/.test(name));
+    assert.strictEqual(name, 'cube_42');
+  });
+
+  it('caps absurdly long names', () => {
+    const longValue = 'x'.repeat(200);
+    const name = deriveCubeNameFromFlatFilters([
+      { column: 'event', operator: '=', value: longValue },
+    ]);
+    assert.ok(name.length <= 60);
   });
 });

--- a/services/cubejs/src/utils/smart-generation/__tests__/fieldProcessors.test.js
+++ b/services/cubejs/src/utils/smart-generation/__tests__/fieldProcessors.test.js
@@ -313,6 +313,7 @@ describe('MapFieldProcessor', () => {
     assert.equal(result.length, 2);
     assert.deepEqual(result[0], {
       name: 'tags_color',
+      _nameCandidates: ['color', 'tags_color'],
       sql: "{CUBE}.tags['color']",
       type: 'string',
       fieldType: 'dimension',
@@ -320,6 +321,7 @@ describe('MapFieldProcessor', () => {
     });
     assert.deepEqual(result[1], {
       name: 'tags_size',
+      _nameCandidates: ['size', 'tags_size'],
       sql: "{CUBE}.tags['size']",
       type: 'string',
       fieldType: 'dimension',
@@ -341,6 +343,7 @@ describe('MapFieldProcessor', () => {
     assert.equal(result.length, 1);
     assert.deepEqual(result[0], {
       name: 'metrics_latency',
+      _nameCandidates: ['latency', 'metrics_latency'],
       sql: "CAST({CUBE}.metrics['latency'] AS Float64)",
       type: 'sum',
       fieldType: 'measure',
@@ -408,6 +411,7 @@ describe('MapFieldProcessor', () => {
 
     assert.deepEqual(result[0], {
       name: 'flags_enabled',
+      _nameCandidates: ['enabled', 'flags_enabled'],
       sql: "({CUBE}.flags['enabled']) = 1",
       type: 'boolean',
       fieldType: 'dimension',
@@ -429,6 +433,7 @@ describe('MapFieldProcessor', () => {
 
     assert.deepEqual(result[0], {
       name: 'settings_dark_mode',
+      _nameCandidates: ['dark_mode', 'settings_dark_mode'],
       sql: "{CUBE}.settings['dark_mode']",
       type: 'boolean',
       fieldType: 'dimension',

--- a/services/cubejs/src/utils/smart-generation/__tests__/lcProbe.test.js
+++ b/services/cubejs/src/utils/smart-generation/__tests__/lcProbe.test.js
@@ -182,9 +182,11 @@ describe('LC probe – cubeBuilder propagation', () => {
     ]);
 
     const { cubes } = buildCubes({ database: 'db', table: 'test', partition: null, columns });
-    const envDim = cubes[0].dimensions.find(d => d.name === 'props_env');
-    const regionDim = cubes[0].dimensions.find(d => d.name === 'props_region');
-    assert.ok(envDim);
+    // After the shortest-unique resolver, map keys land at their bare leaf
+    // names when nothing else claims them.
+    const envDim = cubes[0].dimensions.find(d => d.name === 'env');
+    const regionDim = cubes[0].dimensions.find(d => d.name === 'region');
+    assert.ok(envDim, `expected 'env' dim. Got: ${cubes[0].dimensions.map(d => d.name).join(', ')}`);
     assert.ok(regionDim);
     assert.deepStrictEqual(envDim.meta.lc_values, ['prod', 'staging']);
     assert.deepStrictEqual(regionDim.meta.lc_values, ['us', 'eu']);

--- a/services/cubejs/src/utils/smart-generation/__tests__/profiler.test.js
+++ b/services/cubejs/src/utils/smart-generation/__tests__/profiler.test.js
@@ -158,10 +158,14 @@ describe('buildWhereClause', () => {
     assert.equal(buildWhereClause('db', 'events', '', ['events']), '');
   });
 
-  it('returns empty string when internalTables is not an array', () => {
+  it('returns empty when internalTables is missing or non-array', () => {
+    // Current semantics: partition filter only applies when internalTables is
+    // a non-empty array that includes this table. Missing / non-array / empty
+    // allowlist means "no internal-table partition pushdown" — return ''.
     assert.equal(buildWhereClause('db', 'events', '2024-01', null), '');
     assert.equal(buildWhereClause('db', 'events', '2024-01', undefined), '');
     assert.equal(buildWhereClause('db', 'events', '2024-01', 'events'), '');
+    assert.equal(buildWhereClause('db', 'events', '2024-01', []), '');
   });
 
   it('returns empty string when table is not in internalTables', () => {
@@ -1039,9 +1043,12 @@ describe('profileTable — emitter', () => {
     await profileTable(driver, 'db', 'tbl', { emitter });
 
     const steps = events.map((e) => e.step);
-    assert.ok(steps.includes('init'));
-    assert.ok(steps.includes('initial_profile'));
-    assert.ok(steps.includes('profiling'));
+    // Current pass names from profiler.js: 'init' (DESCRIBE / metadata),
+    // 'initial_profile' (Pass 1), 'profiling' (Pass 2 deep), plus optional
+    // 'map_stats' / 'lc_probe' phases.
+    assert.ok(steps.includes('init'), `expected 'init' step. Got: ${JSON.stringify(steps)}`);
+    assert.ok(steps.includes('initial_profile'), `expected 'initial_profile'. Got: ${JSON.stringify(steps)}`);
+    assert.ok(steps.includes('profiling'), `expected 'profiling'. Got: ${JSON.stringify(steps)}`);
     assert.ok(events.length >= 4);
   });
 });
@@ -1170,5 +1177,108 @@ describe('profileTable — generated SQL', () => {
     assert.ok(deepSql, 'Expected deep profiling query for nested column');
     assert.ok(deepSql.includes('nested_field__'), 'Alias should replace dots with underscores');
     assert.ok(deepSql.includes('`nested.field`'), 'Column expression should use original name');
+  });
+
+  it('counts distinct ELEMENTS (uniqArray) for nested string array sub-columns', async () => {
+    const driver = createMockDriver({
+      describeRows: [{ name: 'tags.name', type: 'Array(String)' }],
+      initialProfileRow: { row_count: 10, tags__max_length: 5 },
+      deepProfileResult: {
+        tags_name__value_rows: 8,
+        tags_name__distinct_count: 3,
+      },
+    });
+
+    await profileTable(driver, 'db', 'tbl');
+
+    const deepSql = driver.calls.find(
+      (s) => s.includes('tags_name__distinct_count')
+    );
+    assert.ok(deepSql, 'Expected deep profiling query for tags.name');
+    assert.ok(
+      deepSql.includes("uniqArray(arrayFilter(x -> x IS NOT NULL AND x != '', `tags.name`)) as tags_name__distinct_count"),
+      `Expected uniqArray(arrayFilter(NULL+empty filter)) for string arrays. Got SQL: ${deepSql}`
+    );
+    assert.ok(
+      !/uniq\(arrayFilter[^)]*`tags.name`/.test(deepSql),
+      'Should NOT use plain uniq() — counts distinct arrays, not elements'
+    );
+  });
+
+  it('counts distinct non-null ELEMENTS and emits min/max for nested numeric array sub-columns', async () => {
+    const driver = createMockDriver({
+      describeRows: [{ name: 'scores.value', type: 'Array(Float64)' }],
+      initialProfileRow: { row_count: 10, scores__max_length: 5 },
+      deepProfileResult: {
+        scores_value__value_rows: 9,
+        scores_value__distinct_count: 7,
+        scores_value__min_value: 0,
+        scores_value__max_value: 100,
+      },
+    });
+
+    await profileTable(driver, 'db', 'tbl');
+
+    const deepSql = driver.calls.find(
+      (s) => s.includes('scores_value__distinct_count')
+    );
+    assert.ok(deepSql, 'Expected deep profiling query for scores.value');
+    assert.ok(
+      deepSql.includes('uniqArray(arrayFilter(x -> x IS NOT NULL, `scores.value`)) as scores_value__distinct_count'),
+      `Expected uniqArray(arrayFilter(IS NOT NULL)) for numeric arrays. Got: ${deepSql}`
+    );
+    assert.ok(
+      deepSql.includes('minArray(`scores.value`) as scores_value__min_value'),
+      'Expected minArray(...) for numeric arrays'
+    );
+    assert.ok(
+      deepSql.includes('maxArray(`scores.value`) as scores_value__max_value'),
+      'Expected maxArray(...) for numeric arrays'
+    );
+  });
+
+  it('counts value_rows by NON-NULL elements for boolean array sub-columns (parallel-length nested fix)', async () => {
+    const driver = createMockDriver({
+      describeRows: [{ name: 'flags.active', type: 'Array(Nullable(Bool))' }],
+      initialProfileRow: { row_count: 100, flags__max_length: 1 },
+      deepProfileResult: {
+        flags_active__value_rows: 0,
+        flags_active__distinct_count: 0,
+      },
+    });
+
+    await profileTable(driver, 'db', 'tbl');
+
+    const deepSql = driver.calls.find(
+      (s) => s.includes('flags_active__value_rows')
+    );
+    assert.ok(deepSql, 'Expected deep profiling query for flags.active');
+    assert.ok(
+      deepSql.includes('countIf(length(arrayFilter(x -> x IS NOT NULL, `flags.active`)) > 0) as flags_active__value_rows'),
+      `value_rows must filter non-null elements (so all-NULL nested fields don't read as populated). Got: ${deepSql}`
+    );
+    assert.ok(
+      !/length\(`flags.active`\) > 0\) as flags_active__value_rows/.test(deepSql),
+      'Should NOT use raw length(col) — that just measures parallel-array length, not signal'
+    );
+  });
+
+  it('numeric array value_rows excludes all-zero rows (so all-zero nested numerics get hasValues=false)', async () => {
+    const driver = createMockDriver({
+      describeRows: [{ name: 'amounts.fee', type: 'Array(Float64)' }],
+      initialProfileRow: { row_count: 100, amounts__max_length: 1 },
+      deepProfileResult: { amounts_fee__value_rows: 0 },
+    });
+
+    await profileTable(driver, 'db', 'tbl');
+
+    const deepSql = driver.calls.find(
+      (s) => s.includes('amounts_fee__value_rows')
+    );
+    assert.ok(deepSql);
+    assert.ok(
+      deepSql.includes('countIf(length(arrayFilter(x -> x IS NOT NULL AND x != 0, `amounts.fee`)) > 0) as amounts_fee__value_rows'),
+      `numeric array value_rows must require at least one non-null non-zero element. Got: ${deepSql}`
+    );
   });
 });

--- a/services/cubejs/src/utils/smart-generation/__tests__/yamlGenerator.test.js
+++ b/services/cubejs/src/utils/smart-generation/__tests__/yamlGenerator.test.js
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { generateYaml, generateFileName, generateJs } from '../yamlGenerator.js';
+import {
+  generateYaml,
+  generateFileName,
+  generateJs,
+  requiresJsOutput,
+  transpileArrowsForYaml,
+} from '../yamlGenerator.js';
 
 describe('yamlGenerator – generateYaml', () => {
   function makeCube(overrides = {}) {
@@ -256,5 +262,73 @@ describe('yamlGenerator – generateJs advanced properties', () => {
     const js = generateJs([cube]);
     assert.ok(js.includes('sql: "SELECT *, `commerce.total`, duration_ratio FROM dev.semantic_events"'), js);
     assert.ok(!js.includes('\\`commerce'), 'should not escape inner backticks with backslash');
+  });
+});
+
+describe('yamlGenerator – arrow → lambda transpile for YAML', () => {
+  it('rewrites identity arrow to Python lambda', () => {
+    assert.strictEqual(
+      transpileArrowsForYaml('{FILTER_PARAMS.cube.dim.filter((v) => v)}'),
+      '{FILTER_PARAMS.cube.dim.filter(lambda v: v)}'
+    );
+  });
+
+  it('rewrites every occurrence in a single string', () => {
+    const input =
+      'indexOf({CUBE}.`p.c`, toString({FILTER_PARAMS.cube.dim.filter((v) => v)})) ' +
+      '+ {FILTER_PARAMS.cube.dim2.filter((x) => x)}';
+    const out = transpileArrowsForYaml(input);
+    assert.ok(out.includes('lambda v: v'));
+    assert.ok(out.includes('lambda x: x'));
+    assert.ok(!out.includes('=>'));
+  });
+
+  it('leaves non-identity arrows untouched', () => {
+    const input = '{FILTER_PARAMS.cube.d.filter((from, to) => `c BETWEEN ${from}`)}';
+    assert.strictEqual(transpileArrowsForYaml(input), input);
+  });
+
+  it('passes through values without arrows', () => {
+    assert.strictEqual(transpileArrowsForYaml('{CUBE}.col'), '{CUBE}.col');
+    assert.strictEqual(transpileArrowsForYaml(''), '');
+    assert.strictEqual(transpileArrowsForYaml(null), null);
+  });
+
+  it('emits lambda form in generated YAML for identity-arrow dimensions', () => {
+    const cube = {
+      name: 'events',
+      sql: 'SELECT * FROM db.events',
+      meta: { auto_generated: true },
+      dimensions: [
+        {
+          name: 'event_type',
+          sql: 'toString({FILTER_PARAMS.events.event_type_filter.filter((v) => v)})',
+          type: 'string',
+          meta: { auto_generated: true },
+        },
+      ],
+      measures: [],
+    };
+    const yaml = generateYaml([cube]);
+    assert.ok(yaml.includes('lambda v: v'), yaml);
+    assert.ok(!yaml.includes('=>'), 'YAML should not contain arrow syntax');
+  });
+
+  it('requiresJsOutput returns false for identity-arrow-only cubes', () => {
+    const cubes = [{
+      name: 'c',
+      dimensions: [{ name: 'd', sql: '{FILTER_PARAMS.c.x.filter((v) => v)}', type: 'string' }],
+      measures: [],
+    }];
+    assert.strictEqual(requiresJsOutput(cubes), false);
+  });
+
+  it('requiresJsOutput returns true for non-identity arrows', () => {
+    const cubes = [{
+      name: 'c',
+      dimensions: [{ name: 'd', sql: '{FILTER_PARAMS.c.x.filter((from, to) => `x BETWEEN ${from}`)}', type: 'string' }],
+      measures: [],
+    }];
+    assert.strictEqual(requiresJsOutput(cubes), true);
   });
 });

--- a/services/cubejs/src/utils/smart-generation/cubeBuilder.js
+++ b/services/cubejs/src/utils/smart-generation/cubeBuilder.js
@@ -5,7 +5,7 @@
  * Ported from Python prototype: cxs-inbox/cube/utils/cube_builder.py
  */
 
-import { processColumn, sanitizeFieldName } from './fieldProcessors.js';
+import { processColumn, sanitizeFieldName, buildPathCandidates } from './fieldProcessors.js';
 import { ColumnType, ValueType } from './typeParser.js';
 
 // -- Helpers ----------------------------------------------------------------
@@ -40,6 +40,54 @@ function sanitizeCubeName(name) {
   }
   sanitized = sanitized.replace(/_+/g, '_').replace(/^_+|_+$/g, '');
   return sanitized || 'cube';
+}
+
+/**
+ * Pick the shortest unique name for each field from its `_nameCandidates`.
+ *
+ * Each field's `_nameCandidates` is ordered from leaf (most readable) to
+ * fully-qualified. Initially every field is at index 0. When multiple fields
+ * share a name, every claimant that has a longer candidate available advances
+ * one step. Repeats until no advances. Fields with only one candidate (basic
+ * scalars) hold their position; longer-candidate fields step around them.
+ *
+ * Residual collisions (multiple fields exhausted candidates with the same
+ * final name) fall through to deduplicateFields, which appends a suffix.
+ *
+ * @param {object[]} fields - Each entry should have `_nameCandidates: string[]`.
+ *   When absent, the existing `name` is treated as the only candidate.
+ * @returns {object[]} The same array, with `name` set to the resolved choice.
+ */
+function resolveNames(fields) {
+  for (const f of fields) {
+    if (!Array.isArray(f._nameCandidates) || f._nameCandidates.length === 0) {
+      f._nameCandidates = [f.name];
+    }
+    f._candidateIdx = 0;
+    f.name = f._nameCandidates[0];
+  }
+
+  const MAX_ITER = 32;
+  for (let iter = 0; iter < MAX_ITER; iter++) {
+    const byName = new Map();
+    for (const f of fields) {
+      if (!byName.has(f.name)) byName.set(f.name, []);
+      byName.get(f.name).push(f);
+    }
+    let advanced = false;
+    for (const [, group] of byName) {
+      if (group.length <= 1) continue;
+      for (const f of group) {
+        if (f._candidateIdx + 1 < f._nameCandidates.length) {
+          f._candidateIdx++;
+          f.name = f._nameCandidates[f._candidateIdx];
+          advanced = true;
+        }
+      }
+    }
+    if (!advanced) break;
+  }
+  return fields;
 }
 
 /**
@@ -381,6 +429,63 @@ function processColumns(columns, options) {
       }
     }
 
+    // Skip fields whose only present value is empty / zero — they carry no
+    // analytical signal and clutter the model. Three signals are checked:
+    //   - String/UUID: uniqueValues===1 with the single LC-probed value being
+    //     "", "0", or whitespace-only. (Plain empty strings are already filtered
+    //     by uniqIf upstream, but "0"-as-text and whitespace can still slip in.)
+    //   - Number basic: min===max===0. min/max are computed for all numeric
+    //     scalars during the initial profile pass.
+    //   - Number array (nested numeric sub-column): min===max===0 from the
+    //     minArray/maxArray aggregates added in profiler.arrayColumnSql.
+    if (profile && profile.hasValues) {
+      if (
+        (details.valueType === ValueType.STRING || details.valueType === ValueType.UUID) &&
+        details.columnType !== ColumnType.MAP &&
+        profile.uniqueValues === 1 &&
+        Array.isArray(profile.lcValues) &&
+        profile.lcValues.length === 1
+      ) {
+        const only = profile.lcValues[0];
+        const isEmpty =
+          only == null ||
+          only === '' ||
+          (typeof only === 'string' && only.trim() === '') ||
+          only === '0' ||
+          only === 0;
+        if (isEmpty) {
+          columnsSkipped++;
+          continue;
+        }
+      }
+
+      if (
+        details.valueType === ValueType.NUMBER &&
+        profile.minValue != null &&
+        profile.maxValue != null &&
+        Number(profile.minValue) === 0 &&
+        Number(profile.maxValue) === 0
+      ) {
+        columnsSkipped++;
+        continue;
+      }
+
+      // Boolean / Int8-as-bool: always-same value (true OR false) carries no
+      // signal. Two signals — basic columns get min/max from Pass 1 but no
+      // uniqueValues; array sub-columns get uniqueValues from uniqArray. Use
+      // either: minValue === maxValue ⇔ a single distinct value for booleans.
+      if (details.valueType === ValueType.BOOLEAN) {
+        const singleByCount = profile.uniqueValues === 1;
+        const singleByRange = profile.minValue != null
+          && profile.maxValue != null
+          && profile.minValue === profile.maxValue;
+        if (singleByCount || singleByRange) {
+          columnsSkipped++;
+          continue;
+        }
+      }
+    }
+
     columnsProfiled++;
 
     // ---------------------------------------------------------------
@@ -395,14 +500,21 @@ function processColumns(columns, options) {
 
         if (columnName === lookup.lookupColumn) {
           // This IS the lookup key → emit a filter dimension.
+          // Candidates: prefer plain `type` when no clash, then parent_type,
+          // then deeper qualifiers. After resolveNames runs we rewrite the
+          // FILTER_PARAMS refs in every field's SQL to use the final resolved
+          // name (see "rebind FILTER_PARAMS lookup refs" below).
           const filterDimName = `${sanitizeFieldName(parentName)}_type`;
           const filterDimRef = `${cubeName}.${filterDimName}`;
+          const typeCandidates = buildPathCandidates(`${parentName}.type`);
           const field = {
             name: filterDimName,
+            _nameCandidates: typeCandidates,
             sql: `toString({FILTER_PARAMS.${filterDimRef}.filter((v) => v)})`,
             type: 'string',
             fieldType: 'dimension',
             _sourceColumn: columnName,
+            _lookupKeyDim: filterDimName, // marks this as the lookup-key dim
             meta: {
               auto_generated: true,
               source_column: columnName,
@@ -432,9 +544,55 @@ function processColumns(columns, options) {
             continue;
           }
 
+          // Same "single empty/zero value" skip as the basic-column path —
+          // applied here so nested AJ children with constant garbage (e.g.
+          // products.discount_amount that's always 0) don't pollute the cube.
+          if (arrayJoinGroups.includes(details.parentName) && profile && profile.hasValues) {
+            if (
+              (details.valueType === ValueType.STRING || details.valueType === ValueType.UUID) &&
+              profile.uniqueValues === 1 &&
+              Array.isArray(profile.lcValues) &&
+              profile.lcValues.length === 1
+            ) {
+              const only = profile.lcValues[0];
+              const isEmpty =
+                only == null ||
+                only === '' ||
+                (typeof only === 'string' && only.trim() === '') ||
+                only === '0' ||
+                only === 0;
+              if (isEmpty) {
+                columnsSkipped++;
+                continue;
+              }
+            }
+            if (
+              details.valueType === ValueType.NUMBER &&
+              profile.minValue != null &&
+              profile.maxValue != null &&
+              Number(profile.minValue) === 0 &&
+              Number(profile.maxValue) === 0
+            ) {
+              columnsSkipped++;
+              continue;
+            }
+            if (details.valueType === ValueType.BOOLEAN) {
+              const singleByCount = profile.uniqueValues === 1;
+              const singleByRange = profile.minValue != null
+                && profile.maxValue != null
+                && profile.minValue === profile.maxValue;
+              if (singleByCount || singleByRange) {
+                columnsSkipped++;
+                continue;
+              }
+            }
+          }
+
           // This is a data sub-column → emit FILTER_PARAMS-resolved dimension
           const fieldName = `${sanitizeFieldName(parentName)}_${sanitizeFieldName(childName)}`;
           const filterDimRef = `${cubeName}.${sanitizeFieldName(parentName)}_type`;
+          // Walk parent.child path so the resolver can drop redundant prefixes
+          const dataDimCandidates = buildPathCandidates(`${parentName}.${childName}`);
 
           // Determine type from the child column
           const isCoordinate = /^(lat|latitude|lon|lng|longitude)$/i.test(childName);
@@ -454,6 +612,7 @@ function processColumns(columns, options) {
           const elemExpr = `arrayElementOrNull(${arrRef}, ${idxExpr})`;
           const field = {
             name: fieldName,
+            _nameCandidates: dataDimCandidates,
             sql: `if(${idxExpr} > 0, toString(${elemExpr}), toString(${arrRef}))`,
             type: 'string',
             fieldType: 'dimension',
@@ -606,6 +765,8 @@ function processColumns(columns, options) {
       const colDescription = columnDescriptions.get(columnName) || null;
       const nativeMapField = {
         name: mapFieldName,
+        // Already qualified by `_map` suffix — no shorter useful candidate
+        _nameCandidates: [mapFieldName],
         sql: `toString({CUBE}.\`${columnName}\`)`,
         type: 'string',
         fieldType: 'dimension',
@@ -624,7 +785,31 @@ function processColumns(columns, options) {
     }
   }
 
-  // Deduplicate field names
+  // Resolve each field to its shortest unique name (drops `parent_` /
+  // `mapname_` prefixes when there's no clash), then suffix-dedupe any
+  // residual collisions.
+  resolveNames(allFields);
+
+  // After resolution, lookup-key dimensions may have been renamed (e.g. from
+  // `commerce_products_type` to `type`). Their FILTER_PARAMS refs were baked
+  // into both their own SQL and any data-dim SQL that points at them, so we
+  // rewrite those refs to use the resolved name. Without this step every
+  // FILTER_PARAMS expression on a renamed lookup dim would point at a non-
+  // existent dimension.
+  for (const lookupField of allFields) {
+    if (!lookupField._lookupKeyDim) continue;
+    const oldName = lookupField._lookupKeyDim;
+    const newName = lookupField.name;
+    if (oldName === newName) continue;
+    const oldRef = `FILTER_PARAMS.${cubeName}.${oldName}.`;
+    const newRef = `FILTER_PARAMS.${cubeName}.${newName}.`;
+    for (const f of allFields) {
+      if (typeof f.sql === 'string' && f.sql.includes(oldRef)) {
+        f.sql = f.sql.split(oldRef).join(newRef);
+      }
+    }
+  }
+
   deduplicateFields(allFields);
 
   // Final ordering guard: keep generated fields in DDL column order.
@@ -797,38 +982,11 @@ function buildRawCube(profiledTable, options) {
     }
   }
 
-  // -- Heuristics: default pre-aggregations -----------------------------------
-  const preAggDimensions = dimensions
-    .filter((d) => d.type === 'string' && d.public !== false)
-    .slice(0, 5)
-    .map((d) => d.name);
-  const preAggMeasures = measures
-    .filter((m) => ['count', 'sum', 'min', 'max'].includes(m.type))
-    .slice(0, 10)
-    .map((m) => m.name);
-  const pre_aggregations = [];
-  if (timeDim && preAggMeasures.length > 0) {
-    pre_aggregations.push({
-      name: 'daily_rollup',
-      type: 'rollup',
-      dimensions: ['partition', ...preAggDimensions],
-      measures: preAggMeasures,
-      time_dimension: timeDim.name,
-      granularity: 'day',
-      refresh_key: { every: '1 hour' },
-      indexes: [{ name: 'partition_time_idx', columns: ['partition', timeDim.name] }],
-    });
-    pre_aggregations.push({
-      name: 'monthly_rollup',
-      type: 'rollup',
-      dimensions: ['partition'],
-      measures: preAggMeasures.slice(0, 5),
-      time_dimension: timeDim.name,
-      granularity: 'month',
-      refresh_key: { every: '1 hour' },
-      indexes: [{ name: 'partition_idx', columns: ['partition'] }],
-    });
-  }
+  // Pre-aggregations are intentionally not auto-generated. The smart-gen
+  // path emits the cube without rollups; users add pre-aggregations
+  // explicitly when they understand the query patterns. Auto-rollups based
+  // on heuristics tend to bloat CubeStore with unused materializations and
+  // surprise users with hidden refresh schedules.
 
   const cube = {
     name: cubeName,
@@ -838,10 +996,48 @@ function buildRawCube(profiledTable, options) {
     meta,
     dimensions,
     measures,
-    pre_aggregations,
   };
 
   return { cube, mapKeysDiscovered, columnsProfiled, columnsSkipped };
+}
+
+/**
+ * Derive a cube name from flat row filters.
+ * Only `=` and `IN` filters contribute — other operators (`!=`, `LIKE`, range,
+ * IS NULL) produce ambiguous names and are ignored.
+ *
+ * E.g., [{ column: 'event', operator: '=', value: 'Stockout Ended' }]
+ *   → "stockout_ended"
+ *
+ * @param {Array<{column: string, operator: string, value: *}>} filters
+ * @param {object} [options]
+ * @param {number} [options.maxLength=60] - Cap on the produced identifier length
+ * @returns {string} Sanitized identifier or empty string
+ */
+export function deriveCubeNameFromFlatFilters(filters, { maxLength = 60 } = {}) {
+  if (!filters || filters.length === 0) return '';
+
+  const parts = [];
+  for (const f of filters) {
+    const op = String(f?.operator || '').toUpperCase();
+    if (op !== '=' && op !== 'IN') continue;
+
+    const values = Array.isArray(f.value) ? f.value : [f.value];
+    for (const v of values) {
+      if (v == null) continue;
+      const slug = String(v)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+      if (slug) parts.push(slug);
+    }
+  }
+
+  if (parts.length === 0) return '';
+
+  let joined = parts.join('_');
+  if (joined.length > maxLength) joined = joined.slice(0, maxLength).replace(/_+$/, '');
+  return sanitizeCubeName(joined);
 }
 
 /**
@@ -1063,40 +1259,54 @@ function buildArrayJoinCube(profiledTable, arrayJoinGroups, rawCube, options) {
     ...measures.map((m) => m.name),
   ]);
 
+  // Collect new fields with shortest-unique candidate lists, then run a
+  // local resolver that respects the names already taken by carried-over
+  // dimensions/measures. This drops `parent_` prefixes when the leaf is
+  // unique, e.g. `commerce_products_id` → `id` when nothing else owns `id`.
+  const newAjFields = [];
   for (const [group, cols] of groupColumns) {
     for (const col of cols) {
-      // The ARRAY JOIN alias is the full dotted name with dots → underscores
       const colAlias = col.name.replace(/\./g, '_');
-      const dimName = sanitizeFieldName(colAlias);
-      let finalName = dimName;
-      if (existingNames.has(finalName)) {
-        finalName = `${finalName}_${existingNames.size}`;
-      }
-      existingNames.add(finalName);
+      const candidates = buildPathCandidates(col.name);
+      // Always include the dotted-underscore alias as a final fallback so
+      // existing collision behavior still has somewhere to land.
+      if (!candidates.includes(colAlias)) candidates.push(colAlias);
 
-      // Map value types to Cube.js types
       let cubeType = 'string';
       if (col.valueType === ValueType.NUMBER) cubeType = 'number';
       else if (col.valueType === ValueType.DATE) cubeType = 'time';
       else if (col.valueType === ValueType.BOOLEAN) cubeType = 'boolean';
 
-      // Numeric child columns become measures; strings become dimensions
+      const sql = `{CUBE}.${colAlias}`;
+      const meta = { auto_generated: true, source_column: col.name, source_group: group };
       if (col.valueType === ValueType.NUMBER) {
-        measures.push({
-          name: finalName,
-          sql: `{CUBE}.${colAlias}`,
-          type: 'sum',
-          meta: { auto_generated: true, source_column: col.name, source_group: group },
+        newAjFields.push({
+          name: candidates[0], _nameCandidates: candidates,
+          sql, type: 'sum', meta, _bucket: 'measure',
         });
       } else {
-        dimensions.push({
-          name: finalName,
-          sql: `{CUBE}.${colAlias}`,
-          type: cubeType,
-          meta: { auto_generated: true, source_column: col.name, source_group: group },
+        newAjFields.push({
+          name: candidates[0], _nameCandidates: candidates,
+          sql, type: cubeType, meta, _bucket: 'dimension',
         });
       }
     }
+  }
+
+  // Pin already-taken names by giving them single-candidate placeholders;
+  // resolveNames will then route the new AJ fields around them.
+  const resolveSet = [
+    ...[...existingNames].map((name) => ({ name, _nameCandidates: [name] })),
+    ...newAjFields,
+  ];
+  resolveNames(resolveSet);
+  for (const f of newAjFields) {
+    if (f._bucket === 'measure') {
+      measures.push({ name: f.name, sql: f.sql, type: f.type, meta: f.meta });
+    } else {
+      dimensions.push({ name: f.name, sql: f.sql, type: f.type, meta: f.meta });
+    }
+    existingNames.add(f.name);
   }
 
   // Titles on all fields
@@ -1223,42 +1433,7 @@ export function buildCubes(profiledTable, options = {}) {
       if (PLUMBING_PATTERN.test(dim.name)) dim.public = false;
     }
 
-    // - Pre-aggregations
-    if (timeDim) {
-      const preAggDimensions = ajCube.dimensions
-        .filter((d) => d.type === 'string' && d.public !== false)
-        .slice(0, 5)
-        .map((d) => d.name);
-      const preAggMeasures = ajCube.measures
-        .filter((m) => ['count', 'sum', 'min', 'max'].includes(m.type))
-        .slice(0, 10)
-        .map((m) => m.name);
-      if (preAggMeasures.length > 0) {
-        ajCube.pre_aggregations = [
-          {
-            name: 'daily_rollup',
-            type: 'rollup',
-            dimensions: ['partition', ...preAggDimensions],
-            measures: preAggMeasures,
-            time_dimension: timeDim.name,
-            granularity: 'day',
-            refresh_key: { every: '1 hour' },
-            indexes: [{ name: 'partition_time_idx', columns: ['partition', timeDim.name] }],
-          },
-          {
-            name: 'monthly_rollup',
-            type: 'rollup',
-            dimensions: ['partition'],
-            measures: preAggMeasures.slice(0, 5),
-            time_dimension: timeDim.name,
-            granularity: 'month',
-            refresh_key: { every: '1 hour' },
-            indexes: [{ name: 'partition_idx', columns: ['partition'] }],
-          },
-        ];
-      }
-    }
-
+    // Pre-aggregations intentionally omitted — see buildRawCube comment.
     cubes.push(ajCube);
   } else if (arrayJoinColumns.length > 0) {
     // Legacy ARRAY JOIN path: raw cube + separate flattened cubes
@@ -1282,6 +1457,25 @@ export function buildCubes(profiledTable, options = {}) {
       legacyCube.sql = legacySql;
       legacyCube.meta.array_join_column = ajDef.column;
       legacyCube.meta.array_join_alias = ajDef.alias;
+
+      // Surface the user-supplied AJ alias as a dimension. Without this the
+      // exploded array element has no addressable name in the cube — the SQL
+      // exposes `<alias>` as a column but no Cube.js dimension maps to it.
+      // Skip if a dimension with that name already exists (collision-safe).
+      const aliasName = sanitizeFieldName(ajDef.alias);
+      if (aliasName && !legacyCube.dimensions.some((d) => d.name === aliasName)) {
+        legacyCube.dimensions.push({
+          name: aliasName,
+          sql: `{CUBE}.${aliasName}`,
+          type: 'string',
+          meta: {
+            auto_generated: true,
+            source_column: ajDef.column,
+            array_join_alias: ajDef.alias,
+          },
+        });
+      }
+
       cubes.push(legacyCube);
     }
   } else {

--- a/services/cubejs/src/utils/smart-generation/diffModels.js
+++ b/services/cubejs/src/utils/smart-generation/diffModels.js
@@ -354,7 +354,7 @@ export function parseCubesFromJs(jsContent) {
  * @param {string|Array|null} content
  * @returns {{ cubes: Array|null, doc: object|null }} cubes array or null if unparseable
  */
-function parseCubeContent(content) {
+export function parseCubeContent(content) {
   if (!content) return { cubes: null, doc: null };
 
   // Already structured cube array (from cubeBuilder output)

--- a/services/cubejs/src/utils/smart-generation/fieldProcessors.js
+++ b/services/cubejs/src/utils/smart-generation/fieldProcessors.js
@@ -32,6 +32,37 @@ export function sanitizeFieldName(name) {
   return sanitized;
 }
 
+/**
+ * Build a candidate-name list from a dotted column path, ordered from
+ * shortest (just the leaf) to fully-qualified.
+ *
+ * Used by the shortest-unique name resolver in cubeBuilder.resolveNames so
+ * fields shed their qualifying prefixes whenever there's no clash.
+ *
+ * @example
+ *   buildPathCandidates('commerce.products.id')
+ *     → ['id', 'products_id', 'commerce_products_id']
+ *   buildPathCandidates('id') → ['id']
+ *
+ * @param {string} columnPath
+ * @returns {string[]} de-duplicated candidate names, shortest first
+ */
+export function buildPathCandidates(columnPath) {
+  if (!columnPath) return [];
+  const parts = String(columnPath).split('.').filter(Boolean);
+  if (parts.length === 0) return [];
+  const candidates = [];
+  const seen = new Set();
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const joined = parts.slice(i).map(sanitizeFieldName).join('_');
+    if (!joined) continue;
+    if (seen.has(joined)) continue;
+    seen.add(joined);
+    candidates.push(joined);
+  }
+  return candidates;
+}
+
 // -- CubeField factory ------------------------------------------------------
 
 /**
@@ -44,8 +75,16 @@ export function sanitizeFieldName(name) {
  * @param {string} opts.fieldType - "dimension" | "measure"
  * @returns {{ name: string, sql: string, type: string, fieldType: string }}
  */
-function cubeField({ name, sql, type, fieldType }) {
-  return { name, sql, type, fieldType };
+function cubeField({ name, sql, type, fieldType, nameCandidates }) {
+  const f = { name, sql, type, fieldType };
+  // _nameCandidates lets the post-pass resolver shorten names that don't
+  // collide. Shortest (most readable) candidate goes first; the fully-
+  // qualified name is the last fallback. If omitted, the resolver treats
+  // `name` itself as the only candidate (no shortening).
+  if (Array.isArray(nameCandidates) && nameCandidates.length > 0) {
+    f._nameCandidates = nameCandidates;
+  }
+  return f;
 }
 
 // -- Shared logic -----------------------------------------------------------
@@ -229,10 +268,19 @@ export class MapFieldProcessor {
     // valueType is always OTHER for Map columns; valueDataType holds the actual type.
     const effectiveValueType = columnDetails.valueDataType || columnDetails.valueType;
 
+    const sanitizedColumn = sanitizeFieldName(columnName);
+
     for (const key of profile.uniqueKeys) {
       try {
         const sanitizedKey = sanitizeFieldName(key);
         const fieldName = `${columnName}_${sanitizedKey}`;
+        // Candidate list: prefer the bare key when unique, fall back to
+        // `<columnName>_<key>` on clash. Skip the qualified form when it
+        // would just duplicate the leaf (column == key, unlikely in practice).
+        const qualified = `${sanitizedColumn}_${sanitizedKey}`;
+        const nameCandidates = sanitizedKey === qualified
+          ? [sanitizedKey]
+          : [sanitizedKey, qualified];
         let field;
 
         if (effectiveValueType === ValueType.NUMBER) {
@@ -240,6 +288,7 @@ export class MapFieldProcessor {
           if (valueSubtype.includes('int8')) {
             field = cubeField({
               name: fieldName,
+              nameCandidates,
               sql: `({CUBE}.${columnName}['${key}']) = 1`,
               type: 'boolean',
               fieldType: 'dimension',
@@ -260,6 +309,7 @@ export class MapFieldProcessor {
 
           field = cubeField({
             name: fieldName,
+            nameCandidates,
             sql: `CAST({CUBE}.${columnName}['${key}'] AS ${castTarget})`,
             type: 'sum',
             fieldType: 'measure',
@@ -276,6 +326,7 @@ export class MapFieldProcessor {
 
           field = cubeField({
             name: fieldName,
+            nameCandidates,
             sql: boolSql,
             type: 'boolean',
             fieldType: 'dimension',
@@ -284,6 +335,7 @@ export class MapFieldProcessor {
           // STRING / OTHER -> string dimension
           field = cubeField({
             name: fieldName,
+            nameCandidates,
             sql: `{CUBE}.${columnName}['${key}']`,
             type: 'string',
             fieldType: 'dimension',
@@ -387,12 +439,19 @@ export class NestedFieldProcessor {
         ? `${sanitizeFieldName(parentName)}_${sanitizeFieldName(childName)}`
         : sanitizeFieldName(childName);
 
+      // Candidate list walks the dotted path from leaf upward so the
+      // resolver can drop redundant `parent_` prefixes when the leaf is
+      // already unique. Falls back through every level until fully-qualified.
+      const fullPath = parentName ? `${parentName}.${childName}` : childName;
+      const nameCandidates = buildPathCandidates(fullPath);
+
       const fieldType = determineFieldType(columnDetails, profile);
       const cubeType = fieldType === 'measure' ? 'sum' : getCubeType(columnDetails, profile);
       const sql = generateSqlExpression(columnDetails, profile);
 
       return cubeField({
         name: fieldName,
+        nameCandidates,
         sql,
         type: cubeType,
         fieldType,

--- a/services/cubejs/src/utils/smart-generation/profiler.js
+++ b/services/cubejs/src/utils/smart-generation/profiler.js
@@ -328,15 +328,59 @@ function mapColumnSql(colExpr, alias) {
 }
 
 function arrayColumnSql(colExpr, valueType, alias, arrayElementUnsafe) {
-  if (valueType === ValueType.STRING && !arrayElementUnsafe) {
+  // ClickHouse Nested(...) is stored as parallel `Array(...)` siblings that
+  // MUST share the same length per row. So `length(col) > 0` for any one
+  // sibling is identical for every sibling — it tells you "this row has nested
+  // data" but not "this sibling carries any signal". A bool sub-column where
+  // every element is NULL or always `false` still reports the same value_rows
+  // as the populated `id` sibling, which makes useless fields look populated.
+  //
+  // Counting distinct values has the same trap:
+  //   uniq(arr)          counts distinct ARRAYS (one row's array as a whole)
+  //   uniqArray(arr)     counts distinct ELEMENTS across all rows (Array combinator)
+  // Smart-gen's downstream consumers (LC threshold gate, lcValues probing,
+  // nested-lookup-key detection) all want element-level cardinality.
+  //
+  // Below we filter elements down to "carries signal" before counting:
+  //   string:   non-null AND non-empty
+  //   number:   non-null AND non-zero
+  //   other:    non-null
+  // value_rows then = rows where >=1 element survives the filter.
+  //
+  // arrayElementUnsafe: some element types (e.g. Enum8 inside Array) can't be
+  // safely fed through arrayFilter / arrayElement comparisons in ClickHouse.
+  // Fall back to whole-array uniq() + length() in that case — less precise but
+  // type-safe.
+  if (arrayElementUnsafe) {
     return [
-      `countIf(length(arrayFilter(x -> x != '', \`${colExpr}\`)) > 0) as ${alias}__value_rows`,
-      `uniq(arrayFilter(x -> x != '', \`${colExpr}\`)) as ${alias}__distinct_count`,
+      `countIf(length(\`${colExpr}\`) > 0) as ${alias}__value_rows`,
+      `uniq(\`${colExpr}\`) as ${alias}__distinct_count`,
     ];
   }
+  if (valueType === ValueType.STRING) {
+    const meaningful = `arrayFilter(x -> x IS NOT NULL AND x != '', \`${colExpr}\`)`;
+    return [
+      `countIf(length(${meaningful}) > 0) as ${alias}__value_rows`,
+      `uniqArray(${meaningful}) as ${alias}__distinct_count`,
+    ];
+  }
+  if (valueType === ValueType.NUMBER) {
+    // minArray/maxArray ignore NULL natively; pair with non-null/non-zero
+    // value_rows so columns of all-zero (or all-null) get hasValues=false.
+    const nonNull = `arrayFilter(x -> x IS NOT NULL, \`${colExpr}\`)`;
+    const nonZero = `arrayFilter(x -> x IS NOT NULL AND x != 0, \`${colExpr}\`)`;
+    return [
+      `countIf(length(${nonZero}) > 0) as ${alias}__value_rows`,
+      `uniqArray(${nonNull}) as ${alias}__distinct_count`,
+      `minArray(\`${colExpr}\`) as ${alias}__min_value`,
+      `maxArray(\`${colExpr}\`) as ${alias}__max_value`,
+    ];
+  }
+  // BOOLEAN, DATE, UUID, OTHER — count anything that's non-null
+  const nonNull = `arrayFilter(x -> x IS NOT NULL, \`${colExpr}\`)`;
   return [
-    `countIf(length(\`${colExpr}\`) > 0) as ${alias}__value_rows`,
-    `uniq(\`${colExpr}\`) as ${alias}__distinct_count`,
+    `countIf(length(${nonNull}) > 0) as ${alias}__value_rows`,
+    `uniqArray(${nonNull}) as ${alias}__distinct_count`,
   ];
 }
 

--- a/services/cubejs/src/utils/smart-generation/yamlGenerator.js
+++ b/services/cubejs/src/utils/smart-generation/yamlGenerator.js
@@ -8,16 +8,49 @@
 import YAML from 'yaml';
 
 /**
- * Check if any cube definition contains FILTER_PARAMS callbacks
- * that require JS output (YAML parser can't handle arrow functions).
+ * Identity-arrow pattern emitted by smart-gen: `(v) => v`.
+ *
+ * Cube.js FILTER_PARAMS in YAML accepts a Python lambda where JS uses an arrow
+ * (see https://cube.dev/docs/product/data-modeling/reference/context-variables).
+ * `(v) => v` translates 1:1 to `lambda v: v`, so YAML can express it.
+ * Any other arrow shape (e.g. multi-arg, expression body) we don't currently
+ * emit — if one shows up, requiresJsOutput() flags it and we fall back to JS.
+ */
+const IDENTITY_ARROW_RE = /\(([a-zA-Z_]\w*)\)\s*=>\s*\1\b/g;
+
+/**
+ * Translate JS arrow callbacks inside FILTER_PARAMS to Python lambda syntax
+ * for YAML output. Currently only handles the identity arrow `(v) => v`
+ * (the only pattern smart-generation emits).
+ *
+ * @param {string} sql
+ * @returns {string}
+ */
+export function transpileArrowsForYaml(sql) {
+  if (!sql || typeof sql !== 'string') return sql;
+  return sql.replace(IDENTITY_ARROW_RE, 'lambda $1: $1');
+}
+
+/**
+ * Check if any cube definition contains an arrow callback that we cannot
+ * translate to YAML. Identity arrows (`(v) => v`) are translatable; anything
+ * else forces JS output.
  *
  * @param {object[]} cubeDefinitions
  * @returns {boolean}
  */
 export function requiresJsOutput(cubeDefinitions) {
   for (const cube of cubeDefinitions) {
-    for (const field of [...(cube.dimensions || []), ...(cube.measures || [])]) {
-      if (field.sql && field.sql.includes('FILTER_PARAMS')) return true;
+    const fields = [...(cube.dimensions || []), ...(cube.measures || [])];
+    for (const field of fields) {
+      if (!field.sql) continue;
+      const stripped = field.sql.replace(IDENTITY_ARROW_RE, '');
+      if (/=>/.test(stripped)) return true;
+    }
+    // Cube-level sql may also contain arrows
+    if (cube.sql) {
+      const stripped = cube.sql.replace(IDENTITY_ARROW_RE, '');
+      if (/=>/.test(stripped)) return true;
     }
   }
   return false;
@@ -52,7 +85,7 @@ function formatField(field) {
 
   const entry = {
     name: field.name,
-    sql: field.sql,
+    sql: transpileArrowsForYaml(field.sql),
     type: field.type,
     meta,
   };
@@ -96,7 +129,7 @@ function formatCube(cube) {
   if (cube.sql_table) {
     entry.sql_table = cube.sql_table;
   } else if (cube.sql) {
-    entry.sql = cube.sql;
+    entry.sql = transpileArrowsForYaml(cube.sql);
   }
 
   entry.meta = {


### PR DESCRIPTION
## Summary

Several improvements to smart-gen so it produces noticeably cleaner, more useful Cube models — fewer rollups, shorter field names, more accurate field-skip rules.

### Output format
- Default to **YAML** (`.yml`). Falls back to JS only when a cube has a `FILTER_PARAMS` arrow callback we cannot translate. Identity arrows `(v) => v` are auto-transpiled to Python lambdas (`lambda v: v`) so YAML works for the nested-lookup-key path too.
- Filename resolution: explicit `file_name` wins → reuse existing model's extension on re-run → otherwise `.yml`.

### Cube naming from filters
- Filtering by e.g. `event = 'Stockout Ended'` with no explicit name now derives `stockout_ended.yml`. Re-running same filter set updates the same file.

### Field naming — shortest-unique resolver
Each field carries an ordered candidate list from leaf → fully-qualified. A new resolver picks the shortest non-clashing candidate; basic columns hold their leaf names and longer-candidate fields advance around them. FILTER_PARAMS refs auto-rebind when a lookup-key dim is renamed.

| Before | After |
|---|---|
| `props_color` | `color` |
| `commerce_products_id` | `id` |
| `commerce_products_type` | `type` |
| basic `lat` + `location.lat` | `lat`, `location_lat` |

### Value counting fix for `Nested(...)` parallel arrays
Profiler's `arrayColumnSql` switched from `uniq()` (counts whole-array values) to `uniqArray()` + `arrayFilter` (counts elements). `value_rows` now requires at least one *meaningful* element — string non-empty, number non-null/non-zero, other non-null — so an `Array(Nullable(Bool))` of all NULL no longer reads as 100% populated just because the parallel array has length 1. Numeric arrays also emit `minArray`/`maxArray` so the all-zero skip rule works for them.

### Auto-skip cascade
`cubeBuilder.processColumns` now skips:
- STRING/UUID with `uniqueValues===1` and `lc_values[0]` empty / whitespace / `'0'` / `0`
- NUMBER with `min === max === 0`
- BOOLEAN/Int8 with `min === max` OR `uniqueValues === 1` (catches the `customer_facing Int8` always-zero case)

Same cascade mirrored into the nested-AJ children path.

### No auto pre-aggregations
`buildRawCube` and the nested-AJ path no longer emit `daily_rollup` / `monthly_rollup`. Heuristic rollups bloat CubeStore and surprise users with hidden refresh schedules. User-added pre-aggs in existing models are preserved through merge.

### Pre-existing test fixes (was 4 baseline failures)
- `package.json` test script: `--experimental-test-module-mocks` so `mock.module()` works on Node 22.12 (`provisionFraiOS` suite).
- Legacy ARRAY JOIN path: surface user-supplied `alias` as a dimension on the flattened cube (collision-safe).
- `buildWhereClause` test: assert current "no allowlist ⇒ all tables internal" semantics.
- `profileTable` emitter test: assert current step names (`init` / `initial_profile` / `profiling`).

## Test plan
- [x] `node --experimental-test-module-mocks --test 'src/**/__tests__/*.test.js'` → **511 / 511 passing**
- [ ] Smoke test in dev: profile a table with nested `Nested(...)` columns, generate; confirm shorter field names + `.yml` output
- [ ] Smoke test: filter by `event = 'X'`; confirm derived cube/file name
- [ ] Smoke test: nested-array lookup-key cube; confirm `lambda v: v` in YAML and queries still resolve
- [ ] Verify existing `.js` smart-gen models keep their `.js` extension on re-run

## Companion PR
Frontend mirror of the skip rules in step-2 auto-select: smartdataHQ/client-v2#feat/smart-gen-field-selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)