### PR TITLE
feat(cubejs/smart-gen): pre-warm compiler cache after save

### DIFF
--- a/services/cubejs/src/routes/smartGenerate.js
+++ b/services/cubejs/src/routes/smartGenerate.js
@@ -884,6 +884,29 @@ export default async (req, res, cubejs) => {
       cubejs.compilerCache.purgeStale();
     }
 
+    // Pre-warm the compiler cache for the new version. The editor's first
+    // action after a save is to refetch metaConfig — without warm-up that
+    // refetch hits a cold compile (often 15-30s on real schemas) and the
+    // user sees a "save timed out" toast even though the save succeeded.
+    //
+    // Fire-and-forget: we don't await it. If it errors out we log and move
+    // on; the next user-facing fetch will trigger compile as a fallback.
+    if (result?.id) {
+      const warmContext = { ...securityContext };
+      const warmRequestId = `prewarm-${result.id}`;
+      Promise.resolve()
+        .then(async () => {
+          const apiGateway = cubejs.apiGateway?.();
+          if (!apiGateway) return;
+          const ctx = await apiGateway.contextByReq(req, warmContext, warmRequestId);
+          const compilerApi = await apiGateway.getCompilerApi(ctx);
+          await compilerApi.metaConfig(ctx, { requestId: warmRequestId });
+        })
+        .catch((err) => {
+          console.warn(`[smartGenerate] cache pre-warm failed (non-fatal): ${err?.message || err}`);
+        });
+    }
+
     const { summary } = cubeResult;
     const payload = {
       code: 'ok',


### PR DESCRIPTION
## Why

The editor refetches \`metaConfig\` immediately after a save to refresh the field tree. Without warm-up, that refetch is the first request to see the new \`content_version\`, so it hits a cold compile (15-30s on real schemas) and Hasura's webhook timeout fires before the response. The user sees "save timed out" even though the version row is already in the database.

Companion to #54 (which raises the action timeout from 30s → 120s as a safety belt). With both shipped, the user-visible latency on save is bounded by the response of the **already-running** background compile, not a fresh cold-compile.

## What

In \`services/cubejs/src/routes/smartGenerate.js\`, after \`createDataSchema\` + \`compilerCache.purgeStale()\`, fire-and-forget a \`compilerApi.metaConfig()\` call for the new context. Save response returns immediately; next user-facing fetch hits a warm cache.

Errors swallowed: failed pre-warm falls back to the previous behavior of compiling on first user fetch. No correctness change, only latency.

## Test plan
- [ ] Save a cube on dbx.fraios.dev with the synmetrix#54 action-timeout fix already deployed
- [ ] Watch \`kubectl logs -n synmetrix synmetrix-cubejs-* -f\` — see the \`prewarm-<versionId>\` request follow each save
- [ ] Network tab in editor: \`fetch_meta\` after a save returns in <1s (warm) instead of 15-30s (cold)
- [ ] If pre-warm fails (e.g. context ctor errors), confirm warning logged and save still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)