### PR TITLE
fix(hasura): bump fetch_meta action timeout to 120s

### DIFF
--- a/services/hasura/metadata/actions.yaml
+++ b/services/hasura/metadata/actions.yaml
@@ -39,6 +39,11 @@ actions:
       kind: ""
       handler: '{{ACTIONS_URL}}/rpc/fetch_meta'
       forward_client_headers: true
+      # Cube.js compile of a fresh branch can take 25-30s on schemas with many
+      # cubes. The default 30s webhook timeout was racing the compile and
+      # surfacing as "save timeout" in the UI (the editor re-fetches meta
+      # immediately after saving, hitting a cold cache). 120s gives headroom.
+      timeout: 120
     permissions:
       - role: user
   - name: fetch_tables


### PR DESCRIPTION
## Symptom

Saving cubes on dbx.fraios.dev appears to time out from the user's POV. Logs show the actual save mutation succeeds (the \`versions\` row gets inserted) but the editor's immediate \`fetch_meta\` re-query hits Hasura's default 30s webhook timeout:

\`\`\`
"http exception when calling webhook"
"Response timeout"
"path": "/rpc/fetch_meta"
"responseTimeout": "ResponseTimeoutMicro 30000000"
"query_execution_time": 30.001728027
\`\`\`

Pattern in actions logs (single user session, branch \`f553ff44…\`):

| time   | duration | result |
|--------|---------:|--------|
| 20:21:25 | 13934ms | 200 |
| 20:25:31 | 21999ms | 200 |
| 20:24:49 | 30000ms | timeout (hasura) |
| 20:24:50 | 30000ms | timeout (hasura) |
| 20:25:53 | 27855ms | 200 |
| 20:26:26 |   146ms | 200 (warm cache) |

Cold compile of a schema with many cubes consistently lands in the 14-30s window, racing the 30s timeout. Save invalidates the compiler cache (new version → new content_version), so the very next meta fetch is always cold.

## Fix

Add \`timeout: 120\` to the \`fetch_meta\` action — same order as \`fetch_tables\` (180s), \`gen_schemas_docs\` (300s), etc. Other actions in this file already set explicit timeouts; \`fetch_meta\` was defaulting to 30s.

## Why this works

- Saves themselves were never the problem — they're a Hasura mutation, no webhook involved.
- The editor refetches \`meta\` immediately after save to refresh the field tree. With cold cache, that webhook call needs ~25-30s to complete a full Cube.js compile pass. 120s gives headroom even for unusually large schemas.
- Cache warm-up is unchanged; once the compile finishes once, subsequent fetches stay sub-200ms until the next save.

## Follow-up

Longer-term improvement (separate change): \`smartGenerate\` route already calls \`compilerCache.purgeStale()\` after persisting a new version. Could additionally pre-warm by triggering a meta build of the new version on a worker, so the next user-facing fetch is warm. Out of scope for this fix.

## Test plan

- [ ] After deploy: save a cube, watch network tab — \`fetch_meta\` either completes in <30s or runs to 60-90s without a Hasura-side timeout
- [ ] Confirm via \`kubectl logs synmetrix-actions-* -n synmetrix\` that requests still come through
- [ ] Verify the editor doesn't surface a "save timed out" toast on a real save

🤖 Generated with [Claude Code](https://claude.com/claude-code)